### PR TITLE
Remove unnecessary use of CreateAssn

### DIFF
--- a/larsim/EventGenerator/GENIE/GENIEGen_module.cc
+++ b/larsim/EventGenerator/GENIE/GENIEGen_module.cc
@@ -350,8 +350,8 @@ namespace evgen{
 	  truthcol ->push_back(truth);
 	  fluxcol  ->push_back(flux);
 	  gtruthcol->push_back(gTruth);
-	  util::CreateAssn(*this, evt, *truthcol, *fluxcol, *tfassn, fluxcol->size()-1, fluxcol->size());
-	  util::CreateAssn(*this, evt, *truthcol, *gtruthcol, *tgtassn, gtruthcol->size()-1, gtruthcol->size());
+	  util::CreateAssn(evt, *truthcol, *fluxcol, *tfassn, fluxcol->size()-1, fluxcol->size());
+	  util::CreateAssn(evt, *truthcol, *gtruthcol, *tgtassn, gtruthcol->size()-1, gtruthcol->size());
 
 	  FillHistograms(truth);
 

--- a/larsim/EventGenerator/GENIE/GENIEGen_module.cc
+++ b/larsim/EventGenerator/GENIE/GENIEGen_module.cc
@@ -29,6 +29,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "canvas/Persistency/Common/Assns.h"
 #include "art/Framework/Core/EDProducer.h"
+#include "art/Persistency/Common/PtrMaker.h"
 
 // art extensions
 #include "nurandom/RandomUtils/NuRandomService.h"
@@ -43,7 +44,6 @@
 #include "larcoreobj/SummaryData/RunData.h"
 #include "larcoreobj/SummaryData/POTSummary.h"
 #include "nugen/EventGeneratorBase/GENIE/GENIEHelper.h"
-#include "lardata/Utilities/AssociationUtil.h"
 
 ///Event Generation using GENIE, cosmics or single particles
 namespace evgen {
@@ -350,8 +350,9 @@ namespace evgen{
 	  truthcol ->push_back(truth);
 	  fluxcol  ->push_back(flux);
 	  gtruthcol->push_back(gTruth);
-	  util::CreateAssn(evt, *truthcol, *fluxcol, *tfassn, fluxcol->size()-1, fluxcol->size());
-	  util::CreateAssn(evt, *truthcol, *gtruthcol, *tgtassn, gtruthcol->size()-1, gtruthcol->size());
+          auto const truthPtr = art::PtrMaker<simb::MCTruth>{evt}(truthcol->size() - 1);
+          tfassn->addSingle(truthPtr, art::PtrMaker<simb::MCFlux>{evt}(fluxcol->size() - 1));
+          tgtassn->addSingle(truthPtr, art::PtrMaker<simb::GTruth>{evt}(gtruthcol->size() - 1));
 
 	  FillHistograms(truth);
 

--- a/larsim/EventGenerator/MARLEY/MARLEYTimeGen_module.cc
+++ b/larsim/EventGenerator/MARLEY/MARLEYTimeGen_module.cc
@@ -753,7 +753,7 @@ void evgen::MarleyTimeGen::produce(art::Event& e)
     // Associate the last entries in each of the truth object vectors (the
     // truth objects that were just created for the current neutrino vertex)
     // with each other
-    util::CreateAssn(*this, e, *truthcol, *sn_truthcol, *truth_assns,
+    util::CreateAssn(e, *truthcol, *sn_truthcol, *truth_assns,
       truthcol->size() - 1, truthcol->size()/*, sn_truthcol->size() - 1*/);
   }
 

--- a/larsim/EventGenerator/MARLEY/MARLEYTimeGen_module.cc
+++ b/larsim/EventGenerator/MARLEY/MARLEYTimeGen_module.cc
@@ -27,6 +27,7 @@
 #include "fhiclcpp/types/OptionalAtom.h"
 #include "fhiclcpp/types/Table.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
+#include "art/Persistency/Common/PtrMaker.h"
 
 // art extensions
 #include "nurandom/RandomUtils/NuRandomService.h"
@@ -34,7 +35,6 @@
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
 #include "larcoreobj/SummaryData/RunData.h"
-#include "lardata/Utilities/AssociationUtil.h"
 #include "lardataobj/Simulation/SupernovaTruth.h"
 #include "larsim/EventGenerator/MARLEY/MARLEYHelper.h"
 #include "larsim/EventGenerator/MARLEY/ActiveVolumeVertexSampler.h"
@@ -753,8 +753,8 @@ void evgen::MarleyTimeGen::produce(art::Event& e)
     // Associate the last entries in each of the truth object vectors (the
     // truth objects that were just created for the current neutrino vertex)
     // with each other
-    util::CreateAssn(e, *truthcol, *sn_truthcol, *truth_assns,
-      truthcol->size() - 1, truthcol->size()/*, sn_truthcol->size() - 1*/);
+    truth_assns->addSingle(art::PtrMaker<simb::MCTruth>{e}(truthcol->size() - 1),
+                           art::PtrMaker<sim::SupernovaTruth>{e}(sn_truthcol->size() - 1));
   }
 
   // Load the completed truth object vectors and associations into the event


### PR DESCRIPTION
This PR favors using the bare `art::Assns::addSingle` interface, which is less difficult to understand, albeit slightly more verbose.  It has the benefit of removing an extra layer of complexity.