### PR TITLE
Small fix to interpretation of azimuthal angle in MUSUN generator.

### DIFF
--- a/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
+++ b/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
@@ -549,7 +549,7 @@ namespace evgen{
 
     //  The minus sign above is for y-axis pointing up, so the y-momentum
     //  is always pointing down
-    cx       = -sin(theta)*sin(phi);
+    cx       = +sin(theta)*sin(phi);
     cy       = -cos(theta);
     cz       = +sin(theta)*cos(phi);
     Momentum = std::sqrt(Energy*Energy-m*m); // Get momentum


### PR DESCRIPTION
The input flux assumes convention where azimuth angle (phi) runs counterclockwise from east direction. This translates to counterclockwise rotation from local negative Z direction to local negative X. The code as it is now makes phi run clockwise. To add here, flux angles determine direction of the origin of the muons, the direction of their momentum is the opposite. Hence direction cosines cx and cz in the code should both have a plus sign.