### PR TITLE
Fixing a bug in MUSUN generator

### DIFF
--- a/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
+++ b/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
@@ -571,8 +571,8 @@ namespace evgen{
     } else if( xfl1 <= (sh1+sv1)/ss ) {
       x0 = (fXmax - fXmin)*flat.fire() + fXmin;
       y0 = (fYmax - fYmin)*flat.fire() + fYmin;
-      if( cz >= 0 ) z0 = fZmax;
-      else z0 = fZmin;
+      if( cz >= 0 ) z0 = fZmin;
+      else z0 = fZmax;
     } else {
       if( cx >= 0 ) x0 = fXmin;
       else x0 = fXmax;


### PR DESCRIPTION
Description of the bug: 
MUSUN generates muons on the surface of a box which contains the main detector module and part of the surrounding rock. 

For muons pointing in the positive direction of Z, the direction of FNAL beam, the face at Max Z is chosen. For muons pointing in the negative direction of Z, the direction towards FNAL, the face at Min Z is chosen. This effectively makes the muons be shot away from the main volume on these faces.

This is not the case for the XY faces with direction along X.

The author of the code, Karl Warburton, has been contacted and the fix was agreed on.

This bug is not directly related to the previous fix in MUSUN, 8f560d4b29eb.