### PR TITLE
Add missing library dependencies

### DIFF
--- a/larsim/DetSim/CMakeLists.txt
+++ b/larsim/DetSim/CMakeLists.txt
@@ -4,8 +4,8 @@ simple_plugin(SimWireAna "module"
               ${ART_ROOT_IO_TFILE_SUPPORT}
               ${ART_ROOT_IO_TFILESERVICE_SERVICE}
               ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST})
+              ROOT::Core
+              ROOT::Hist)
 
 simple_plugin(SimWire "module"
               lardataobj_RawData
@@ -18,9 +18,9 @@ simple_plugin(SimWire "module"
               ${ART_ROOT_IO_TFILE_SUPPORT}
               ${CLHEP}
               ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST}
-              ${ROOT_MATHCORE})
+              ROOT::Core
+              ROOT::Hist
+              ROOT::MathCore)
 
 simple_plugin(WienerFilterAna "module"
               larcorealg_Geometry
@@ -28,8 +28,8 @@ simple_plugin(WienerFilterAna "module"
               ${ART_ROOT_IO_TFILE_SUPPORT}
               ${ART_ROOT_IO_TFILESERVICE_SERVICE}
               ${MF_MESSAGELOGGER}
-              ${ROOT_CORE}
-              ${ROOT_HIST})
+              ROOT::Core
+              ROOT::Hist)
 
 install_headers()
 install_fhicl()

--- a/larsim/ElectronDrift/CMakeLists.txt
+++ b/larsim/ElectronDrift/CMakeLists.txt
@@ -16,8 +16,8 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${CLHEP}
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_TREE}
+           ROOT::Core
+           ROOT::Tree
          )
 
 

--- a/larsim/EventGenerator/CMakeLists.txt
+++ b/larsim/EventGenerator/CMakeLists.txt
@@ -4,10 +4,10 @@ art_make(LIB_LIBRARIES
            cetlib_except
            ${FHICLCPP}
            ${CLHEP}
-           ${ROOT_CORE}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
-           ${ROOT_RIO}
+           ROOT::Core
+           ROOT::Hist
+           ROOT::Physics
+           ROOT::RIO
          MODULE_LIBRARIES
            larcorealg_Geometry
            larcoreobj_SummaryData
@@ -20,12 +20,12 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${CLHEP}
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_EG}
-           ${ROOT_GEOM}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
-           ${ROOT_RIO}
+           ROOT::Core
+           ROOT::EG
+           ROOT::Geom
+           ROOT::Hist
+           ROOT::Physics
+           ROOT::RIO
         )
 
 install_headers()

--- a/larsim/EventGenerator/CORSIKA/CMakeLists.txt
+++ b/larsim/EventGenerator/CORSIKA/CMakeLists.txt
@@ -7,9 +7,9 @@ art_make(MODULE_LIBRARIES
            ${CLHEP}
            ${IFDH}
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_EG}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::EG
+           ROOT::Physics
            ${SQLITE3}
          )
 

--- a/larsim/EventGenerator/CRY/CMakeLists.txt
+++ b/larsim/EventGenerator/CRY/CMakeLists.txt
@@ -10,9 +10,9 @@ art_make(MODULE_LIBRARIES
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Hist
+           ROOT::Physics
          )
 
 install_headers()

--- a/larsim/EventGenerator/GENIE/CMakeLists.txt
+++ b/larsim/EventGenerator/GENIE/CMakeLists.txt
@@ -10,16 +10,16 @@ art_make(MODULE_LIBRARIES
          nurandom_RandomUtils_NuRandomService_service
          nugen_EventGeneratorBase_GENIE
          ${ART_FRAMEWORK_SERVICES_REGISTRY}
-         ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+         ${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
          ${ART_ROOT_IO_TFILESERVICE_SERVICE}
          art_Persistency_Provenance
          ${MF_MESSAGELOGGER}
          ${CLHEP}
          ${GENIE_LIB_LIST}
-         ${ROOT_EGPYTHIA6}    # FIXME!!! - resolving genie run time reference
-         ${ROOT_EG}
-         ${ROOT_HIST}
-         ${ROOT_MATHCORE}
+         ROOT::EGPythia6    # FIXME!!! - resolving genie run time reference
+         ROOT::EG
+         ROOT::Hist
+         ROOT::MathCore
         )
 
 install_headers()

--- a/larsim/EventGenerator/MARLEY/CMakeLists.txt
+++ b/larsim/EventGenerator/MARLEY/CMakeLists.txt
@@ -10,9 +10,9 @@ art_make(LIB_LIBRARIES
            ${MF_MESSAGELOGGER}
            cetlib
            cetlib_except
-           ${ROOT_CORE}
-           ${ROOT_GEOM}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Geom
+           ROOT::Physics
            ${ART_UTILITIES}
          MODULE_LIBRARIES
            larsim_EventGenerator_MARLEY
@@ -21,9 +21,9 @@ art_make(LIB_LIBRARIES
            ${ART_FRAMEWORK_SERVICES_REGISTRY}
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            ${ART_ROOT_IO_TFILE_SUPPORT}
-           ${ROOT_HIST}
-           ${ROOT_TREE}
-           ${ROOT_RIO}
+           ROOT::Hist
+           ROOT::Tree
+           ROOT::RIO
          )
 
 install_headers()

--- a/larsim/EventGenerator/MuonPropagation/CMakeLists.txt
+++ b/larsim/EventGenerator/MuonPropagation/CMakeLists.txt
@@ -10,12 +10,12 @@ art_make(MODULE_LIBRARIES
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${MF_MESSAGELOGGER}
            ${CLHEP}
-           ${ROOT_CORE}
-           ${ROOT_EG}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
-           ${ROOT_RIO}
-           ${ROOT_TREE}
+           ROOT::Core
+           ROOT::EG
+           ROOT::Hist
+           ROOT::Physics
+           ROOT::RIO
+           ROOT::Tree
          )
 
 install_headers()

--- a/larsim/EventWeight/Base/CMakeLists.txt
+++ b/larsim/EventWeight/Base/CMakeLists.txt
@@ -2,8 +2,8 @@ art_make(LIB_LIBRARIES
          canvas
          cetlib_except
          ${CLHEP}
-         ${ROOT_CORE}
-         ${ROOT_MATRIX}
+         ROOT::Core
+         ROOT::Matrix
          ${ART_UTILITIES})
 
 install_headers()

--- a/larsim/IonizationScintillation/CMakeLists.txt
+++ b/larsim/IonizationScintillation/CMakeLists.txt
@@ -16,8 +16,8 @@ art_make(LIB_LIBRARIES
            ${ART_ROOT_IO_TFILE_SUPPORT}
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            ${CLHEP}
-           ${ROOT_CORE}
-           ${ROOT_TREE}
+           ROOT::Core
+           ROOT::Tree
            ${MF_MESSAGELOGGER})
 
 install_headers()

--- a/larsim/LArG4/CMakeLists.txt
+++ b/larsim/LArG4/CMakeLists.txt
@@ -17,11 +17,11 @@ art_make(LIB_LIBRARIES
            canvas
            ${MF_MESSAGELOGGER}
            cetlib_except
-           ${ROOT_CORE}
-           ${ROOT_HIST}
-           ${ROOT_PHYSICS}
-           ${ROOT_GEOM}
-           ${ROOT_MATHCORE}
+           ROOT::Core
+           ROOT::Hist
+           ROOT::Physics
+           ROOT::Geom
+           ROOT::MathCore
            ${CLHEP}
            ${G4DIGITS_HITS}
            ${G4EVENT}
@@ -44,9 +44,9 @@ art_make(LIB_LIBRARIES
            ${ART_FRAMEWORK_SERVICES_REGISTRY}
            ${ART_ROOT_IO_TFILESERVICE_SERVICE}
            ${ART_ROOT_IO_TFILE_SUPPORT}
-           ${ROOT_HIST}
-           ${ROOT_CORE}
-           ${ROOT_TREE}
+           ROOT::Hist
+           ROOT::Core
+           ROOT::Tree
          )
 
 install_headers()

--- a/larsim/MCCheater/CMakeLists.txt
+++ b/larsim/MCCheater/CMakeLists.txt
@@ -7,7 +7,7 @@ cet_make_library(
     ${MF_MESSAGELOGGER}
     ${FHICLCPP}
     cetlib_except
-    ${ROOT_CORE}
+    ROOT::Core
   )
 
 cet_make_library(
@@ -17,7 +17,7 @@ cet_make_library(
     cetlib_except
     ${FHICLCPP}
     ${MF_MESSAGELOGGER}
-    ${ROOT_CORE}
+    ROOT::Core
     canvas
     larsim_MCCheater_ParticleInventory
     larcorealg_Geometry
@@ -32,7 +32,7 @@ cet_make_library(
     cetlib_except
     ${FHICLCPP}
     ${MF_MESSAGELOGGER}
-    ${ROOT_CORE}
+    ROOT::Core
     larcorealg_Geometry
     lardataobj_Simulation
     nug4_ParticleNavigation
@@ -43,8 +43,8 @@ simple_plugin(ParticleInventoryService "service"
   ${ART_PERSISTENCY_PROVENANCE}
   larsim_MCCheater_ParticleInventory
   nug4_ParticleNavigation
-  ${ROOT_CORE}
-  ${ROOT_PHYSICS}
+  ROOT::Core
+  ROOT::Physics
   ${MF_MESSAGELOGGER})
 
 simple_plugin(PhotonBackTrackerService "service"
@@ -56,7 +56,7 @@ simple_plugin(PhotonBackTrackerService "service"
 simple_plugin(BackTrackerService "service"
   ${ART_FRAMEWORK_PRINCIPAL}
   ${ART_PERSISTENCY_PROVENANCE}
-  ${ROOT_CORE}
+  ROOT::Core
   ${MF_MESSAGELOGGER}
   larsim_MCCheater_BackTracker
   larsim_MCCheater_ParticleInventory)
@@ -67,7 +67,7 @@ simple_plugin(CheckBackTracking "module"
   lardataobj_RecoBase
   ${MF_MESSAGELOGGER}
   ${ART_FRAMEWORK_SERVICES_REGISTRY}
-  ${ROOT_CORE})
+  ROOT::Core)
 
 simple_plugin(RecoCheckAna "module"
   larsim_MCCheater_BackTrackerService_service
@@ -77,9 +77,9 @@ simple_plugin(RecoCheckAna "module"
   ${ART_ROOT_IO_TFILESERVICE_SERVICE}
   ${ART_ROOT_IO_TFILE_SUPPORT}
   ${MF_MESSAGELOGGER}
-  ${ROOT_CORE}
-  ${ROOT_HIST}
-  ${ROOT_TREE})
+  ROOT::Core
+  ROOT::Hist
+  ROOT::Tree)
 
 simple_plugin(BackTrackerLoader "module"
   larsim_MCCheater_BackTrackerService_service

--- a/larsim/MCDumpers/CMakeLists.txt
+++ b/larsim/MCDumpers/CMakeLists.txt
@@ -2,8 +2,8 @@ art_make(MODULE_LIBRARIES
          lardataalg_MCDumpers
          nusimdata_SimulationBase
          ${MF_MESSAGELOGGER}
-         ${ROOT_CORE}
-         ${ROOT_PHYSICS})
+         ROOT::Core
+         ROOT::Physics)
 
 install_headers()
 install_fhicl()

--- a/larsim/MCSTReco/CMakeLists.txt
+++ b/larsim/MCSTReco/CMakeLists.txt
@@ -9,13 +9,14 @@ art_make(LIB_LIBRARIES
            cetlib_except
            ${MF_MESSAGELOGGER}
            ${FHICLCPP}
-           ${ROOT_CORE}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Physics
+           ${ART_UTILITIES}
          MODULE_LIBRARIES
            larsim_MCSTReco
            ${MF_MESSAGELOGGER}
-           ${ROOT_CORE}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Physics
          )
 
 install_headers()

--- a/larsim/MergeSimSources/CMakeLists.txt
+++ b/larsim/MergeSimSources/CMakeLists.txt
@@ -11,22 +11,22 @@ art_make(LIB_LIBRARIES  larsim_PhotonPropagation
                         larcore_Geometry_Geometry_service
                         nusimdata_SimulationBase
                         ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+                        ${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
                         ${ART_ROOT_IO_TFILESERVICE_SERVICE}
                         canvas
                         ${MF_MESSAGELOGGER}
                         ${FHICLCPP}
                         cetlib_except
         ${ROOT_BASIC_LIB_LIST}
-                        ${ROOT_GENVECTOR}
-                        ${ROOT_EG}
-                        ${ROOT_TREEPLAYER}
-                        ${ROOT_FFTW}
+                        ROOT::GenVector
+                        ROOT::EG
+                        ROOT::TreePlayer
+                        ROOT::FFTW
                         ${ROOT_REFLEX}
-                        ${ROOT_EGPYTHIA6}
-                        ${ROOT_GUI}
-                        ${ROOT_GEOM}
-                        ${ROOT_MATHCORE}
+                        ROOT::EGPythia6
+                        ROOT::Gui
+                        ROOT::Geom
+                        ROOT::MathCore
                         ${CLHEP}
                         ${G4_LIB_LIST}
            MODULE_LIBRARIES larsim_MergeSimSources
@@ -37,10 +37,10 @@ art_make(LIB_LIBRARIES  larsim_PhotonPropagation
                         larcore_Geometry_Geometry_service
                         nusimdata_SimulationBase
                         ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+                        ${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
                         ${ART_ROOT_IO_TFILESERVICE_SERVICE}
                         ${MF_MESSAGELOGGER}
-                        ${ROOT_GENVECTOR}
+                        ROOT::GenVector
         ${ROOT_BASIC_LIB_LIST}
                         ${CLHEP}
                         ${G4_LIB_LIST}

--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -5,19 +5,19 @@ art_make(LIB_LIBRARIES larevt_Filters
                        larsim_Simulation
                        larsim_IonizationScintillation
                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-                       ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+                       ${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
                        canvas
                        ${MF_MESSAGELOGGER}
                        ${FHICLCPP}
                        ${CLHEP}
                        cetlib_except
-                       ${ROOT_EG}
-                       ${ROOT_RIO}
-                       ${ROOT_HIST}
-                       ${ROOT_MATRIX}
-                       ${ROOT_TREE}
-                       ${ROOT_GENVECTOR}
+                       ROOT::EG
+                       ROOT::RIO
+                       ROOT::Hist
+                       ROOT::Matrix
+                       ROOT::Tree
+                       ROOT::GenVector
           SERVICE_LIBRARIES larsim_PhotonPropagation
                        larsim_Simulation
                        nug4_ParticleNavigation
@@ -26,10 +26,10 @@ art_make(LIB_LIBRARIES larevt_Filters
                        lardataobj_RawData
                        larcorealg_Geometry
                        larcore_Geometry_Geometry_service
-                       ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
+                       ${ART_ROOT_IO_TFILE_SUPPORT} ROOT::Core
                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
                        ${MF_MESSAGELOGGER}
-                       ${ROOT_GENVECTOR}
+                       ROOT::GenVector
           MODULE_LIBRARIES larsim_PhotonPropagation
                         larsim_LArG4
                         larsim_ElectronDrift
@@ -43,13 +43,13 @@ art_make(LIB_LIBRARIES larevt_Filters
                         ${ART_ROOT_IO_TFILESERVICE_SERVICE}
                         ${ART_FRAMEWORK_SERVICES_REGISTRY}
                         ${ART_ROOT_IO_TFILE_SUPPORT}
-                        ${ROOT_CORE}
+                        ROOT::Core
                         ${MF_MESSAGELOGGER}
                         nurandom_RandomUtils_NuRandomService_service
                         art_Persistency_Provenance
                         ${CLHEP}
-                        ${ROOT_GENVECTOR}
-                        ${ROOT_GPAD}
+                        ROOT::GenVector
+                        ROOT::Gpad
          )
 
 

--- a/larsim/PhotonPropagation/LibraryMappingTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/LibraryMappingTools/CMakeLists.txt
@@ -4,10 +4,11 @@ art_make(NO_PLUGINS
     PhotonMappingIdentityTransformations_tool.cc
     PhotonMappingXMirrorTransformations_tool.cc
   LIB_LIBRARIES
-    ${ROOT_CORE}
+    ROOT::Core
     larcorealg_Geometry
     ${ART_FRAMEWORK_SERVICES_REGISTRY}
     ${CANVAS}
+    ${ART_UTILITIES}
   )
 
 simple_plugin(PhotonMappingIdentityTransformations "tool"

--- a/larsim/PhotonPropagation/ScintTimeTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/ScintTimeTools/CMakeLists.txt
@@ -2,7 +2,7 @@ art_make(NO_PLUGINS
   EXCLUDE
     ScintTimeLAr_tool.cc
   LIB_LIBRARIES
-    ${ROOT_CORE}
+    ROOT::Core
     larcorealg_Geometry
     ${ART_FRAMEWORK_SERVICES_REGISTRY}
     ${CANVAS}

--- a/larsim/SimFilters/CMakeLists.txt
+++ b/larsim/SimFilters/CMakeLists.txt
@@ -4,8 +4,8 @@ art_make(MODULE_LIBRARIES
          nusimdata_SimulationBase
          ${ART_FRAMEWORK_SERVICES_REGISTRY}
          ${MF_MESSAGELOGGER}
-         ${ROOT_CORE}
-         ${ROOT_PHYSICS})
+         ROOT::Core
+         ROOT::Physics)
 
 # install_headers()
 install_fhicl()

--- a/larsim/Simulation/CMakeLists.txt
+++ b/larsim/Simulation/CMakeLists.txt
@@ -8,8 +8,8 @@ art_make(NO_PLUGINS
            ${ART_FRAMEWORK_SERVICES_REGISTRY}
            ${ART_FRAMEWORK_PRINCIPAL}
            ${ART_PERSISTENCY_PROVENANCE}
-           ${ROOT_CORE}
-           ${ROOT_PHYSICS})
+           ROOT::Core
+           ROOT::Physics)
 
 simple_plugin(LArVoxelCalculator "service")
 simple_plugin(LArG4Parameters "service")


### PR DESCRIPTION
Also change to ROOT target-based dependencies.

This is part of a coordinated set of PRs that accomplish two tasks:

- Switching to geometry collections that own by value instead of by pointer
- Switching the (AuxDet) geometry systems to be thread-safe within a run

There are breaking changes associated with this PR, and they will be presented at the next LArSoft coordination meeting.