### PR TITLE
Improved RadioGen

### DIFF
--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -112,14 +112,14 @@ namespace evgen {
     void readfile(std::string type, std::string const& filename);
     void samplespectrum(std::string nuclideName, ParticleInfo& part);
 
-    
+
     struct ParticleInfo{
       ti_PDGID pdg;
       td_Mass mass;
       TLorentzVector pos;
       TLorentzVector mom;
     };
-    
+
     ParticleInfo AlphaDecay(double t, TVector3 pos, double time);
     ParticleInfo BetaDecay(double t, TVector3 pos, double time, double Z);
     std::vector<ParticleInfo> BetaThenAlphaDecay(double t_beta, double t_alpha, double t_mean, TVector3 pos, double time, double Z);
@@ -128,7 +128,7 @@ namespace evgen {
 
     TVector3 GetGoodPosition(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, std::string material, bool& flag);
     TVector3 GetRandomPointInVolume(std::string volname, std::string matname, bool& flag);
-    
+
     void Ar42Gamma2(std::vector<ParticleInfo>& v_prods);
     void Ar42Gamma3(std::vector<ParticleInfo>& v_prods);
     void Ar42Gamma4(std::vector<ParticleInfo>& v_prods);
@@ -169,21 +169,21 @@ namespace evgen {
     // TGenPhaseSpace rg;  // put this here so we don't constantly construct and destruct it
 
 
-    
+
     std::vector<std::string> spectrumname;
-    
+
     std::map<std::string,std::unique_ptr<TH1D>> alphaspectrum;
     std::map<std::string,double> alphaintegral;
-    
+
     std::map<std::string,std::unique_ptr<TH1D>> betaspectrum;
     std::map<std::string,double> betaintegral;
-    
+
     std::map<std::string,std::unique_ptr<TH1D>> gammaspectrum;
     std::map<std::string,double> gammaintegral;
-    
+
     std::map<std::string,std::unique_ptr<TH1D>> neutronspectrum;
     std::map<std::string,double> neutronintegral;
-    
+
     art::ServiceHandle<geo::Geometry const> fGeo;
     TGeoManager* fGeoManager;
     int nevent;
@@ -204,11 +204,11 @@ namespace evgen {
 }
 
 namespace {
-  
+
   constexpr double m_e = 0.000510998928;  // mass of electron in GeV
   constexpr double m_alpha = 3.727379240; // mass of an alpha particle in GeV
   constexpr double m_neutron = 0.9395654133; // mass of a neutron in GeV
-  
+
   constexpr int kAlphaPDG    = 1000020040;
   constexpr int kElectronPDG = 11;
   constexpr int kGammaPDG    = 22;
@@ -241,7 +241,7 @@ namespace evgen{
         TGeoVolume* vol = fGeoManager->FindVolumeFast(volname.c_str());
         if (!vol)
           throw cet::exception("RadioGen") << "Volume: " << volname << " doesn't exist in the geometry. Exit disgracefully.";
-    
+
         const TGeoShape *shape = vol->GetShape();
         TGeoBBox *box = (TGeoBBox *)shape;
         double dx = box->GetDX();
@@ -277,7 +277,7 @@ namespace evgen{
     time_TH1D   = tfs->make<TH1D>("Time", ";Time[ns];n particles", 100, tmin, tmax);
     timediff_TH1D = tfs->make<TH1D>("TimeDiff", ";Time Diff[ns];n particles", (int)(tmax/100), 0, tmax);
   }
-  
+
   void RadioGen::endJob(){
     if (nevent>0){
       pos_xy_TH2D->Scale(1./nevent);
@@ -339,12 +339,12 @@ namespace evgen{
 
     produces< std::vector<simb::MCTruth> >();
     produces< sumdata::RunData, art::InRun >();
- 
+
     // check for consistency of vector sizes
     unsigned int nsize = fNuclide.size();
-    if (fMaterial.size() != nsize) { throw cet::exception("RadioGen") << "Different size Material vector and Nuclide vector"; } 
-    if (fBq      .size() != nsize) { throw cet::exception("RadioGen") << "Different size Bq vector and Nuclide vector";       } 
-    if (fT0      .size() != nsize) { throw cet::exception("RadioGen") << "Different size T0 vector and Nuclide vector";       } 
+    if (fMaterial.size() != nsize) { throw cet::exception("RadioGen") << "Different size Material vector and Nuclide vector"; }
+    if (fBq      .size() != nsize) { throw cet::exception("RadioGen") << "Different size Bq vector and Nuclide vector";       }
+    if (fT0      .size() != nsize) { throw cet::exception("RadioGen") << "Different size T0 vector and Nuclide vector";       }
     if (fT1      .size() != nsize) { throw cet::exception("RadioGen") << "Different size T1 vector and Nuclide vector";       }
     if (fVolume.size() == 0 &&
         fX0.size() != nsize &&
@@ -355,7 +355,7 @@ namespace evgen{
         fZ1.size() != nsize) {
       throw cet::exception("RadioGen") << "You need to specify either Volume or X0,X1,Y0,Y1,Z0,Z1 vectors (and they must be the same size as Nuclide)";
     }
-    
+
     if (fVolume.size() != nsize &&
         (fX0.size() != nsize ||
          fY0.size() != nsize ||
@@ -365,7 +365,7 @@ namespace evgen{
          fZ1.size() != nsize)) {
       throw cet::exception("RadioGen") << "You need to specify either Volume vector (and it must be the same size as Nuclide)";
     }
-    
+
     for (std::string & nuclideName : fNuclide) {
       std::cout << "Initialising " << nuclideName << "\n";
 
@@ -379,7 +379,7 @@ namespace evgen{
       else if(nuclideName=="218Po"      ){continue;} //...
       else if(nuclideName=="214Pb"      ){continue;} //...
       else if(nuclideName=="BiPo(Rn222)"){continue;} //...
-      else if(nuclideName=="59Ni"       ){continue;} 
+      else if(nuclideName=="59Ni"       ){continue;}
       else if(nuclideName=="42Ar"       ){
         readfile("42Ar_1", "Argon_42_1.root"); //Each possible beta decay mode of Ar42 is given it's own .root file for now.
         readfile("42Ar_2", "Argon_42_2.root"); //This allows us to know which decay chain to follow for the dexcitation gammas.
@@ -416,7 +416,7 @@ namespace evgen{
     for (unsigned int i=0; i<fNuclide.size(); ++i) {
       SampleOne(i,truth);
     }//end loop over nuclides
-    
+
     MF_LOG_DEBUG("RadioGen") << truth;
     truthcol->push_back(truth);
     evt.put(std::move(truthcol));
@@ -428,9 +428,9 @@ namespace evgen{
     TGeoVolume* vol = fGeoManager->FindVolumeFast(volname.c_str());
     if (!vol)
       throw cet::exception("RadioGen") << "Volume: " << volname << " doesn't exist in the geometry. Exit disgracefully.";
-    
+
     std::regex regex_material = (std::regex)matname;
-    
+
     const TGeoShape *shape = vol->GetShape();
     TGeoBBox *box = (TGeoBBox *)shape;
     double dx = box->GetDX();
@@ -469,14 +469,14 @@ namespace evgen{
     delete xyz;
     return pos;
   }
-  
-  
+
+
   TVector3 RadioGen::GetGoodPosition(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, std::string material, bool& flag)
   {
     // int trial = 0;
     TVector3 pos;
     flag = true;
-    
+
     pos = TVector3(minX + fRandomFlat->fire()*(maxX - minX),
                    minY + fRandomFlat->fire()*(maxY - minY),
                    minZ + fRandomFlat->fire()*(maxZ - minZ));
@@ -484,15 +484,15 @@ namespace evgen{
     std::string volmaterial = fGeoManager->FindNode(pos.X(),pos.Y(),pos.Z())->GetMedium()->GetMaterial()->GetName();
     std::regex regex_material = (std::regex)material;
     flag = std::regex_match(volmaterial, regex_material);
-      
+
     return pos;
   }
 
-  
+
   RadioGen::ParticleInfo RadioGen::AlphaDecay(double t, TVector3 pos, double time)
   {
     double p=0; td_Mass m=m_alpha;// ti_PDGID pdgid=kAlphaPDG;
-    double energy = t + m; 
+    double energy = t + m;
     double p2     = energy*energy - m*m;
     if (p2 > 0) p = TMath::Sqrt(p2);
     else        p = 0;
@@ -503,7 +503,7 @@ namespace evgen{
     part.pos  = TLorentzVector(pos, time);
     return part;
   }
-  
+
   RadioGen::ParticleInfo RadioGen::BetaDecay(double t, TVector3 pos, double time, double Z)
   {
     ParticleInfo part;
@@ -515,7 +515,7 @@ namespace evgen{
     part.pos  = TLorentzVector(pos, time);
     return part;
   }
-  
+
   std::vector<RadioGen::ParticleInfo> RadioGen::BetaThenAlphaDecay(double t_beta, double t_alpha, double t_mean, TVector3 pos, double time, double Z)
   {
     std::vector<ParticleInfo> vec;
@@ -527,12 +527,12 @@ namespace evgen{
   //____________________________________________________________________________
   // Generate radioactive decays per nuclide per volume according to the FCL parameters
   double RadioGen::GetRate(int i) {
-    
+
     if ((size_t)i < fVolume.size()) {
        TGeoVolume* vol = fGeoManager->FindVolumeFast(fVolume[i].c_str());
       if (!vol)
         throw cet::exception("RadioGen") << "Volume: " << fVolume[i] << " doesn't exist in the geometry. Exit disgracefully.";
-    
+
       const TGeoShape *shape = vol->GetShape();
       TGeoBBox *box = (TGeoBBox *)shape;
       double dx = box->GetDX();
@@ -555,7 +555,7 @@ namespace evgen{
     }
 
   }
-  
+
   void RadioGen::SampleOne(int i, simb::MCTruth &mct)
   {
 
@@ -584,34 +584,34 @@ namespace evgen{
         pos = GetRandomPointInVolume(fVolume[i], fMaterial[i], flag);
       else
         pos = GetGoodPosition(fX0[i],fY0[i],fZ0[i],fX1[i],fY1[i],fZ1[i],fMaterial[i], flag);
-      
+
       if (!flag)
         continue;
-      
+
       double time = (idecay==0 && fIsFirstSignalSpecial) ? 0 : ( fT0[i] + fRandomFlat->fire()*(fT1[i] - fT0[i]));
 
       std::vector<ParticleInfo> v_prods; //(First is for PDGID, second is mass, third is Momentum)
-      
+
       if (fNuclide[i] == "222Rn")          // Treat 222Rn separately
       {
         v_prods.emplace_back(AlphaDecay(0.0055904, pos, time));
       }
-      
+
       else if(fNuclide[i] == "226Ra")
       {
         v_prods.emplace_back(AlphaDecay(0.0050975, pos, time));
       }
-      
+
       else if(fNuclide[i] == "218Po")
       {
         v_prods.emplace_back(AlphaDecay(0.00611475, pos, time));
       }
-      
+
       else if(fNuclide[i]=="214Pb")
       {
         v_prods.emplace_back(BetaDecay(0.002240300, pos, time, 83));
       }
-      
+
       else if (fNuclide[i] == "BiPo(Rn222)")          // Treat 222Rn separately
       {
         std::vector<ParticleInfo> bipo_prod = BetaThenAlphaDecay(0.003269, 0.00783354, 164000, pos, time, 84);
@@ -620,7 +620,7 @@ namespace evgen{
           v_prods.emplace_back(p);
         }
       }
-      
+
       else if(fNuclide[i] == "59Ni"){ //Treat 59Ni Calibration Source separately (as I haven't made a spectrum for it, and ultimately it should be handeled with multiple particle outputs.
         double p=0.008997; // td_Mas=double. ti_PDFID=int. Assigning p directly, as t=p for gammas.
         ParticleInfo part;
@@ -630,7 +630,7 @@ namespace evgen{
         part.pos = TLorentzVector(pos, time);
         v_prods.emplace_back(part);
       }//end special case Ni59 calibration source
-      
+
       else if(fNuclide[i] == "42Ar")
       {   // Spot for special treatment of Ar42.
         ParticleInfo part;
@@ -657,12 +657,12 @@ namespace evgen{
           v_prods.emplace_back(part);
           Ar42Gamma5(v_prods);
         }
-        
+
         for (auto& it: v_prods) { // All the Ar42 are produced at the same place.
           it.pos = TLorentzVector(pos, time);
         }
       }
-      
+
       else
       { //General Case.
         ParticleInfo part;
@@ -708,9 +708,9 @@ namespace evgen{
         dir_z_TH1D ->Fill(prodEntry.mom.Z()/mom);
         time_TH1D  ->Fill(prodEntry.pos.T());
       }//End Loop over all particles produces in this single decay.
-    
+
     }
- 
+
   }
 
 //Calculate an arbitrary direction with a given magnitude p
@@ -728,9 +728,9 @@ namespace evgen{
         std::sqrt(p*p+m*m)};
   }
 
-  
+
   std::unique_ptr<TH1D> ParseTGraph(TGraph* graph, std::string type, double& integral) {
-    
+
     if (graph) {
       int np = graph->GetN();
       //double *x = graph->GetX();
@@ -748,7 +748,7 @@ namespace evgen{
     }
     integral = 0;
     return nullptr;
-    
+
   }
 
   // only reads those files that are on the fNuclide list.  Copy information from the TGraphs to TH1D's
@@ -767,10 +767,10 @@ namespace evgen{
     //     break;
     //   }
     // }
-    
+
     // if (!found) return;
     //if (type == kUnknown) throw cet::exception("RadioGen") << "The file \"" << filename << "\" will be saved to unknown, so won't be used.";
-      
+
     Bool_t addStatus = TH1::AddDirectoryStatus();
     TH1::AddDirectory(kFALSE); // cloned histograms go in memory, and aren't deleted when files are closed.
     // be sure to restore this state when we're out of the routine.
@@ -839,7 +839,7 @@ namespace evgen{
     } catch (...) {
       throw cet::exception("RadioGen") << "Missing information for : " << type << "\n";
     }
-    
+
     for (int itry=0;itry<10;itry++) // maybe a tiny normalization issue with a sum of 0.99999999999 or something, so try a few times.
     {
       if (rtype <= alphaintegral.at(type) && alphaspectrum.at(type) != nullptr)
@@ -866,15 +866,15 @@ namespace evgen{
         part.mass = m_neutron;
         t = samplefromth1d(*neutronspectrum.at(type))/1000000.0;
       }
-      
+
       if (part.pdg >= 0) break;
     }
-    
+
     if (part.pdg == -1)
     {
       throw cet::exception("RadioGen") << "Normalization problem with nuclide: " << type;
     }
-    
+
     double e = t + part.mass;
     double p = e*e - part.mass* part.mass;
     if (p>=0)
@@ -952,7 +952,7 @@ namespace evgen{
   {
 
     double chan1 = (0.052 / (0.052+0.020) );
-    
+
     if(fRandomFlat->fire()<chan1){
       std::vector<double> vd_p = {.0008997};//Momentum in GeV
       for(auto p : vd_p){

--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -27,6 +27,11 @@
 //             Ni59 Calibration sources. This is another "hacky"
 //             fix to something that really deserves a more
 //             elegant and comprehensive solution.
+//           Feb 2020 PLasorak
+//             Add the posibility to specify volume names in the fhicl rather
+//             than just hardcoded number for volumes.
+//             Make the code a bit cleaner
+//             Add time correlation for decay like BiPo
 ////////////////////////////////////////////////////////////////////////
 
 // C++ includes.
@@ -47,6 +52,7 @@
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art/Framework/Core/ModuleMacros.h"
+#include "art_root_io/TFileService.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "cetlib_except/exception.h"
 #include "cetlib/search_path.h"
@@ -70,17 +76,17 @@
 #include "TGenPhaseSpace.h"
 #include "TMath.h"
 #include "TFile.h"
-#include "TH1.h"
 #include "TH1D.h"
+#include "TH2D.h"
 #include "TGraph.h"
-
+#include "TVector3.h"
+#include "CLHEP/Random/RandExponential.h"
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/RandPoisson.h"
 
 namespace simb { class MCTruth; }
 
 namespace evgen {
-
   /// Module to generate particles created by radiological decay, patterend off of SingleGen
   /// Currently it generates only in rectangular prisms oriented along the x,y,z axes
 
@@ -92,22 +98,41 @@ namespace evgen {
     // This is called for each event.
     void produce(art::Event& evt);
     void beginRun(art::Run& run);
+    void beginJob();
+    void endJob();
 
     typedef int    ti_PDGID;  // These typedefs may look odd, and unecessary. I chose to use them to make the tuples I use later more readable. ti, type integer :JStock
     typedef double td_Mass;   // These typedefs may look odd, and unecessary. I chose to use them to make the tuples I use later more readable. td, type double  :JStock
 
-    void SampleOne(unsigned int   i,
+    void SampleOne(int i,
        simb::MCTruth &mct);
 
     TLorentzVector dirCalc(double p, double m);
 
-    void readfile(std::string nuclide, std::string const& filename);
-    void samplespectrum(std::string nuclide, int &itype, double &t, double &m, double &p);
+    void readfile(std::string type, std::string const& filename);
+    void samplespectrum(std::string nuclideName, ParticleInfo& part);
 
-    void Ar42Gamma2(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods);
-    void Ar42Gamma3(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods);
-    void Ar42Gamma4(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods);
-    void Ar42Gamma5(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods);
+    
+    struct ParticleInfo{
+      ti_PDGID pdg;
+      td_Mass mass;
+      TLorentzVector pos;
+      TLorentzVector mom;
+    };
+    
+    ParticleInfo AlphaDecay(double t, TVector3 pos, double time);
+    ParticleInfo BetaDecay(double t, TVector3 pos, double time, double Z);
+    std::vector<ParticleInfo> BetaThenAlphaDecay(double t_beta, double t_alpha, double t_mean, TVector3 pos, double time, double Z);
+    double sample_beta_decay_spectrum(double Q, double Z);  // PLasorak: A simple rejection method with beta spectrum
+    double GetRate(int i);
+
+    TVector3 GetGoodPosition(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, std::string material, bool& flag);
+    TVector3 GetRandomPointInVolume(std::string volname, std::string matname, bool& flag);
+    
+    void Ar42Gamma2(std::vector<ParticleInfo>& v_prods);
+    void Ar42Gamma3(std::vector<ParticleInfo>& v_prods);
+    void Ar42Gamma4(std::vector<ParticleInfo>& v_prods);
+    void Ar42Gamma5(std::vector<ParticleInfo>& v_prods);
 
     // recoded so as to use the LArSoft-managed random number generator
     double samplefromth1d(TH1D& hist);
@@ -124,6 +149,7 @@ namespace evgen {
 
     std::vector<std::string> fNuclide;   ///< List of nuclides to simulate.  Example:  "39Ar".
     std::vector<std::string> fMaterial;  ///< List of regexes of materials in which to generate the decays.  Example: "LAr"
+    std::vector<std::string> fVolume;
     std::vector<double> fBq;             ///< Radioactivity in Becquerels (decay per sec) per cubic cm.
     std::vector<double> fT0;             ///< Beginning of time window to simulate in ns
     std::vector<double> fT1;             ///< End of time window to simulate in ns
@@ -133,6 +159,7 @@ namespace evgen {
     std::vector<double> fX1;             ///< Top corner x position (cm) in world coordinates
     std::vector<double> fY1;             ///< Top corner y position (cm) in world coordinates
     std::vector<double> fZ1;             ///< Top corner z position (cm) in world coordinates
+
     bool                fIsFirstSignalSpecial;
     int trackidcounter;                  ///< Serial number for the MC track ID
 
@@ -141,79 +168,226 @@ namespace evgen {
     // const double gevperamu = 0.931494061;
     // TGenPhaseSpace rg;  // put this here so we don't constantly construct and destruct it
 
+
+    
     std::vector<std::string> spectrumname;
-    std::vector<std::unique_ptr<TH1D>> alphaspectrum;
-    std::vector<double> alphaintegral;
-    std::vector<std::unique_ptr<TH1D>> betaspectrum;
-    std::vector<double> betaintegral;
-    std::vector<std::unique_ptr<TH1D>> gammaspectrum;
-    std::vector<double> gammaintegral;
-    std::vector<std::unique_ptr<TH1D>> neutronspectrum;
-    std::vector<double> neutronintegral;
-    CLHEP::HepRandomEngine& fEngine;
+    
+    std::map<std::string,std::unique_ptr<TH1D>> alphaspectrum;
+    std::map<std::string,double> alphaintegral;
+    
+    std::map<std::string,std::unique_ptr<TH1D>> betaspectrum;
+    std::map<std::string,double> betaintegral;
+    
+    std::map<std::string,std::unique_ptr<TH1D>> gammaspectrum;
+    std::map<std::string,double> gammaintegral;
+    
+    std::map<std::string,std::unique_ptr<TH1D>> neutronspectrum;
+    std::map<std::string,double> neutronintegral;
+    
+    art::ServiceHandle<geo::Geometry const> fGeo;
+    TGeoManager* fGeoManager;
+    int nevent;
+    TH2D* pos_xy_TH2D;
+    TH2D* pos_xz_TH2D;
+    TH1D* dir_x_TH1D ;
+    TH1D* dir_y_TH1D ;
+    TH1D* dir_z_TH1D ;
+    TH1D* pdg_TH1D   ;
+    TH1D* mom_TH1D   ;
+    TH1D* time_TH1D  ;
+    TH1D* timediff_TH1D;
+
+    std::unique_ptr<CLHEP::RandFlat       > fRandomFlat;
+    std::unique_ptr<CLHEP::RandExponential> fRandomExponential;
+    std::unique_ptr<CLHEP::RandPoisson    > fRandomPoisson;
   };
 }
 
 namespace {
+  
   constexpr double m_e = 0.000510998928;  // mass of electron in GeV
   constexpr double m_alpha = 3.727379240; // mass of an alpha particle in GeV
   constexpr double m_neutron = 0.9395654133; // mass of a neutron in GeV
+  
+  constexpr int kAlphaPDG    = 1000020040;
+  constexpr int kElectronPDG = 11;
+  constexpr int kGammaPDG    = 22;
+  constexpr int kNeutronPDG  = 2112;
 }
 
 namespace evgen{
-
   //____________________________________________________________________________
+  void RadioGen::beginJob(){
+    art::ServiceHandle<art::TFileService> tfs;
+    nevent = 0;
+    double xmin = 0;
+    double xmax = 0;
+    double ymin = 0;
+    double ymax = 0;
+    double zmin = 0;
+    double zmax = 0;
+    double tmin = 0;
+    double tmax = 0;
+
+    std::vector<double> X0 = fX0;
+    std::vector<double> X1 = fX1;
+    std::vector<double> Y0 = fY0;
+    std::vector<double> Y1 = fY1;
+    std::vector<double> Z0 = fZ0;
+    std::vector<double> Z1 = fZ1;
+
+    if (fVolume.size()) {
+      for (auto const& volname: fVolume) {
+        TGeoVolume* vol = fGeoManager->FindVolumeFast(volname.c_str());
+        if (!vol)
+          throw cet::exception("RadioGen") << "Volume: " << volname << " doesn't exist in the geometry. Exit disgracefully.";
+    
+        const TGeoShape *shape = vol->GetShape();
+        TGeoBBox *box = (TGeoBBox *)shape;
+        double dx = box->GetDX();
+        double dy = box->GetDY();
+        double dz = box->GetDZ();
+        double ox = (box->GetOrigin())[0];
+        double oy = (box->GetOrigin())[1];
+        double oz = (box->GetOrigin())[2];
+        X0.push_back(ox-dx);
+        X1.push_back(ox+dx);
+        Y0.push_back(oy-dy);
+        Y1.push_back(oy+dy);
+        Z0.push_back(oz-dz);
+        Z1.push_back(oz+dz);
+      }
+    }
+
+    xmin = *std::min_element(X0.begin(), X0.end());
+    xmax = *std::max_element(X1.begin(), X1.end());
+    ymin = *std::min_element(Y0.begin(), Y0.end());
+    ymax = *std::max_element(Y1.begin(), Y1.end());
+    zmin = *std::min_element(Z0.begin(), Z0.end());
+    zmax = *std::max_element(Z1.begin(), Z1.end());
+    tmin = *std::min_element(fT0.begin(), fT0.end());
+    tmax = *std::max_element(fT1.begin(), fT1.end());
+    pos_xy_TH2D = tfs->make<TH2D>("posXY", ";X [cm];Y [cm]", 100, xmin, xmax, 100, ymin, ymax);
+    pos_xz_TH2D = tfs->make<TH2D>("posXZ", ";X [cm];Z [cm]", 100, xmin, xmax, 100, zmin, zmax);
+    dir_x_TH1D  = tfs->make<TH1D>("dirX", ";X momentum projection", 100, -1, 1);
+    dir_y_TH1D  = tfs->make<TH1D>("dirY", ";Y momentum projection", 100, -1, 1);
+    dir_z_TH1D  = tfs->make<TH1D>("dirZ", ";Z momentum projection", 100, -1, 1);
+    pdg_TH1D    = tfs->make<TH1D>("PDG", ";PDG;n particles", 100, 0, 100);
+    mom_TH1D    = tfs->make<TH1D>("Momentum", ";Momentum [MeV];n particles", 5000, 0, 500);
+    time_TH1D   = tfs->make<TH1D>("Time", ";Time[ns];n particles", 100, tmin, tmax);
+    timediff_TH1D = tfs->make<TH1D>("TimeDiff", ";Time Diff[ns];n particles", (int)(tmax/100), 0, tmax);
+  }
+  
+  void RadioGen::endJob(){
+    if (nevent>0){
+      pos_xy_TH2D->Scale(1./nevent);
+      pos_xz_TH2D->Scale(1./nevent);
+      dir_x_TH1D ->Scale(1./nevent);
+      dir_y_TH1D ->Scale(1./nevent);
+      dir_z_TH1D ->Scale(1./nevent);
+      pdg_TH1D   ->Scale(1./nevent);
+      mom_TH1D   ->Scale(1./nevent);
+      time_TH1D  ->Scale(1./nevent);
+    }
+  }
+
+//____________________________________________________________________________
   RadioGen::RadioGen(fhicl::ParameterSet const& pset)
     : EDProducer{pset}
     , fNuclide {pset.get< std::vector<std::string>>("Nuclide")}
     , fMaterial{pset.get< std::vector<std::string>>("Material")}
+    , fVolume{pset.get< std::vector<std::string>>("Volume", {})}
     , fBq{pset.get< std::vector<double> >("BqPercc")}
     , fT0{pset.get< std::vector<double> >("T0")}
     , fT1{pset.get< std::vector<double> >("T1")}
-    , fX0{pset.get< std::vector<double> >("X0")}
-    , fY0{pset.get< std::vector<double> >("Y0")}
-    , fZ0{pset.get< std::vector<double> >("Z0")}
-    , fX1{pset.get< std::vector<double> >("X1")}
-    , fY1{pset.get< std::vector<double> >("Y1")}
-    , fZ1{pset.get< std::vector<double> >("Z1")}
+    , fX0{pset.get< std::vector<double> >("X0", {})}
+    , fY0{pset.get< std::vector<double> >("Y0", {})}
+    , fZ0{pset.get< std::vector<double> >("Z0", {})}
+    , fX1{pset.get< std::vector<double> >("X1", {})}
+    , fY1{pset.get< std::vector<double> >("Y1", {})}
+    , fZ1{pset.get< std::vector<double> >("Z1", {})}
     , fIsFirstSignalSpecial{pset.get< bool >("IsFirstSignalSpecial", false)}
     // create a default random engine; obtain the random seed from NuRandomService,
     // unless overridden in configuration with key "Seed"
-    , fEngine(art::ServiceHandle<rndm::NuRandomService>{}->createEngine(*this, pset, "Seed"))
+    , fGeo               ()
+    , fGeoManager        (fGeo->ROOTGeoManager())
+    , nevent             (0)
+    , pos_xy_TH2D        ()
+    , pos_xz_TH2D        ()
+    , dir_x_TH1D         ()
+    , dir_y_TH1D         ()
+    , dir_z_TH1D         ()
+    , pdg_TH1D           ()
+    , mom_TH1D           ()
+    , time_TH1D          ()
+    , timediff_TH1D      ()
   {
+    auto& Seeds = *(art::ServiceHandle<rndm::NuRandomService>());
+
+    // declare an engine; NuRandomService associates an (unknown) engine, in
+    // the current module and an instance name, with a seed (returned)
+    auto const seed = Seeds.declareEngine();
+
+    // now create the engine (for example, use art); seed will be set
+    auto& engine = createEngine(seed, "HepJamesRandom", "RadioGenModule");
+
+    // finally, complete the registration; seed will be set again
+    Seeds.defineEngine(engine);
+    fRandomFlat        = std::make_unique<CLHEP::RandFlat       >(engine);
+    fRandomExponential = std::make_unique<CLHEP::RandExponential>(engine);
+    fRandomPoisson     = std::make_unique<CLHEP::RandPoisson    >(engine);
+
     produces< std::vector<simb::MCTruth> >();
     produces< sumdata::RunData, art::InRun >();
-
+ 
     // check for consistency of vector sizes
     unsigned int nsize = fNuclide.size();
-    if (  fMaterial.size() != nsize ) throw cet::exception("RadioGen") << "Different size Material vector and Nuclide vector\n";
-    if (  fBq.size() != nsize ) throw cet::exception("RadioGen") << "Different size Bq vector and Nuclide vector\n";
-    if (  fT0.size() != nsize ) throw cet::exception("RadioGen") << "Different size T0 vector and Nuclide vector\n";
-    if (  fT1.size() != nsize ) throw cet::exception("RadioGen") << "Different size T1 vector and Nuclide vector\n";
-    if (  fX0.size() != nsize ) throw cet::exception("RadioGen") << "Different size X0 vector and Nuclide vector\n";
-    if (  fY0.size() != nsize ) throw cet::exception("RadioGen") << "Different size Y0 vector and Nuclide vector\n";
-    if (  fZ0.size() != nsize ) throw cet::exception("RadioGen") << "Different size Z0 vector and Nuclide vector\n";
-    if (  fX1.size() != nsize ) throw cet::exception("RadioGen") << "Different size X1 vector and Nuclide vector\n";
-    if (  fY1.size() != nsize ) throw cet::exception("RadioGen") << "Different size Y1 vector and Nuclide vector\n";
-    if (  fZ1.size() != nsize ) throw cet::exception("RadioGen") << "Different size Z1 vector and Nuclide vector\n";
+    if (fMaterial.size() != nsize) { throw cet::exception("RadioGen") << "Different size Material vector and Nuclide vector"; } 
+    if (fBq      .size() != nsize) { throw cet::exception("RadioGen") << "Different size Bq vector and Nuclide vector";       } 
+    if (fT0      .size() != nsize) { throw cet::exception("RadioGen") << "Different size T0 vector and Nuclide vector";       } 
+    if (fT1      .size() != nsize) { throw cet::exception("RadioGen") << "Different size T1 vector and Nuclide vector";       }
+    if (fVolume.size() == 0 &&
+        fX0.size() != nsize &&
+        fY0.size() != nsize &&
+        fZ0.size() != nsize &&
+        fX1.size() != nsize &&
+        fY1.size() != nsize &&
+        fZ1.size() != nsize) {
+      throw cet::exception("RadioGen") << "You need to specify either Volume or X0,X1,Y0,Y1,Z0,Z1 vectors (and they must be the same size as Nuclide)";
+    }
+    
+    if (fVolume.size() != nsize &&
+        (fX0.size() != nsize ||
+         fY0.size() != nsize ||
+         fZ0.size() != nsize ||
+         fX1.size() != nsize ||
+         fY1.size() != nsize ||
+         fZ1.size() != nsize)) {
+      throw cet::exception("RadioGen") << "You need to specify either Volume vector (and it must be the same size as Nuclide)";
+    }
+    
+    for (std::string & nuclideName : fNuclide) {
+      std::cout << "Initialising " << nuclideName << "\n";
 
-    for(std::string & nuclideName : fNuclide){
-      if(nuclideName=="39Ar"      ){readfile("39Ar","Argon_39.root")    ;}
-      else if(nuclideName=="60Co" ){readfile("60Co","Cobalt_60.root")   ;}
-      else if(nuclideName=="85Kr" ){readfile("85Kr","Krypton_85.root")  ;}
-      else if(nuclideName=="40K"  ){readfile("40K","Potassium_40.root") ;}
-      else if(nuclideName=="232Th"){readfile("232Th","Thorium_232.root");}
-      else if(nuclideName=="238U" ){readfile("238U","Uranium_238.root") ;}
-      else if(nuclideName=="222Rn"){continue;} //Rn222 is handled separately later
-      else if(nuclideName=="59Ni"){continue;} //Rn222 is handled separately later
-      else if(nuclideName=="42Ar" ){
+      if     (nuclideName=="39Ar"       ){readfile(nuclideName, "Argon_39.root"    );}
+      else if(nuclideName=="60Co"       ){readfile(nuclideName, "Cobalt_60.root"   );}
+      else if(nuclideName=="85Kr"       ){readfile(nuclideName, "Krypton_85.root"  );}
+      else if(nuclideName=="40K"        ){readfile(nuclideName, "Potassium_40.root");}
+      else if(nuclideName=="232Th"      ){readfile(nuclideName, "Thorium_232.root" );}
+      else if(nuclideName=="238U"       ){readfile(nuclideName, "Uranium_238.root" );}
+      else if(nuclideName=="222Rn"      ){continue;} //...
+      else if(nuclideName=="218Po"      ){continue;} //...
+      else if(nuclideName=="214Pb"      ){continue;} //...
+      else if(nuclideName=="BiPo(Rn222)"){continue;} //...
+      else if(nuclideName=="59Ni"       ){continue;} 
+      else if(nuclideName=="42Ar"       ){
         readfile("42Ar_1", "Argon_42_1.root"); //Each possible beta decay mode of Ar42 is given it's own .root file for now.
         readfile("42Ar_2", "Argon_42_2.root"); //This allows us to know which decay chain to follow for the dexcitation gammas.
         readfile("42Ar_3", "Argon_42_3.root"); //The dexcitation gammas are not included in the root files as we want to
         readfile("42Ar_4", "Argon_42_4.root"); //probabilistically simulate the correct coincident gammas, which we cannot guarantee
         readfile("42Ar_5", "Argon_42_5.root"); //by sampling a histogram.
         continue;
-      } //Ar42  is handeled separately later
+      }
       else{
         std::string searchName = nuclideName;
         searchName+=".root";
@@ -232,40 +406,166 @@ namespace evgen{
   //____________________________________________________________________________
   void RadioGen::produce(art::Event& evt)
   {
+    nevent++;
     ///unique_ptr allows ownership to be transferred to the art::Event after the put statement
     std::unique_ptr< std::vector<simb::MCTruth> > truthcol(new std::vector<simb::MCTruth>);
 
     simb::MCTruth truth;
     truth.SetOrigin(simb::kSingleParticle);
-
     trackidcounter = -1;
     for (unsigned int i=0; i<fNuclide.size(); ++i) {
       SampleOne(i,truth);
     }//end loop over nuclides
-
+    
     MF_LOG_DEBUG("RadioGen") << truth;
     truthcol->push_back(truth);
     evt.put(std::move(truthcol));
+
+  }
+
+  TVector3 RadioGen::GetRandomPointInVolume(std::string volname, std::string matname, bool& flag) {
+
+    TGeoVolume* vol = fGeoManager->FindVolumeFast(volname.c_str());
+    if (!vol)
+      throw cet::exception("RadioGen") << "Volume: " << volname << " doesn't exist in the geometry. Exit disgracefully.";
+    
+    std::regex regex_material = (std::regex)matname;
+    
+    const TGeoShape *shape = vol->GetShape();
+    TGeoBBox *box = (TGeoBBox *)shape;
+    double dx = box->GetDX();
+    double dy = box->GetDY();
+    double dz = box->GetDZ();
+    double ox = (box->GetOrigin())[0];
+    double oy = (box->GetOrigin())[1];
+    double oz = (box->GetOrigin())[2];
+    double *xyz = new double[3];
+    TGeoNode *node = 0;
+    int i=0;
+    // int ic = 0;
+    // double ratio=0;
+    int npoints=10000;
+    while (i<npoints) {
+      xyz[0] = ox-dx+2*dx*fRandomFlat->fire();
+      xyz[1] = oy-dy+2*dy*fRandomFlat->fire();
+      xyz[2] = oz-dz+2*dz*fRandomFlat->fire();
+      fGeoManager->SetCurrentPoint(xyz);
+      node = fGeoManager->FindNode();
+      if (!node) continue;
+      if (node->IsOverlapping()) continue;
+      i++;
+
+      std::string volmaterial = node->GetMedium()->GetMaterial()->GetName();
+      flag = std::regex_match(volmaterial, regex_material);
+      TVector3 pos(xyz[0],
+                   xyz[1],
+                   xyz[2]);
+      return pos;
+    }
+    throw art::Exception(art::errors::LogicError) << "Couldn't find a point in the volume: "
+                                                  << volname << " which has material: "
+                                                  << matname << " after 10000 attempts.\n";
+    TVector3 pos(-99999,-99999,-99999);
+    delete xyz;
+    return pos;
+  }
+  
+  
+  TVector3 RadioGen::GetGoodPosition(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, std::string material, bool& flag)
+  {
+    // int trial = 0;
+    TVector3 pos;
+    flag = true;
+    
+    pos = TVector3(minX + fRandomFlat->fire()*(maxX - minX),
+                   minY + fRandomFlat->fire()*(maxY - minY),
+                   minZ + fRandomFlat->fire()*(maxZ - minZ));
+
+    std::string volmaterial = fGeoManager->FindNode(pos.X(),pos.Y(),pos.Z())->GetMedium()->GetMaterial()->GetName();
+    std::regex regex_material = (std::regex)material;
+    flag = std::regex_match(volmaterial, regex_material);
+      
+    return pos;
+  }
+
+  
+  RadioGen::ParticleInfo RadioGen::AlphaDecay(double t, TVector3 pos, double time)
+  {
+    double p=0; td_Mass m=m_alpha;// ti_PDGID pdgid=kAlphaPDG;
+    double energy = t + m; 
+    double p2     = energy*energy - m*m;
+    if (p2 > 0) p = TMath::Sqrt(p2);
+    else        p = 0;
+    ParticleInfo part;
+    part.mass = m_alpha;
+    part.pdg  = kAlphaPDG;
+    part.mom  = dirCalc(p, m);
+    part.pos  = TLorentzVector(pos, time);
+    return part;
+  }
+  
+  RadioGen::ParticleInfo RadioGen::BetaDecay(double t, TVector3 pos, double time, double Z)
+  {
+    ParticleInfo part;
+    part.mass = m_e;
+    part.pdg  = kElectronPDG;
+    double ke = sample_beta_decay_spectrum(t, Z);
+    double mom = TMath::Sqrt(TMath::Power(ke+part.mass,2) - TMath::Power(+part.mass,2));
+    part.mom  = dirCalc(mom, part.mass);
+    part.pos  = TLorentzVector(pos, time);
+    return part;
+  }
+  
+  std::vector<RadioGen::ParticleInfo> RadioGen::BetaThenAlphaDecay(double t_beta, double t_alpha, double t_mean, TVector3 pos, double time, double Z)
+  {
+    std::vector<ParticleInfo> vec;
+    vec.emplace_back(BetaDecay(t_beta, pos, time, Z));
+    vec.emplace_back(AlphaDecay(t_alpha, pos, time+fRandomExponential->fire(t_mean)));
+    return vec;
   }
 
   //____________________________________________________________________________
   // Generate radioactive decays per nuclide per volume according to the FCL parameters
+  double RadioGen::GetRate(int i) {
+    
+    if ((size_t)i < fVolume.size()) {
+       TGeoVolume* vol = fGeoManager->FindVolumeFast(fVolume[i].c_str());
+      if (!vol)
+        throw cet::exception("RadioGen") << "Volume: " << fVolume[i] << " doesn't exist in the geometry. Exit disgracefully.";
+    
+      const TGeoShape *shape = vol->GetShape();
+      TGeoBBox *box = (TGeoBBox *)shape;
+      double dx = box->GetDX();
+      double dy = box->GetDY();
+      double dz = box->GetDZ();
+      double ox = (box->GetOrigin())[0];
+      double oy = (box->GetOrigin())[1];
+      double oz = (box->GetOrigin())[2];
+      double X0 = ox-dx;
+      double X1 = ox+dx;
+      double Y0 = oy-dy;
+      double Y1 = oy+dy;
+      double Z0 = oz-dz;
+      double Z1 = oz+dz;
 
-  void RadioGen::SampleOne(unsigned int i, simb::MCTruth &mct)
+      double rate = fabs( fBq[i] * (fT1[i] - fT0[i]) * (X1 - X0) * (Y1 - Y0) * (Z1 - Z0) ) / 1.0E9;
+      return rate;
+    } else {
+      return fabs( fBq[i] * (fT1[i] - fT0[i]) * (fX1[i] - fX0[i]) * (fY1[i] - fY0[i]) * (fZ1[i] - fZ0[i]) ) / 1.0E9;
+    }
+
+  }
+  
+  void RadioGen::SampleOne(int i, simb::MCTruth &mct)
   {
-    art::ServiceHandle<geo::Geometry const> geo;
-    TGeoManager *geomanager = geo->ROOTGeoManager();
-
-    CLHEP::RandFlat     flat(fEngine);
-    CLHEP::RandPoisson  poisson(fEngine);
 
     // figure out how many decays to generate, assuming that the entire prism consists of the radioactive material.
     // we will skip over decays in other materials later.
 
-    double rate = fabs( fBq[i] * (fT1[i] - fT0[i]) * (fX1[i] - fX0[i]) * (fY1[i] - fY0[i]) * (fZ1[i] - fZ0[i]) ) / 1.0E9;
-    long ndecays = poisson.shoot(rate);
+    double rate = GetRate(i);
+    long ndecays = fRandomPoisson->fire(rate);
+    MF_LOG_DEBUG("RadioGen") << "Number of decays generated: " << ndecays << " (central value: " << rate << ") for " << fNuclide[i] << "\n";
 
-    std::regex const re_material{fMaterial[i]};
     for (unsigned int idecay=0; idecay<ndecays; idecay++)
     {
       // generate just one particle at a time.  Need a little recoding if a radioactive
@@ -273,75 +573,113 @@ namespace evgen{
       // uniformly distributed in position and time
       //
       // JStock: Leaving this as a single position for the decay products. For now I will assume they all come from the same spot.
-      TLorentzVector pos( fX0[i] + flat.fire()*(fX1[i] - fX0[i]),
-          fY0[i] + flat.fire()*(fY1[i] - fY0[i]),
-          fZ0[i] + flat.fire()*(fZ1[i] - fZ0[i]),
-          (idecay==0 && fIsFirstSignalSpecial) ? 0 : ( fT0[i] + flat.fire()*(fT1[i] - fT0[i]) ) );
-
-      // discard decays that are not in the proper material
-      std::string volmaterial = geomanager->FindNode(pos.X(),pos.Y(),pos.Z())->GetMedium()->GetMaterial()->GetName();
-        if (!std::regex_match(volmaterial, re_material)) continue;
 
       //Moved pdgid into the next statement, so that it is localized.
       // electron=11, photon=22, alpha = 1000020040, neutron = 2112
 
       //JStock: Allow us to have different particles from the same decay. This requires multiple momenta.
-      std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>> v_prods; //(First is for PDGID, second is mass, third is Momentum)
+      bool flag = true;
+      TVector3 pos;
+      if (fVolume.size())
+        pos = GetRandomPointInVolume(fVolume[i], fMaterial[i], flag);
+      else
+        pos = GetGoodPosition(fX0[i],fY0[i],fZ0[i],fX1[i],fY1[i],fZ1[i],fMaterial[i], flag);
+      
+      if (!flag)
+        continue;
+      
+      double time = (idecay==0 && fIsFirstSignalSpecial) ? 0 : ( fT0[i] + fRandomFlat->fire()*(fT1[i] - fT0[i]));
 
+      std::vector<ParticleInfo> v_prods; //(First is for PDGID, second is mass, third is Momentum)
+      
       if (fNuclide[i] == "222Rn")          // Treat 222Rn separately
       {
-        double p=0; double t=0.00548952; td_Mass m=m_alpha; ti_PDGID pdgid=1000020040; //td_Mass = double. ti_PDGID = int;
-        double energy = t + m;
-        double p2     = energy*energy - m*m;
-        if (p2 > 0) p = TMath::Sqrt(p2);
-        else        p = 0;
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
-      }//End special case RN222
+        v_prods.emplace_back(AlphaDecay(0.0055904, pos, time));
+      }
+      
+      else if(fNuclide[i] == "226Ra")
+      {
+        v_prods.emplace_back(AlphaDecay(0.0050975, pos, time));
+      }
+      
+      else if(fNuclide[i] == "218Po")
+      {
+        v_prods.emplace_back(AlphaDecay(0.00611475, pos, time));
+      }
+      
+      else if(fNuclide[i]=="214Pb")
+      {
+        v_prods.emplace_back(BetaDecay(0.002240300, pos, time, 83));
+      }
+      
+      else if (fNuclide[i] == "BiPo(Rn222)")          // Treat 222Rn separately
+      {
+        std::vector<ParticleInfo> bipo_prod = BetaThenAlphaDecay(0.003269, 0.00783354, 164000, pos, time, 84);
+        timediff_TH1D->Fill(bipo_prod[1].pos.T() - bipo_prod[0].pos.T());
+        for (auto const& p: bipo_prod) {
+          v_prods.emplace_back(p);
+        }
+      }
+      
       else if(fNuclide[i] == "59Ni"){ //Treat 59Ni Calibration Source separately (as I haven't made a spectrum for it, and ultimately it should be handeled with multiple particle outputs.
-        double p=0.008997; td_Mass m=0; ti_PDGID pdgid=22; // td_Mas=double. ti_PDFID=int. Assigning p directly, as t=p for gammas.
-          v_prods.emplace_back(pdgid, m, dirCalc(p,m));
+        double p=0.008997; // td_Mas=double. ti_PDFID=int. Assigning p directly, as t=p for gammas.
+        ParticleInfo part;
+        part.mass = 0;
+        part.pdg = kGammaPDG;
+        part.mom = dirCalc(p, part.mass);
+        part.pos = TLorentzVector(pos, time);
+        v_prods.emplace_back(part);
       }//end special case Ni59 calibration source
-      else if(fNuclide[i] == "42Ar"){   // Spot for special treatment of Ar42.
-        double p=0; double t=0; td_Mass m = 0; ti_PDGID pdgid=0; //td_Mass = double. ti_PDGID = int;
-        double bSelect = flat.fire();   //Make this a random number from 0 to 1.
+      
+      else if(fNuclide[i] == "42Ar")
+      {   // Spot for special treatment of Ar42.
+        ParticleInfo part;
+
+        double bSelect = fRandomFlat->fire();   //Make this a random number from 0 to 1.
         if(bSelect<0.819){              //beta channel 1. No Gamma. beta Q value 3525.22 keV
-          samplespectrum("42Ar_1", pdgid, t, m, p);
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+          samplespectrum("42Ar_1", part);
+          v_prods.emplace_back(part);
           //No gamma here.
         }else if(bSelect<0.9954){       //beta channel 2. 1 Gamma (1524.6 keV). beta Q value 2000.62
-          samplespectrum("42Ar_2", pdgid, t, m, p);
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+          samplespectrum("42Ar_2", part);
+          v_prods.emplace_back(part);
           Ar42Gamma2(v_prods);
         }else if(bSelect<0.9988){       //beta channel 3. 1 Gamma Channel. 312.6 keV + gamma 2. beta Q value 1688.02 keV
-          samplespectrum("42Ar_3", pdgid, t, m, p);
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+          samplespectrum("42Ar_3", part);
+          v_prods.emplace_back(part);
           Ar42Gamma3(v_prods);
         }else if(bSelect<0.9993){       //beta channel 4. 2 Gamma Channels. Either 899.7 keV (i 0.052) + gamma 2 or 2424.3 keV (i 0.020). beta Q value 1100.92 keV
-          samplespectrum("42Ar_4", pdgid, t, m, p);
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+          samplespectrum("42Ar_4", part);
+          v_prods.emplace_back(part);
           Ar42Gamma4(v_prods);
         }else{                          //beta channel 5. 3 gamma channels. 692.0 keV + 1228.0 keV + Gamma 2 (i 0.0033) ||OR|| 1021.2 keV + gamma 4 (i 0.0201) ||OR|| 1920.8 keV + gamma 2 (i 0.041). beta Q value 79.82 keV
-          samplespectrum("42Ar_5", pdgid, t, m, p);
-            v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+          samplespectrum("42Ar_5", part);
+          v_prods.emplace_back(part);
           Ar42Gamma5(v_prods);
         }
-        //Add beta.
-        //Call gamma function for beta mode.
+        
+        for (auto& it: v_prods) { // All the Ar42 are produced at the same place.
+          it.pos = TLorentzVector(pos, time);
+        }
       }
-      else{ //General Case.
-        double p=0; double t=0; td_Mass m = 0; ti_PDGID pdgid=0; //td_Mass = double. ti_PDGID = int;
-        samplespectrum(fNuclide[i],pdgid,t,m,p);
-        std::tuple<ti_PDGID, td_Mass, TLorentzVector> partMassMom = std::make_tuple(pdgid, m, dirCalc(p,m));
-        v_prods.push_back(partMassMom);
+      
+      else
+      { //General Case.
+        ParticleInfo part;
+        samplespectrum(fNuclide[i],part);
+        part.pos = TLorentzVector(pos, time);
+        v_prods.push_back(part);
       }//end else (not RN or other special case
+
 
       //JStock: Modify this to now loop over the v_prods.
       for(auto prodEntry : v_prods){
         // set track id to a negative serial number as these are all primary particles and have id <= 0
         int trackid = trackidcounter;
-        ti_PDGID pdgid = std::get<0>(prodEntry);
-        td_Mass  m = std::get<1>(prodEntry);
-        TLorentzVector pvec = std::get<2>(prodEntry);
+        ti_PDGID pdgid = prodEntry.pdg;
+        td_Mass  m = prodEntry.mass;
+        TLorentzVector mom_vec = prodEntry.mom;
+        TLorentzVector pos_vec = prodEntry.pos;
         trackidcounter--;
         std::string primary("primary");
 
@@ -349,58 +687,95 @@ namespace evgen{
         // // so don't rely so heavily on default arguments to the MCParticle constructor
         if (pdgid == 1000020040){
           simb::MCParticle part(trackid, pdgid, primary,-1,m,1);
-          part.AddTrajectoryPoint(pos, pvec);
+          part.AddTrajectoryPoint(pos_vec, mom_vec);
+          pdg_TH1D->Fill(80);
           mct.Add(part);
         }// end "If alpha"
         else{
           simb::MCParticle part(trackid, pdgid, primary);
-          part.AddTrajectoryPoint(pos, pvec);
+          part.AddTrajectoryPoint(pos_vec, mom_vec);
+          pdg_TH1D->Fill(pdgid);
           mct.Add(part);
         }// end All standard cases.
+        pos_xy_TH2D->Fill(prodEntry.pos.X(), prodEntry.pos.Y());
+        pos_xz_TH2D->Fill(prodEntry.pos.X(), prodEntry.pos.Z());
+        double mom = sqrt(prodEntry.mom.X() * prodEntry.mom.X() +
+                          prodEntry.mom.Y() * prodEntry.mom.Y() +
+                          prodEntry.mom.Z() * prodEntry.mom.Z());
+        mom_TH1D   ->Fill(mom*1000.);
+        dir_x_TH1D ->Fill(prodEntry.mom.X()/mom);
+        dir_y_TH1D ->Fill(prodEntry.mom.Y()/mom);
+        dir_z_TH1D ->Fill(prodEntry.mom.Z()/mom);
+        time_TH1D  ->Fill(prodEntry.pos.T());
       }//End Loop over all particles produces in this single decay.
+    
     }
+ 
   }
 
-  //Calculate an arbitrary direction with a given magnitude p
+//Calculate an arbitrary direction with a given magnitude p
   TLorentzVector RadioGen::dirCalc(double p, double m)
   {
-    CLHEP::RandFlat  flat(fEngine);
       // isotropic production angle for the decay product
-      double costheta = (2.0*flat.fire() - 1.0);
+      double costheta = (2.0*fRandomFlat->fire() - 1.0);
       if (costheta < -1.0) costheta = -1.0;
       if (costheta > 1.0) costheta = 1.0;
     double const sintheta = sqrt(1.0-costheta*costheta);
-    double const phi = 2.0*M_PI*flat.fire();
+    double const phi = 2.0*M_PI*fRandomFlat->fire();
     return TLorentzVector{p*sintheta*std::cos(phi),
-          p*sintheta*std::sin(phi),
-          p*costheta,
-                          std::sqrt(p*p+m*m)};
+        p*sintheta*std::sin(phi),
+        p*costheta,
+        std::sqrt(p*p+m*m)};
+  }
+
+  
+  std::unique_ptr<TH1D> ParseTGraph(TGraph* graph, std::string type, double& integral) {
+    
+    if (graph) {
+      int np = graph->GetN();
+      //double *x = graph->GetX();
+      double *y = graph->GetY();
+      std::string name = "RadioGen_" + type;
+      auto hist = std::make_unique<TH1D>(name.c_str(),(name+" Spectrum").c_str(),np,0,np); // TODO!!
+      //auto hist = std::make_unique<TH1D>(name.c_str(),(name+" Spectrum").c_str(),np,x[0],x[np-1]);
+      //Change the previous line to this at some point
+      for (int i=0; i<np; i++) {
+        hist->SetBinContent(i+1,y[i]);
+        hist->SetBinError  (i+1,0);
+      }
+      integral = hist->Integral();
+      return std::move(hist);
+    }
+    integral = 0;
+    return nullptr;
+    
   }
 
   // only reads those files that are on the fNuclide list.  Copy information from the TGraphs to TH1D's
-
-  void RadioGen::readfile(std::string nuclide, std::string const& filename)
+  void RadioGen::readfile(std::string type, std::string const& filename)
   {
-    bool found{false};
-    std::regex const re_argon{"42Ar.*"};
-    for (size_t i=0; i<fNuclide.size(); i++)
-    {
-      if (fNuclide[i] == nuclide){ //This check makes sure that the nuclide we are searching for is in fact in our fNuclide list. Ar42 handeled separately.
-          found = true;
-        break;
-      } //End If nuclide is in our list. Next is the special case of Ar42
-        else if (std::regex_match(nuclide, re_argon) && fNuclide[i]=="42Ar") {
-          found = true;
-        break;
-      }
-    }
-    if (!found) return;
+    // bool found{false};
 
+    // for (size_t i=0; i<fNuclide.size(); i++)
+    // {
+    //   if (fNuclide[i] == nuclide){ //This check makes sure that the nuclide we are searching for is in fact in our fNuclide list. Ar42 handeled separately.
+    //       found = true;
+    //     break;
+    //   } //End If nuclide is in our list. Next is the special case of Ar42
+    //     else if (std::regex_match(nuclide, re_argon) && fNuclide[i]=="42Ar") {
+    //       found = true;
+    //     break;
+    //   }
+    // }
+    
+    // if (!found) return;
+    //if (type == kUnknown) throw cet::exception("RadioGen") << "The file \"" << filename << "\" will be saved to unknown, so won't be used.";
+      
     Bool_t addStatus = TH1::AddDirectoryStatus();
     TH1::AddDirectory(kFALSE); // cloned histograms go in memory, and aren't deleted when files are closed.
     // be sure to restore this state when we're out of the routine.
 
-    spectrumname.push_back(nuclide);
+    //spectrumname.push_back(nuclide);
     cet::search_path sp("FW_SEARCH_PATH");
     std::string fn2 = "Radionuclides/";
     fn2 += filename;
@@ -418,174 +793,95 @@ namespace evgen{
     TGraph *gammagraph = (TGraph*) f.Get("Gammas");
     TGraph *neutrongraph = (TGraph*) f.Get("Neutrons");
 
-    if (alphagraph)
-    {
-      int np = alphagraph->GetN();
-      double *y = alphagraph->GetY();
-      std::string name;
-      name = "RadioGen_";
-      name += nuclide;
-      name += "_Alpha";
-        auto alphahist = std::make_unique<TH1D>(name.c_str(),"Alpha Spectrum",np,0,np);
-        for (int i=0; i<np; i++) {
-        alphahist->SetBinContent(i+1,y[i]);
-        alphahist->SetBinError(i+1,0);
-      }
-      alphaintegral.push_back(alphahist->Integral());
-        alphaspectrum.push_back(move(alphahist));
-    }
-    else
-    {
-      alphaintegral.push_back(0);
-        alphaspectrum.push_back(nullptr);
-    }
 
-
-    if (betagraph)
-    {
-      int np = betagraph->GetN();
-
-      double *y = betagraph->GetY();
-      std::string name;
-      name = "RadioGen_";
-      name += nuclide;
-      name += "_Beta";
-        auto betahist = std::make_unique<TH1D>(name.c_str(),"Beta Spectrum",np,0,np);
-        for (int i=0; i<np; i++) {
-        betahist->SetBinContent(i+1,y[i]);
-        betahist->SetBinError(i+1,0);
-      }
-      betaintegral.push_back(betahist->Integral());
-        betaspectrum.push_back(move(betahist));
-    }
-    else
-    {
-      betaintegral.push_back(0);
-        betaspectrum.push_back(nullptr);
-    }
-
-    if (gammagraph)
-    {
-      int np = gammagraph->GetN();
-      double *y = gammagraph->GetY();
-      std::string name;
-      name = "RadioGen_";
-      name += nuclide;
-      name += "_Gamma";
-        auto gammahist = std::make_unique<TH1D>(name.c_str(),"Gamma Spectrum",np,0,np);
-        for (int i=0; i<np; i++) {
-        gammahist->SetBinContent(i+1,y[i]);
-        gammahist->SetBinError(i+1,0);
-      }
-      gammaintegral.push_back(gammahist->Integral());
-        gammaspectrum.push_back(move(gammahist));
-    }
-    else
-    {
-      gammaintegral.push_back(0);
-        gammaspectrum.push_back(nullptr);
-    }
-
-    if (neutrongraph)
-    {
-      int np = neutrongraph->GetN();
-      double *y = neutrongraph->GetY();
-      std::string name;
-      name = "RadioGen_";
-      name += nuclide;
-      name += "_Neutron";
-        auto neutronhist = std::make_unique<TH1D>(name.c_str(),"Neutron Spectrum",np,0,np);
-      for (int i=0; i<np; i++)
-      {
-        neutronhist->SetBinContent(i+1,y[i]);
-        neutronhist->SetBinError(i+1,0);
-      }
-      neutronintegral.push_back(neutronhist->Integral());
-        neutronspectrum.push_back(move(neutronhist));
-    }
-    else
-    {
-      neutronintegral.push_back(0);
-        neutronspectrum.push_back(nullptr);
-    }
+    double integral = 0;
+    alphaspectrum  [type] = ParseTGraph(alphagraph,   type, integral); alphaintegral[type]   = integral;
+    betaspectrum   [type] = ParseTGraph(betagraph,    type, integral); betaintegral[type]    = integral;
+    gammaspectrum  [type] = ParseTGraph(gammagraph,   type, integral); gammaintegral[type]   = integral;
+    neutronspectrum[type] = ParseTGraph(neutrongraph, type, integral); neutronintegral[type] = integral;
 
     f.Close();
     TH1::AddDirectory(addStatus);
 
-    double total = alphaintegral.back() + betaintegral.back() + gammaintegral.back() + neutronintegral.back();
+    double total = alphaintegral[type] + betaintegral[type] + gammaintegral[type] + neutronintegral[type];
     if (total>0)
     {
-      alphaintegral.back() /= total;
-      betaintegral.back() /= total;
-      gammaintegral.back() /= total;
-      neutronintegral.back() /= total;
+      alphaintegral  [type] /= total;
+      betaintegral   [type] /= total;
+      gammaintegral  [type] /= total;
+      neutronintegral[type] /= total;
     }
   }
 
+  double RadioGen::sample_beta_decay_spectrum(double Q, double Z) {
+    // PLasorak: A simple rejection method with beta spectrum
+    //... that return the Q value(!)
+    return Q;
+  }
 
-  void RadioGen::samplespectrum(std::string nuclide, int &itype, double &t, double &m, double &p)
+  void RadioGen::samplespectrum(std::string type, ParticleInfo& part)
   {
-    CLHEP::RandFlat  flat(fEngine);
 
-    int inuc = -1;
-    for (size_t i=0; i<spectrumname.size(); i++)
-    {
-      if (nuclide == spectrumname[i])
-      {
-        inuc = i;
-        break;
-      }
+    double t = 0;
+    double rtype = fRandomFlat->fire();
+
+    part.pdg = -1;
+    part.mass = 0;
+    part.mom = TLorentzVector(0,0,0,0);
+
+    try {
+      (void)alphaspectrum.at(type);
+      (void)alphaintegral.at(type);
+      (void)betaintegral .at(type);
+      (void)betaspectrum .at(type);
+      (void)gammaintegral.at(type);
+      (void)gammaspectrum.at(type);
+    } catch (...) {
+      throw cet::exception("RadioGen") << "Missing information for : " << type << "\n";
     }
-    if (inuc == -1)
-    {
-      t=0;  // throw an exception in the future
-      itype = 0;
-      throw cet::exception("RadioGen") << "Ununderstood nuclide:  " << nuclide << "\n";
-    }
-
-    double rtype = flat.fire();
-
-    itype = -1;
-    m = 0;
-    p = 0;
+    
     for (int itry=0;itry<10;itry++) // maybe a tiny normalization issue with a sum of 0.99999999999 or something, so try a few times.
     {
-        if (rtype <= alphaintegral[inuc] && alphaspectrum[inuc] != nullptr)
+      if (rtype <= alphaintegral.at(type) && alphaspectrum.at(type) != nullptr)
       {
-        itype = 1000020040; // alpha
-        m = m_alpha;
-            t = samplefromth1d(*alphaspectrum[inuc])/1000000.0;
+        part.pdg = 1000020040; // alpha
+        part.mass = m_alpha;
+        t = samplefromth1d(*alphaspectrum.at(type))/1000000.0;
       }
-        else if (rtype <= alphaintegral[inuc]+betaintegral[inuc] && betaspectrum[inuc] != nullptr)
+      else if (rtype <= alphaintegral.at(type)+betaintegral.at(type) && betaspectrum.at(type) != nullptr)
       {
-        itype = 11; // beta
-        m = m_e;
-            t = samplefromth1d(*betaspectrum[inuc])/1000000.0;
+        part.pdg = 11; // beta
+        part.mass = m_e;
+        t = samplefromth1d(*betaspectrum.at(type))/1000000.0;
       }
-        else if ( rtype <= alphaintegral[inuc] + betaintegral[inuc] + gammaintegral[inuc] && gammaspectrum[inuc] != nullptr)
+      else if ( rtype <= alphaintegral.at(type) + betaintegral.at(type) + gammaintegral.at(type) && gammaspectrum.at(type) != nullptr)
       {
-        itype = 22; // gamma
-        m = 0;
-            t = samplefromth1d(*gammaspectrum[inuc])/1000000.0;
+        part.pdg = 22; // gamma
+        part.mass = 0;
+        t = samplefromth1d(*gammaspectrum.at(type))/1000000.0;
       }
-        else if( neutronspectrum[inuc] != nullptr)
+      else if( neutronspectrum.at(type) != nullptr)
       {
-        itype = 2112;
-        m     = m_neutron;
-            t     = samplefromth1d(*neutronspectrum[inuc])/1000000.0;
+        part.pdg = 2112;
+        part.mass = m_neutron;
+        t = samplefromth1d(*neutronspectrum.at(type))/1000000.0;
       }
-      if (itype >= 0) break;
+      
+      if (part.pdg >= 0) break;
     }
-    if (itype == -1)
+    
+    if (part.pdg == -1)
     {
-      throw cet::exception("RadioGen") << "Normalization problem with nuclide:  " << nuclide << "\n";
+      throw cet::exception("RadioGen") << "Normalization problem with nuclide: " << type;
     }
-    double e = t + m;
-    p = e*e - m*m;
+    
+    double e = t + part.mass;
+    double p = e*e - part.mass* part.mass;
     if (p>=0)
     { p = TMath::Sqrt(p); }
     else
     { p=0; }
+    part.mom = dirCalc(p, part.mass);
   }
 
   // this is just a copy of TH1::GetRandom that uses the art-managed CLHEP random number generator instead of gRandom
@@ -593,8 +889,7 @@ namespace evgen{
 
   double RadioGen::samplefromth1d(TH1D& hist)
   {
-    CLHEP::RandFlat  flat(fEngine);
-
+    //return hist.GetRandom(); // TODO Change the folling code to that
     int nbinsx = hist.GetNbinsX();
     std::vector<double> partialsum;
     partialsum.resize(nbinsx+1);
@@ -611,7 +906,7 @@ namespace evgen{
     // normalize to unit sum
     for (int i=1;i<=nbinsx;i++) partialsum[i] /= integral;
 
-    double r1 = flat.fire();
+    double r1 = fRandomFlat->fire();
     int ibin = TMath::BinarySearch(nbinsx,&(partialsum[0]),r1);
     Double_t x = hist.GetBinLowEdge(ibin+1);
     if (r1 > partialsum[ibin]) {
@@ -628,66 +923,93 @@ namespace evgen{
   //beta channel 4. 2 Gamma Channels. Either 899.7 keV (i 0.052) + gamma 2 or 2424.3 keV (i 0.020). beta Q value 1100.92 keV
   //beta channel 5. 3 gamma channels. 692.0 keV + 1228.0 keV + Gamma 2 (i 0.0033) ||OR|| 1021.2 keV + gamma 4 (i 0.0201) ||OR|| 1920.8 keV + gamma 2 (i 0.041). beta Q value 79.82 keV
   //No Ar42Gamma1 as beta channel 1 does not produce a dexcitation gamma.
-  void RadioGen::Ar42Gamma2(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods)
+  void RadioGen::Ar42Gamma2(std::vector<ParticleInfo>& v_prods)
   {
-    ti_PDGID pdgid = 22; td_Mass m = 0.0; //we are writing gammas
     std::vector<double> vd_p = {.0015246};//Momentum in GeV
     for(auto p : vd_p){
-      v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+      ParticleInfo part;
+      part.pdg = kGammaPDG;
+      part.mass = 0;
+      part.mom = dirCalc(p, part.mass);
+      v_prods.emplace_back(part);
     }
   }
 
-  void RadioGen::Ar42Gamma3(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods)
+  void RadioGen::Ar42Gamma3(std::vector<ParticleInfo>& v_prods)
   {
-    ti_PDGID pdgid = 22; td_Mass m = 0.0; //we are writing gammas
     std::vector<double> vd_p = {.0003126};
     for(auto p : vd_p){
-      v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+      ParticleInfo part;
+      part.pdg = kGammaPDG;
+      part.mass = 0;
+      part.mom = dirCalc(p, part.mass);
+      v_prods.emplace_back(part);
     }
     Ar42Gamma2(v_prods);
   }
 
-  void RadioGen::Ar42Gamma4(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods)
+  void RadioGen::Ar42Gamma4(std::vector<ParticleInfo>& v_prods)
   {
-    CLHEP::RandFlat     flat(fEngine);
-    ti_PDGID pdgid = 22; td_Mass m = 0.0; //we are writing gammas
+
     double chan1 = (0.052 / (0.052+0.020) );
-    if(flat.fire()<chan1){
+    
+    if(fRandomFlat->fire()<chan1){
       std::vector<double> vd_p = {.0008997};//Momentum in GeV
       for(auto p : vd_p){
-        v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+        ParticleInfo part;
+        part.pdg = kGammaPDG;
+        part.mass = 0;
+        part.mom = dirCalc(p, part.mass);
+        v_prods.emplace_back(part);
       }
       Ar42Gamma2(v_prods);
     }else{
       std::vector<double> vd_p = {.0024243};//Momentum in GeV
       for(auto p : vd_p){
-        v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+        ParticleInfo part;
+        part.pdg = kGammaPDG;
+        part.mass = 0;
+        part.mom = dirCalc(p, part.mass);
+        v_prods.emplace_back(part);
       }
     }
   }
 
-  void RadioGen::Ar42Gamma5(std::vector<std::tuple<ti_PDGID, td_Mass, TLorentzVector>>& v_prods)
+  void RadioGen::Ar42Gamma5(std::vector<ParticleInfo>& v_prods)
   {
-    CLHEP::RandFlat     flat(fEngine);
-    ti_PDGID pdgid = 22; td_Mass m = 0.0; //we are writing gammas
+
     double chan1 = ( 0.0033 / (0.0033 + 0.0201 + 0.041) ); double chan2 = ( 0.0201 / (0.0033 + 0.0201 + 0.041) );
-    double chanPick = flat.fire();
+
+    double chanPick = fRandomFlat->fire();
+
     if(chanPick < chan1){
       std::vector<double> vd_p = {0.000692, 0.001228};//Momentum in GeV
       for(auto p : vd_p){
-        v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+        ParticleInfo part;
+        part.pdg = kGammaPDG;
+        part.mass = 0;
+        part.mom = dirCalc(p, part.mass);
+        v_prods.emplace_back(part);
       }
       Ar42Gamma2(v_prods);
     }else if (chanPick<(chan1+chan2)){
       std::vector<double> vd_p = {0.0010212};//Momentum in GeV
       for(auto p : vd_p){
-        v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+        ParticleInfo part;
+        part.pdg = kGammaPDG;
+        part.mass = 0;
+        part.mom = dirCalc(p, part.mass);
+        v_prods.emplace_back(part);
       }
       Ar42Gamma4(v_prods);
     }else{
       std::vector<double> vd_p = {0.0019208};//Momentum in GeV
       for(auto p : vd_p){
-        v_prods.emplace_back(pdgid, m, dirCalc(p, m));
+        ParticleInfo part;
+        part.pdg = kGammaPDG;
+        part.mass = 0;
+        part.mom = dirCalc(p, part.mass);
+        v_prods.emplace_back(part);
       }
       Ar42Gamma2(v_prods);
     }
@@ -709,7 +1031,7 @@ namespace evgen{
   //      double weight = rg.Generate();  // want to unweight these if possible
   //      TLorentzVector *e4v = rg.GetDecay(1);  // get electron four-vector
   //      p = e4v->P();
-  //  if (weight >= wmax * flat.fire()) break;
+  //  if (weight >= wmax * flat->fire()) break;
   //   }
   //return p;
   //}


### PR DESCRIPTION
The changes in the module allow it to:
- Does time-correlated decays (Bismuth/Polonium),
- Uses a `struct` to pass the decay info, rather than `std::tuple`,
- Better parsing of file spectrum files (convert the `TGraph` to the `TH1D` without relying on the format of the file),
- Creates output plots (time of the particules generated, position (xy, yz), time correlation, momentum, pdg),
- Can be called with volume names, rather than hardcoding the box values based on geometry.

Probably would need to be tested more systematically to make sure that it yields to the same results as the previous version. I can do make some plots that compare what is generated for different experiments if required (I'd just need to be told which actual fhicl are to be run). 