### PR TITLE
Performance, memory and styling improvements in OpFastScintillation

### DIFF
--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -492,6 +492,9 @@ namespace larg4 {
     // get the number of photons produced from the IonizationAndScintillation
     // singleton
     larg4::IonizationAndScintillation::Instance()->Reset(&aStep);
+    // TODO: I believe MeanNumberOfPhotons should be unsigned int or
+    // long unsigned int, this would need to change across different files
+    // ~icaza
     double MeanNumberOfPhotons = larg4::IonizationAndScintillation::Instance()->NumberScintillationPhotons();
     // double stepEnergy          = larg4::IonizationAndScintillation::Instance()->VisibleEnergyDeposit()/CLHEP::MeV;
     RecordPhotonsProduced(aStep, MeanNumberOfPhotons);//, stepEnergy);
@@ -773,6 +776,9 @@ namespace larg4 {
             fzdimension = fOpDetLength.at(OpDet);
             // set detector struct for solid angle function
             detPoint.h = fydimension; detPoint.w = fzdimension;
+            // TODO: potentially loosing photons:
+            //       Num is double but gets casted to int in the function below
+            // ~icaza
             DetThisPMT = VUVHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
           }
 
@@ -792,6 +798,9 @@ namespace larg4 {
               TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0],
                                   fOpDetCenter.at(OpDet)[1],
                                   fOpDetCenter.at(OpDet)[2]);
+              // TODO: potentially loosing photons:
+              //       Num is double but gets casted to int in the function below
+              // ~icaza
               ReflDetThisPMT = VISHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
             }
             if(ReflDetThisPMT > 0) {

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1537,7 +1537,8 @@ namespace larg4 {
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz) ||
+       (std::abs(ScintPoint[0]) <= fplane_depth)) {
       return 0;
     }
 
@@ -1611,7 +1612,8 @@ namespace larg4 {
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz) ||
+       (std::abs(ScintPoint[0]) <= fplane_depth)) {
       return 0;
     }
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1855,9 +1855,6 @@ namespace larg4 {
     const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
-    if(TMath::Abs(boost::math::ellint_1(bb) - bb) < 1e-10 && TMath::Abs(boost::math::ellint_3(cc, bb) - cc) < 1e-10) {
-      throw(std::runtime_error("Problem loading ELLIPTIC INTEGRALS running Disk_SolidAngle!"));
-    }
     if(d < b) {
       return 2.*TMath::Pi() - 2.*aa * (boost::math::ellint_1(bb) + TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc));
     }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1732,6 +1732,42 @@ namespace larg4 {
   }
 
 
+  G4double OpFastScintillation::single_exp(G4double t, G4double tau2) const
+  {
+    return std::exp(-1.0 * t / tau2) / tau2;
+  }
+
+
+  G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
+  {
+    return std::exp(-1.0 * t / tau2) *
+      (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
+  }
+
+
+  G4double OpFastScintillation::Gaisser_Hillas(double x, double *par)
+  {
+    double X_mu_0 = par[3];
+    double Normalization = par[0];
+    double Diff = par[1] - X_mu_0;
+    double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
+    double Exponential = std::exp((par[1] - x) / par[2]);
+    return (Normalization * Term * Exponential);
+  }
+
+
+  double OpFastScintillation::Pol_5(double x, double *par)
+  {
+    // 5th order polynomial function
+    double xpow = 1.;
+    for(unsigned i=1; i<=5; ++i){
+      xpow *= x;
+      par[0] += par[i] * xpow ;
+    }
+    return par[0];
+  }
+
+
   double finter_d(double *x, double *par)
   {
     double y1 = par[2] * TMath::Landau(x[0], par[0], par[1]);
@@ -1859,7 +1895,7 @@ namespace larg4 {
 
 
   // solid angle of circular aperture
-  double Disk_SolidAngle(const double d, const double h, const double b)
+  double OpFastScintillation::Disk_SolidAngle(const double d, const double h, const double b)
   {
     if(b <= 0. || d < 0. || h <= 0.) return 0.;
     const double aa = TMath::Sqrt(h * h / (h * h + (b + d) * (b + d)));
@@ -1886,7 +1922,7 @@ namespace larg4 {
 
 
   // solid angle of rectanglular aperture
-  double Rectangle_SolidAngle(double a, double b, double d)
+  double OpFastScintillation::Rectangle_SolidAngle(double a, double b, double d)
   {
     double aa = a / (2.0 * d);
     double bb = b / (2.0 * d);
@@ -1895,7 +1931,7 @@ namespace larg4 {
   }
 
 
-  double Rectangle_SolidAngle(acc& out, TVector3 v)
+  double OpFastScintillation::Rectangle_SolidAngle(acc& out, TVector3 v)
   {
     //v is the position of the track segment with respect to
     //the center position of the arapuca window

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1789,13 +1789,13 @@ namespace larg4 {
   }
 
 
-  constexpr G4double OpFastScintillation::single_exp(const G4double t, const G4double tau2) const
+  G4double OpFastScintillation::single_exp(const G4double t, const G4double tau2) const
   {
     return std::exp(-1.0 * t / tau2) / tau2;
   }
 
 
-  constexpr G4double OpFastScintillation::bi_exp(const G4double t, const G4double tau1,
+  G4double OpFastScintillation::bi_exp(const G4double t, const G4double tau1,
                                                  const G4double tau2) const
   {// TODO: what's up with this? ... / tau2 / tau2 ...
     return std::exp(-1.0 * t / tau2) *
@@ -1803,7 +1803,7 @@ namespace larg4 {
   }
 
 
-  constexpr G4double OpFastScintillation::Gaisser_Hillas(const double x,
+  G4double OpFastScintillation::Gaisser_Hillas(const double x,
                                                          const double *par)
   {
     double X_mu_0 = par[3];

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -220,8 +220,10 @@ namespace larg4 {
       std::cout << "miny: " << fminy << "  maxy: " << fmaxy << std::endl;
       std::cout << "minz: " << fminz << "  maxz: " << fmaxz << std::endl;
 
-      TVector3 Cathode_centre(geo->TPC(0, 0).GetCathodeCenter().X(), (fminy + fmaxy) / 2, (fminz + fmaxz) / 2);
-      std::cout << "Cathode_centre: " << Cathode_centre.X() << "  " << Cathode_centre.Y() << "  " << Cathode_centre.Z() << std::endl;
+      TVector3 Cathode_centre(geo->TPC(0, 0).GetCathodeCenter().X(),
+                              (fminy + fmaxy) / 2, (fminz + fmaxz) / 2);
+      std::cout << "Cathode_centre: " << Cathode_centre.X()
+                << "  " << Cathode_centre.Y() << "  " << Cathode_centre.Z() << std::endl;
 
       for(size_t i = 0; i != pvs->NOpChannels(); i++) {
         double OpDetCenter_i[3];
@@ -269,7 +271,8 @@ namespace larg4 {
         // VIS time parameterisation
         if (pvs->StoreReflected()) {
           // load parameters
-          pvs->LoadTimingsForVISPar(fdistances_refl, fcut_off_pars, ftau_pars, fvis_vmean, fn_LAr_vis, fn_LAr_vuv);
+          pvs->LoadTimingsForVISPar(fdistances_refl, fcut_off_pars, ftau_pars,
+                                    fvis_vmean, fn_LAr_vis, fn_LAr_vuv);
         }
       }
       if(pvs->UseNhitsModel()) {
@@ -297,8 +300,10 @@ namespace larg4 {
         fReference_to_corner = std::sqrt(fYactive_corner*fYactive_corner +
                                          fZactive_corner*fZactive_corner);
 
-        std::cout << "For border corrections: " << fborder_corr[0] << "  " << fborder_corr[1] << std::endl;
-        std::cout << "Photocathode-plane centre (z,y) = (" << fZcathode << ", " << fYcathode << ") and corner (z, y) = (" << fZactive_corner << ", " << fYactive_corner << ")" << std::endl;
+        std::cout << "For border corrections: "
+                  << fborder_corr[0] << "  " << fborder_corr[1] << std::endl;
+        std::cout << "Photocathode-plane centre (z,y) = (" << fZcathode << ", " << fYcathode << ") "
+                  << "and corner (z, y) = (" << fZactive_corner << ", " << fYactive_corner << ")" << std::endl;
         std::cout << "Reference_to_corner: " << fReference_to_corner << std::endl;
 
         if(pvs->StoreReflected()) {
@@ -310,7 +315,8 @@ namespace larg4 {
           if (pvs->ApplyVISBorderCorrection()) {
             // load border corrections
             std::cout << "Loading vis border corrections" << std::endl;
-            pvs->LoadParsForVISBorderCorrection(fvis_border_distances_x, fvis_border_distances_r, fvis_border_correction);
+            pvs->LoadParsForVISBorderCorrection(fvis_border_distances_x,
+                                                fvis_border_distances_r, fvis_border_correction);
             fApplyVisBorderCorrection = true;
             fVisBorderCorrectionType = pvs->VISBorderCorrectionType();
           }
@@ -581,17 +587,20 @@ namespace larg4 {
                      GetConstProperty("PROTONYIELDRATIO");
       }
       // Muons
-      else if(pDef == G4MuonPlus::MuonPlusDefinition() || pDef == G4MuonMinus::MuonMinusDefinition()) {
+      else if(pDef == G4MuonPlus::MuonPlusDefinition() ||
+              pDef == G4MuonMinus::MuonMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
                      GetConstProperty("MUONYIELDRATIO");
       }
       // Pions
-      else if(pDef == G4PionPlus::PionPlusDefinition() || pDef == G4PionMinus::PionMinusDefinition()) {
+      else if(pDef == G4PionPlus::PionPlusDefinition() ||
+              pDef == G4PionMinus::PionMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
                      GetConstProperty("PIONYIELDRATIO");
       }
       // Kaons
-      else if(pDef == G4KaonPlus::KaonPlusDefinition() || pDef == G4KaonMinus::KaonMinusDefinition()) {
+      else if(pDef == G4KaonPlus::KaonPlusDefinition() ||
+              pDef == G4KaonMinus::KaonMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
                      GetConstProperty("KAONYIELDRATIO");
       }
@@ -621,7 +630,7 @@ namespace larg4 {
       }
     }
 
-    double const xyz[3] = { x0[0] / CLHEP::cm, x0[1] / CLHEP::cm, x0[2] / CLHEP::cm };
+    double const xyz[3] = { x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm };
     auto const& Visibilities = pvs->GetAllVisibilities(xyz);
 
     phot::MappedCounts_t ReflVisibilities;
@@ -749,7 +758,9 @@ namespace larg4 {
           }
           else {
             TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
-            TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
+            TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0],
+                                fOpDetCenter.at(OpDet)[1],
+                                fOpDetCenter.at(OpDet)[2]);
             fydimension = fOpDetLength.at(OpDet);
             fzdimension = fOpDetHeight.at(OpDet);
             DetThisPMT = VUVHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
@@ -768,7 +779,9 @@ namespace larg4 {
             }
             else {
               TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
-              TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
+              TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0],
+                                  fOpDetCenter.at(OpDet)[1],
+                                  fOpDetCenter.at(OpDet)[2]);
               ReflDetThisPMT = VISHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
             }
             if(ReflDetThisPMT > 0) {
@@ -1029,7 +1042,8 @@ namespace larg4 {
   {
     G4StepPoint const* pPreStepPoint  = aStep.GetPreStepPoint();
     G4StepPoint const* pPostStepPoint = aStep.GetPostStepPoint();
-    G4double avgVelocity = (pPreStepPoint->GetVelocity() + pPostStepPoint->GetVelocity()) / 2.;
+    G4double avgVelocity = (pPreStepPoint->GetVelocity() +
+                            pPostStepPoint->GetVelocity()) / 2.;
     G4double deltaTime = aStep.GetStepLength() / avgVelocity;
     if (ScintillationRiseTime == 0.0) {
       deltaTime = deltaTime -
@@ -1059,19 +1073,23 @@ namespace larg4 {
       if (Reflected)
         throw cet::exception("OpFastScintillation") << "No parameterized propagation time for reflected light";
       for(size_t i = 0; i < arrival_time_dist.size(); ++i) {
-        arrival_time_dist[i] = ParPropTimeTF1[OpChannel].GetRandom(); // TODO: std:fill
+        arrival_time_dist[i] = ParPropTimeTF1[OpChannel].GetRandom();
       }
     }
     else if (pvs->IncludePropTime()) {
       // Get VUV photons arrival time distribution from the parametrization
-      G4ThreeVector OpDetPoint(fOpDetCenter.at(OpChannel)[0]*CLHEP::cm, fOpDetCenter.at(OpChannel)[1]*CLHEP::cm, fOpDetCenter.at(OpChannel)[2]*CLHEP::cm);
+      const G4ThreeVector OpDetPoint(fOpDetCenter.at(OpChannel)[0]*CLHEP::cm,
+                                     fOpDetCenter.at(OpChannel)[1]*CLHEP::cm,
+                                     fOpDetCenter.at(OpChannel)[2]*CLHEP::cm);
       if (!Reflected) {
         double distance_in_cm = (x0 - OpDetPoint).mag() / CLHEP::cm; // this must be in CENTIMETERS!
         getVUVTimes(arrival_time_dist, distance_in_cm); // in ns
       }
       else {
-        TVector3 ScintPoint( x0[0] / CLHEP::cm, x0[1] / CLHEP::cm, x0[2] / CLHEP::cm ); // in cm
-        TVector3 OpDetPoint_tv3(fOpDetCenter.at(OpChannel)[0], fOpDetCenter.at(OpChannel)[1], fOpDetCenter.at(OpChannel)[2]); // in cm
+        TVector3 ScintPoint( x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm ); // in cm
+        TVector3 OpDetPoint_tv3(fOpDetCenter.at(OpChannel)[0],
+                                fOpDetCenter.at(OpChannel)[1],
+                                fOpDetCenter.at(OpChannel)[2]); // in cm
         getVISTimes(arrival_time_dist, ScintPoint, OpDetPoint_tv3); // in ns
       }
     }
@@ -1101,7 +1119,8 @@ namespace larg4 {
 
   double OpFastScintillation::reemission_energy() const
   {
-    return rgen0->fire() * ((*(--tpbemission.end())).first - (*tpbemission.begin()).first) + (*tpbemission.begin()).first;
+    return rgen0->fire() * ((*(--tpbemission.end())).first - (*tpbemission.begin()).first) +
+      (*tpbemission.begin()).first;
   }
 
 
@@ -1279,7 +1298,8 @@ namespace larg4 {
     // Deciding which time model to use (depends on the distance)
     // defining useful times for the VUV arrival time shapes
     if(distance_in_cm >= finflexion_point_distance) {
-      double pars_far[4] = {t_direct_min, pars_landau[0], pars_landau[1], pars_landau[2]};
+      double pars_far[4] = {t_direct_min, pars_landau[0], pars_landau[1],
+                            pars_landau[2]};
       // Set model: Landau
       fVUVTiming = TF1("fVUVTiming", model_far, 0, signal_t_range, 4);
       fVUVTiming.SetParameters(pars_far);
@@ -1290,7 +1310,8 @@ namespace larg4 {
       // Exponential parameters
       double pars_expo[2];
       // Getting the exponential parameters from the time parametrization
-      pars_expo[1] = interpolate(fparameters[4], fparameters[5], distance_in_cm, true);
+      pars_expo[1] = interpolate(fparameters[4], fparameters[5],
+                                 distance_in_cm, true);
       //For simplicity, not considering the small dependency with the offset angle in pars_expo[0]
       //Using the value for the [30,60deg] range. fparameters[6] and fparameters[8] are the values
       //for [0,30deg] range and [60,90deg] range respectively
@@ -1299,31 +1320,28 @@ namespace larg4 {
       pars_expo[0] = std::log(pars_expo[0]);
       // this is to find the intersection point between the two functions:
       TF1 fint = TF1("fint", finter_d, pars_landau[0], 4 * t_direct_mean, 5);
-      double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+      double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2],
+                           pars_expo[0], pars_expo[1]};
       fint.SetParameters(parsInt);
       double t_int = fint.GetMinimumX();
       double minVal = fint.Eval(t_int);
       // the functions must intersect - output warning if they don't
       if(minVal > 0.015) {
-        std::cout << "WARNING: Parametrization of VUV light discontinuous for distance = " << distance_in_cm << std::endl;
+        std::cout << "WARNING: Parametrization of VUV light discontinuous for distance = "
+                  << distance_in_cm << std::endl;
         std::cout << "WARNING: This shouldn't be happening " << std::endl;
       }
-      double parsfinal[7] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1], t_direct_min};
+      double parsfinal[7] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2],
+                             pars_expo[0], pars_expo[1], t_direct_min};
       fVUVTiming.SetParameters(parsfinal);
     }
 
     // set the number of points used to sample parameterisation
     // for shorter distances, peak is sharper so more sensitive sampling required
     int fsampling;
-    if (distance_in_cm < 50) {
-      fsampling = 10000;
-    }
-    else if (distance_in_cm < 100) {
-      fsampling = 5000;
-    }
-    else {
-      fsampling = 1000;
-    }
+    if (distance_in_cm < 50) {fsampling = 10000;}
+    else if (distance_in_cm < 100) {fsampling = 5000;}
+    else {fsampling = 1000;}
     fVUVTiming.SetNpx(fsampling);
 
     // calculate max and min distance relevant to sample parameterisation
@@ -1350,16 +1368,14 @@ namespace larg4 {
   // VUV arrival times calculation function
   void OpFastScintillation::getVUVTimes(std::vector<double>& arrivalTimes, double distance)
   {
-    // distance < 25cm
     if (distance < 25) {
       // times are fixed shift i.e. direct path only
       double t_prop_correction = distance / fvuv_vgroup_mean;
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-        arrivalTimes[i] = t_prop_correction;// TODO: std::fill
+        arrivalTimes[i] = t_prop_correction;
       }
     }
-    // distance >= 25cm
-    else {
+    else { // distance >= 25cm
       // determine nearest parameterisation in discretisation
       int index = std::round((distance - 25) / fstep_size);
       // check whether required parameterisation has been generated, generating if not
@@ -1368,7 +1384,7 @@ namespace larg4 {
       }
       // randomly sample parameterisation for each photon
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-        arrivalTimes[i] = VUV_timing[index].GetRandom(VUV_min[index], VUV_max[index]);//TODO"std::fill"
+        arrivalTimes[i] = VUV_timing[index].GetRandom(VUV_min[index], VUV_max[index]);
       }
     }
   }
@@ -1391,8 +1407,8 @@ namespace larg4 {
       plane_depth = fplane_depth;
     }
 
-    // calculate point of reflection for shortest path accounting for difference in refractive indicies
-    // vectors for storing results
+    // calculate point of reflection for shortest path accounting for difference
+    // in refractive indices vectors for storing results
     TVector3 image(0, 0, 0);
     TVector3 bounce_point(0, 0, 0);
 
@@ -1448,8 +1464,8 @@ namespace larg4 {
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
-    // 2). cutoff = largest smeared time allowed, preventing excessively large times caused by exponential
-    // distance to cathode
+    // 2). cutoff = largest smeared time allowed, preventing excessively large
+    //     times caused by exponential distance to cathode
     double distance_cathode_plane = std::abs(plane_depth - ScintPoint[0]);
     // angular bin
     size_t alpha_bin = alpha / 10;
@@ -1457,13 +1473,11 @@ namespace larg4 {
       alpha_bin = ftau_pars.size() - 1;      // default to the largest available bin if alpha larger than parameterised region; i.e. last bin effectively [last bin start value, 90] deg bin
     }
     // cut-off and tau
-    double cutoff = interpolate( fdistances_refl, fcut_off_pars[alpha_bin], distance_cathode_plane, true );
-    double tau = interpolate( fdistances_refl, ftau_pars[alpha_bin], distance_cathode_plane, true );
-
-    // fail-safe if tau extrapolate goes wrong, drops below zero since last distance close to zero [did not occur in testing, but possible]
-    if (tau < 0) {
-      tau = 0;
-    }
+    double cutoff = interpolate(fdistances_refl, fcut_off_pars[alpha_bin],
+                                 distance_cathode_plane, true);
+    double tau = interpolate(fdistances_refl, ftau_pars[alpha_bin],
+                             distance_cathode_plane, true);
+    if (tau < 0) {tau = 0;} // if tau extrapolate goes wrong
 
     // apply smearing:
     for (size_t i = 0; i < arrivalTimes.size(); ++i) {
@@ -1487,9 +1501,9 @@ namespace larg4 {
             // generate random number in appropriate range
             double x = gRandom->Uniform(0.5, 1.0);
             // apply the exponential smearing
-            arrival_time_smeared = arrivalTimes[i] + (arrivalTimes[i]-fastest_time)*(std::pow(x,-tau) -1);
+            arrival_time_smeared = arrivalTimes[i] +
+              (arrivalTimes[i] - fastest_time)*(std::pow(x,-tau) - 1);
           }
-          // increment counter
           counter++;
         }
         while (arrival_time_smeared > cutoff);
@@ -1510,8 +1524,8 @@ namespace larg4 {
     }
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
-        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-        (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+       (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
+       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
       return 0;
     }
 
@@ -1551,8 +1565,8 @@ namespace larg4 {
     // calculate number of photons hits by geometric acceptance: accounting for solid angle and LAr absorbtion length
     double hits_geo = std::exp(-1.*distance / fL_abs_vuv) * (solid_angle / (4 * CLHEP::pi)) * Nphotons_created;
 
-    // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
-    // offset angle bin
+    // apply Gaisser-Hillas correction for Rayleigh scattering distance
+    // and angular dependence offset angle bin
     const size_t j = (theta / fdelta_angulo);
 
     //Accounting for border effects
@@ -1575,7 +1589,8 @@ namespace larg4 {
 
 
   // VIS hits semi-analytic model calculation
-  int OpFastScintillation::VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type)
+  int OpFastScintillation::VISHits(int Nphotons_created, TVector3 ScintPoint,
+                                   TVector3 OpDetPoint, int optical_detector_type)
   {
     // check optical channel is in same TPC as scintillation light, if not return 0 hits
     // temporary method working for SBND, DUNE 1x2x6; to be replaced to work in full DUNE geometry
@@ -1586,8 +1601,8 @@ namespace larg4 {
 
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
-        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-        (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+       (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
+       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
       return 0;
     }
 
@@ -1612,20 +1627,21 @@ namespace larg4 {
     // calculate solid angle of cathode from the scintillation point
     double solid_angle_cathode = Rectangle_SolidAngle(cathode_plane, ScintPoint_relative);
     // calculate distance and angle between ScintPoint and hotspot
-    // vast majority of hits in hotspot region directly infront of scintpoint,therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
+    // vast majority of hits in hotspot region directly infront of scintpoint,
+    // therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
     double distance_cathode = std::abs(plane_depth - ScintPoint[0]);
     double cosine_cathode = 1;
     double theta_cathode = 0;
     // calculate hits on cathode plane via geometric acceptance
-    double cathode_hits_geo = std::exp(-1.*distance_cathode / fL_abs_vuv) * (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
+    double cathode_hits_geo = std::exp(-1.*distance_cathode / fL_abs_vuv) *
+      (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
     const size_t j = (theta_cathode / fdelta_angulo);
     double  pars_ini_[4] = {fGHvuvpars[0][j],
                             fGHvuvpars[1][j],
                             fGHvuvpars[2][j],
-                            fGHvuvpars[3][j]
-                           };
+                            fGHvuvpars[3][j]};
     double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini_);
     double cathode_hits_rec = GH_correction * cathode_hits_geo / cosine_cathode;
 
@@ -1660,7 +1676,7 @@ namespace larg4 {
     }
 
     // calculate number of hits via geometeric acceptance
-    double hits_geo = (solid_angle_detector / (2.*CLHEP::pi)) * cathode_hits_rec;	// 2*pi rather than 4*pi due to presence of reflective foils (vm2000)
+    double hits_geo = (solid_angle_detector / (2.*CLHEP::pi)) * cathode_hits_rec; // 2*pi due to presence of reflective foils
 
     // calculate distances and angles for application of corrections
     // distance to hotspot
@@ -1673,7 +1689,8 @@ namespace larg4 {
     const size_t k = (theta_vis / fdelta_angulo);
 
     // apply geometric correction
-    double pars_ini_vis[6] = { fvispars[0][k], fvispars[1][k], fvispars[2][k], fvispars[3][k], fvispars[4][k], fvispars[5][k] };
+    double pars_ini_vis[6] = {fvispars[0][k], fvispars[1][k], fvispars[2][k],
+                              fvispars[3][k], fvispars[4][k], fvispars[5][k]};
     double geo_correction = Pol_5(distance_vuv, pars_ini_vis);
     double hits_rec = gRandom->Poisson(geo_correction * hits_geo / cosine_vis);
 
@@ -1695,7 +1712,8 @@ namespace larg4 {
       const size_t nbins_r = fvis_border_correction[k].size();
       std::vector<double> interp_vals(nbins_r, 0.0);
       for (size_t i = 0; i < nbins_r; ++i) {
-        interp_vals[i] = interpolate(fvis_border_distances_x, fvis_border_correction[k][i], std::abs(ScintPoint[0]), false);
+        interp_vals[i] = interpolate(fvis_border_distances_x, fvis_border_correction[k][i],
+                                     std::abs(ScintPoint[0]), false);
       }
       // interpolate in r
       double border_correction = interpolate(fvis_border_distances_r, interp_vals, r, false);
@@ -1780,23 +1798,24 @@ namespace larg4 {
   //   Returns interpolated value at x from parallel arrays ( xData, yData )
   //   Assumes that xData has at least two elements, is sorted and is strictly monotonic increasing
   //   boolean argument extrapolate determines behaviour beyond ends of array (if needed)
-  double interpolate( std::vector<double> &xData, std::vector<double> &yData, double x, bool extrapolate )
+  double interpolate(std::vector<double> &xData, std::vector<double> &yData,
+                     double x, bool extrapolate)
   {
     size_t size = xData.size();
-    size_t i = 0;                                          // find left end of interval for interpolation
-    if ( x >= xData[size - 2] ) {                       // special case: beyond right end
+    size_t i = 0; // find left end of interval for interpolation
+    if (x >= xData[size-2]) { // special case: beyond right end
       i = size - 2;
     }
     else {
-      while ( x > xData[i + 1] ) i++;
+      while (x > xData[i+1]) i++;
     }
-    double xL = xData[i], yL = yData[i], xR = xData[i + 1], yR = yData[i + 1]; // points on either side (unless beyond ends)
-    if ( !extrapolate ) {                                                  // if beyond ends of array and not extrapolating
-      if ( x < xL ) yR = yL;
-      if ( x > xR ) yL = yR;
+    double xL = xData[i], yL = yData[i], xR = xData[i+1], yR = yData[i+1]; // points on either side (unless beyond ends)
+    if (!extrapolate) { // if beyond ends of array and not extrapolating
+      if (x < xL) yR = yL;
+      if (x > xR) yL = yR;
     }
-    double dydx = ( yR - yL ) / ( xR - xL );            // gradient
-    return yL + dydx * ( x - xL );                      // linear interpolation
+    double dydx = (yR - yL) / (xR - xL); // gradient
+    return yL + dydx * ( x - xL ); // linear interpolation
   }
 
 
@@ -1805,29 +1824,30 @@ namespace larg4 {
                    std::vector<double> &yData3, double x, bool extrapolate)
   {
     size_t size = xData.size();
-    size_t i = 0;                                          // find left end of interval for interpolation
-    if ( x >= xData[size - 2] ) {                       // special case: beyond right end
+    size_t i = 0; // find left end of interval for interpolation
+    if (x >= xData[size-2]) { // special case: beyond right end
       i = size - 2;
     }
     else {
-      while ( x > xData[i + 1] ) i++;
+      while (x > xData[i+1]) i++;
     }
-    double xL = xData[i], xR = xData[i + 1]; // points on either side (unless beyond ends)
-    double yL1 = yData1[i], yR1 = yData1[i + 1], yL2 = yData2[i], yR2 = yData2[i + 1], yL3 = yData3[i], yR3 = yData3[i + 1];
+    double xL = xData[i], xR = xData[i+1]; // points on either side (unless beyond ends)
+    double yL1 = yData1[i], yR1 = yData1[i+1];
+    double yL2 = yData2[i], yR2 = yData2[i+1];
+    double yL3 = yData3[i], yR3 = yData3[i+1];
 
-    if ( !extrapolate ) {                                                  // if beyond ends of array and not extrapolating
-      if ( x < xL ) {
+    if (!extrapolate) { // if beyond ends of array and not extrapolating
+      if (x < xL) {
         yR1 = yL1;
         yR2 = yL2;
         yR3 = yL3;
       }
-      if ( x > xR ) {
+      if (x > xR) {
         yL1 = yR1;
         yL2 = yR2;
         yL3 = yR3;
       }
     }
-
     inter[0] = (x - xL) * (yR1 - yL1) / (xR - xL);
     inter[1] = (x - xL) * ( yR2 - yL2 ) / ( xR - xL );
     inter[2] = (x - xL) * ( yR3 - yL3 ) / ( xR - xL );
@@ -1850,13 +1870,16 @@ namespace larg4 {
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
     if(isDefinitelyLessThan(d,b)) {
-      return 2.*TMath::Pi() - 2.*aa*(boost::math::ellint_1(bb, noLDoublePromote()) + TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()));
+      return 2.*TMath::Pi() -
+        2.*aa*(boost::math::ellint_1(bb, noLDoublePromote()) +
+               TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()));
     }
     if(isApproximatelyEqual(d,b)) {
       return TMath::Pi() - 2.*aa*boost::math::ellint_1(bb,noLDoublePromote());
     }
     if(isDefinitelyGreaterThan(d,b)) {
-      return 2.*aa*(TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) - boost::math::ellint_1(bb,noLDoublePromote()));
+      return 2.*aa*(TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) -
+                    boost::math::ellint_1(bb,noLDoublePromote()));
     }
     return 0.;
   }
@@ -1889,7 +1912,10 @@ namespace larg4 {
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (B + b), d) - Rectangle_SolidAngle(2 * A, 2 * (B + b), d) - Rectangle_SolidAngle(2 * (A + a), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (B + b), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * (B + b), d) -
+                          Rectangle_SolidAngle(2 * (A + a), 2 * B, d) +
+                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
@@ -1900,7 +1926,10 @@ namespace larg4 {
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) + Rectangle_SolidAngle(2 * A, 2 * (b - B), d) + Rectangle_SolidAngle(2 * (a - A), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) +
+                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
+                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
+                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
@@ -1911,7 +1940,10 @@ namespace larg4 {
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (b - B), d) - Rectangle_SolidAngle(2 * A, 2 * (b - B), d) + Rectangle_SolidAngle(2 * (A + a), 2 * B, d) - Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (b - B), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
+                          Rectangle_SolidAngle(2 * (A + a), 2 * B, d) -
+                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
@@ -1922,7 +1954,10 @@ namespace larg4 {
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (B + b), d) - Rectangle_SolidAngle(2 * (a - A), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * (B + b), d) - Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (B + b), d) -
+                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
+                          Rectangle_SolidAngle(2 * A, 2 * (B + b), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
     // error message if none of these cases, i.e. something has gone wrong!

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -144,11 +144,11 @@
 #include "boost/math/special_functions/ellint_1.hpp"
 #include "boost/math/special_functions/ellint_3.hpp"
 
-namespace larg4{
+namespace larg4 {
 
-/////////////////////////
-// Class Implementation
-/////////////////////////
+  /////////////////////////
+  // Class Implementation
+  /////////////////////////
 
   //////////////
   // Operators
@@ -166,14 +166,10 @@ namespace larg4{
     : G4VRestDiscreteProcess(processName, type)
     , bPropagate(!(art::ServiceHandle<sim::LArG4Parameters const>()->NoPhotonPropagation()))
   {
-
     SetProcessSubType(25);
-
     fTrackSecondariesFirst = false;
     fFiniteRiseTime = false;
-
-
-    YieldFactor=1.0;
+    YieldFactor = 1.0;
     ExcitationRatio = 1.0;
 
     const detinfo::LArProperties* larp = lar::providerFrom<detinfo::LArPropertiesService>();
@@ -183,12 +179,11 @@ namespace larg4{
     theFastIntegralTable = NULL;
     theSlowIntegralTable = NULL;
 
-    if (verboseLevel>0) {
+    if (verboseLevel > 0) {
       G4cout << GetProcessName() << " is created " << G4endl;
     }
 
     BuildThePhysicsTable();
-
     emSaturation = NULL;
 
     if (bPropagate) {
@@ -204,110 +199,107 @@ namespace larg4{
       fmaxy = -1e9;
       fminz = 1e9;
       fmaxz = -1e9;
-      for (size_t i = 0; i<geo->NTPC(); ++i){
-	const geo::TPCGeo &tpc = geo->TPC(i);
-	if (fminx>tpc.MinX()) fminx = tpc.MinX();
-	if (fmaxx<tpc.MaxX()) fmaxx = tpc.MaxX();
-	if (fminy>tpc.MinY()) fminy = tpc.MinY();
-	if (fmaxy<tpc.MaxY()) fmaxy = tpc.MaxY();
-	if (fminz>tpc.MinZ()) fminz = tpc.MinZ();
-	if (fmaxz<tpc.MaxZ()) fmaxz = tpc.MaxZ();
+      for (size_t i = 0; i < geo->NTPC(); ++i) {
+        const geo::TPCGeo &tpc = geo->TPC(i);
+        if (fminx > tpc.MinX()) fminx = tpc.MinX();
+        if (fmaxx < tpc.MaxX()) fmaxx = tpc.MaxX();
+        if (fminy > tpc.MinY()) fminy = tpc.MinY();
+        if (fmaxy < tpc.MaxY()) fmaxy = tpc.MaxY();
+        if (fminz > tpc.MinZ()) fminz = tpc.MinZ();
+        if (fmaxz < tpc.MaxZ()) fmaxz = tpc.MaxZ();
       }
       std::cout << "Active volume boundaries:" << std::endl;
-      std::cout << "minx: " <<fminx<<"  maxx: "<<fmaxx<< std::endl;
-      std::cout << "miny: " <<fminy<<"  maxy: "<<fmaxy<< std::endl;
-      std::cout << "minz: " <<fminz<<"  maxz: "<<fmaxz<< std::endl;
+      std::cout << "minx: " << fminx << "  maxx: " << fmaxx << std::endl;
+      std::cout << "miny: " << fminy << "  maxy: " << fmaxy << std::endl;
+      std::cout << "minz: " << fminz << "  maxz: " << fmaxz << std::endl;
 
-      TVector3 Cathode_centre(geo->TPC(0,0).GetCathodeCenter().X(), (fminy + fmaxy)/2, (fminz + fmaxz)/2);
-      std::cout<<"Cathode_centre: "<<Cathode_centre.X()<<"  "<<Cathode_centre.Y()<<"  "<<Cathode_centre.Z()<<std::endl;
+      TVector3 Cathode_centre(geo->TPC(0, 0).GetCathodeCenter().X(), (fminy + fmaxy) / 2, (fminz + fmaxz) / 2);
+      std::cout << "Cathode_centre: " << Cathode_centre.X() << "  " << Cathode_centre.Y() << "  " << Cathode_centre.Z() << std::endl;
 
-      for(size_t i = 0; i != pvs->NOpChannels(); i++)
-	{
-	  double OpDetCenter_i[3];
-	  std::vector<double> OpDetCenter_v;
-	  geo->OpDetGeoFromOpDet(i).GetCenter(OpDetCenter_i);
-	  OpDetCenter_v.assign(OpDetCenter_i, OpDetCenter_i +3);
-	  fOpDetCenter.push_back(OpDetCenter_v);
-	  int type_i = -1;
-	  if(strcmp(geo->OpDetGeoFromOpDet(i).Shape()->IsA()->GetName(), "TGeoBBox") == 0) {
-	    type_i = 0;//Arapucas
-	    fOpDetLength.push_back(geo->OpDetGeoFromOpDet(i).Length());
-	    fOpDetHeight.push_back(geo->OpDetGeoFromOpDet(i).Height());
-	  }
-	  else {
-	    type_i = 1;//PMTs
-	    //    std::cout<<"Radio: "<<geo->OpDetGeoFromOpDet(i).RMax()<<std::endl;
-	    fOpDetLength.push_back(-1);
-	    fOpDetHeight.push_back(-1);
-	  }
-	  fOpDetType.push_back(type_i);
-	  //std::cout <<"OpChannel: "<<i<<"  Optical_Detector_Type: "<< type_i <<"  APERTURE_height: "
-	  //	    <<geo->OpDetGeoFromOpDet(i).Height()<<"  APERTURE_width: "<<geo->OpDetGeoFromOpDet(i).Length()<< std::endl;
-	}
-
+      for(size_t i = 0; i != pvs->NOpChannels(); i++) {
+        double OpDetCenter_i[3];
+        std::vector<double> OpDetCenter_v;
+        geo->OpDetGeoFromOpDet(i).GetCenter(OpDetCenter_i);
+        OpDetCenter_v.assign(OpDetCenter_i, OpDetCenter_i + 3);
+        fOpDetCenter.push_back(OpDetCenter_v);
+        int type_i = -1;
+        if(strcmp(geo->OpDetGeoFromOpDet(i).Shape()->IsA()->GetName(), "TGeoBBox") == 0) {
+          type_i = 0;//Arapucas
+          fOpDetLength.push_back(geo->OpDetGeoFromOpDet(i).Length());
+          fOpDetHeight.push_back(geo->OpDetGeoFromOpDet(i).Height());
+        }
+        else {
+          type_i = 1;//PMTs
+          //    std::cout<<"Radio: "<<geo->OpDetGeoFromOpDet(i).RMax()<<std::endl;
+          fOpDetLength.push_back(-1);
+          fOpDetHeight.push_back(-1);
+        }
+        fOpDetType.push_back(type_i);
+        // std::cout <<"OpChannel: "<<i<<"  Optical_Detector_Type: "<< type_i <<"  APERTURE_height: "
+                  // <<geo->OpDetGeoFromOpDet(i).Height()<<"  APERTURE_width: "<<geo->OpDetGeoFromOpDet(i).Length()<< std::endl;
+      }
 
       if(pvs->IncludePropTime()) {
-	std::cout << "Using parameterisation of timings." << std::endl;
+        std::cout << "Using parameterisation of timings." << std::endl;
         //OLD VUV time parapetrization (to be removed soon)
         //pvs->SetDirectLightPropFunctions(functions_vuv, fd_break, fd_max, ftf1_sampling_factor);
         //pvs->SetReflectedCOLightPropFunctions(functions_vis, ft0_max, ft0_break_point);
-	//New VUV time parapetrization
-	pvs->LoadTimingsForVUVPar(fparameters, fstep_size, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance);
+        //New VUV time parapetrization
+        pvs->LoadTimingsForVUVPar(fparameters, fstep_size, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance);
 
-	// create vector of empty TF1s that will be replaces with the parameterisations that are generated as they are required
-	// default TF1() constructor gives function with 0 dimensions, can then check numDim to qucikly see if a parameterisation has been generated
-	int num_params = (fmax_d - 25) / fstep_size;  // for d < 25cm, no parameterisaton, a delta function is used instead
-	std::vector<TF1> VUV_timing_temp(num_params,TF1());
-	VUV_timing = VUV_timing_temp;
+        // create vector of empty TF1s that will be replaces with the parameterisations that are generated as they are required
+        // default TF1() constructor gives function with 0 dimensions, can then check numDim to qucikly see if a parameterisation has been generated
+        int num_params = (fmax_d - 25) / fstep_size;  // for d < 25cm, no parameterisaton, a delta function is used instead
+        std::vector<TF1> VUV_timing_temp(num_params, TF1());
+        VUV_timing = VUV_timing_temp;
 
-	// initialise vectors to contain range parameterisations sampled to in each case
-	// when using TF1->GetRandom(xmin,xmax), must be in same range otherwise sampling is regenerated, this is the slow part!
-	std::vector<double> VUV_empty(num_params, 0);
-	VUV_max = VUV_empty;
-	VUV_min = VUV_empty;
+        // initialise vectors to contain range parameterisations sampled to in each case
+        // when using TF1->GetRandom(xmin,xmax), must be in same range otherwise sampling is regenerated, this is the slow part!
+        std::vector<double> VUV_empty(num_params, 0);
+        VUV_max = VUV_empty;
+        VUV_min = VUV_empty;
 
         // VIS time parameterisation
         if (pvs->StoreReflected()) {
-	  // load parameters
-	  pvs->LoadTimingsForVISPar(fdistances_refl, fcut_off_pars, ftau_pars, fvis_vmean, fn_LAr_vis, fn_LAr_vuv);
-	}
-
+          // load parameters
+          pvs->LoadTimingsForVISPar(fdistances_refl, fcut_off_pars, ftau_pars, fvis_vmean, fn_LAr_vis, fn_LAr_vuv);
+        }
       }
       if(pvs->UseNhitsModel()) {
-	std::cout << "Using semi-analytic model for number of hits:" << std::endl;
-	fUseNhitsModel = true;
-	// LAr absorption length in cm
-	std::map<double, double> abs_length_spectrum = lar::providerFrom<detinfo::LArPropertiesService>()->AbsLengthSpectrum();
-	std::vector<double> x_v, y_v;
-	for(auto elem : abs_length_spectrum) {
-	  x_v.push_back(elem.first);
-	  y_v.push_back(elem.second);
-	}
-	fL_abs_vuv =  interpolate(x_v, y_v, 9.7, false);
+        std::cout << "Using semi-analytic model for number of hits:" << std::endl;
+        fUseNhitsModel = true;
+        // LAr absorption length in cm
+        std::map<double, double> abs_length_spectrum = lar::providerFrom<detinfo::LArPropertiesService>()->AbsLengthSpectrum();
+        std::vector<double> x_v, y_v;
+        for(auto elem : abs_length_spectrum) {
+          x_v.push_back(elem.first);
+          y_v.push_back(elem.second);
+        }
+        fL_abs_vuv =  interpolate(x_v, y_v, 9.7, false);
 
-	// Load Gaisser-Hillas corrections for VUV semi-analytic hits
-	std::cout<<"Loading the GH corrections"<<std::endl;
-	pvs->LoadGHForVUVCorrection(fGHvuvpars, fborder_corr, fradius);
+        // Load Gaisser-Hillas corrections for VUV semi-analytic hits
+        std::cout << "Loading the GH corrections" << std::endl;
+        pvs->LoadGHForVUVCorrection(fGHvuvpars, fborder_corr, fradius);
         fdelta_angulo = 10.; // angle bin size
-	//Needed for Nhits-model border corrections (in cm)
-	fYactive_corner = (fmaxy - fminy)/2;
-	fZactive_corner = (fmaxz - fminz)/2;
+        //Needed for Nhits-model border corrections (in cm)
+        fYactive_corner = (fmaxy - fminy) / 2;
+        fZactive_corner = (fmaxz - fminz) / 2;
 
-	fYcathode = Cathode_centre.Y();
-	fZcathode = Cathode_centre.Z();
-        fReference_to_corner = sqrt(pow(fYactive_corner,2) + pow(fZactive_corner,2));
+        fYcathode = Cathode_centre.Y();
+        fZcathode = Cathode_centre.Z();
+        fReference_to_corner = sqrt(pow(fYactive_corner, 2) + pow(fZactive_corner, 2));
 
-	std::cout<<"For border corrections: "<<fborder_corr[0]<<"  "<<fborder_corr[1]<<std::endl;
-	std::cout<<"Photocathode-plane centre (z,y) = ("<<fZcathode<<", "<<fYcathode<<") and corner (z, y) = ("<<fZactive_corner<<", "<<fYactive_corner<<")"<<std::endl;
-	std::cout<<"Reference_to_corner: "<<fReference_to_corner<<std::endl;
+        std::cout << "For border corrections: " << fborder_corr[0] << "  " << fborder_corr[1] << std::endl;
+        std::cout << "Photocathode-plane centre (z,y) = (" << fZcathode << ", " << fYcathode << ") and corner (z, y) = (" << fZactive_corner << ", " << fYactive_corner << ")" << std::endl;
+        std::cout << "Reference_to_corner: " << fReference_to_corner << std::endl;
 
-	if(pvs->StoreReflected()) {
-	  // Load corrections for VIS semi-anlytic hits
-	  std::cout << "Loading vis corrections"<<std::endl;
-	  pvs->LoadParsForVISCorrection(fvispars,fradius);
-       	  fStoreReflected = true;
+        if(pvs->StoreReflected()) {
+          // Load corrections for VIS semi-anlytic hits
+          std::cout << "Loading vis corrections" << std::endl;
+          pvs->LoadParsForVISCorrection(fvispars, fradius);
+          fStoreReflected = true;
 
-	  if (pvs->ApplyVISBorderCorrection()) {
+          if (pvs->ApplyVISBorderCorrection()) {
             // load border corrections
             std::cout << "Loading vis border corrections" << std::endl;
             pvs->LoadParsForVISBorderCorrection(fvis_border_distances_x, fvis_border_distances_r, fvis_border_correction);
@@ -316,28 +308,27 @@ namespace larg4{
           }
           else fApplyVisBorderCorrection = false;
 
-	  // cathode dimensions required for corrections
-	  fcathode_centre = geo->TPC(0,0).GetCathodeCenter();
-	  fcathode_centre[1] = (fmaxy + fminy)/2; fcathode_centre[2] = (fmaxz + fminz)/2; // to get full cathode dimension rather than just single tpc
+          // cathode dimensions required for corrections
+          fcathode_centre = geo->TPC(0, 0).GetCathodeCenter();
+          fcathode_centre[1] = (fmaxy + fminy) / 2; fcathode_centre[2] = (fmaxz + fminz) / 2; // to get full cathode dimension rather than just single tpc
           fcathode_ydimension = fmaxy - fminy;
-	  fcathode_zdimension = fmaxz - fminz;
-	  fplane_depth = std::abs(fcathode_centre[0]);
-	}
-	else fStoreReflected = false;
-      } else fUseNhitsModel = false;
+          fcathode_zdimension = fmaxz - fminz;
+          fplane_depth = std::abs(fcathode_centre[0]);
+        }
+        else fStoreReflected = false;
+      }
+      else fUseNhitsModel = false;
     }
-    tpbemission=lar::providerFrom<detinfo::LArPropertiesService>()->TpbEm();
+    tpbemission = lar::providerFrom<detinfo::LArPropertiesService>()->TpbEm();
     const int nbins = tpbemission.size();
     double * parent = new double[nbins];
-    int ii=0;
-    for( std::map<double, double>::iterator iter = tpbemission.begin(); iter != tpbemission.end(); ++iter)
-    {
-      parent[ii++]=(*iter).second;
+    int ii = 0;
+    for( std::map<double, double>::iterator iter = tpbemission.begin(); iter != tpbemission.end(); ++iter) {
+      parent[ii++] = (*iter).second;
     }
-    rgen0 = new CLHEP::RandGeneral(parent,nbins);
+    rgen0 = new CLHEP::RandGeneral(parent, nbins);
     delete [] parent;
   }
-
 
 
   OpFastScintillation::OpFastScintillation(const OpFastScintillation& rhs)
@@ -360,11 +351,9 @@ namespace larg4{
   ////////////////
   // Destructors
   ////////////////
-
   OpFastScintillation::~OpFastScintillation()
   {
-
-   if (theFastIntegralTable != NULL) {
+    if (theFastIntegralTable != NULL) {
       theFastIntegralTable->clearAndDestroy();
       delete theFastIntegralTable;
     }
@@ -372,39 +361,35 @@ namespace larg4{
       theSlowIntegralTable->clearAndDestroy();
       delete theSlowIntegralTable;
     }
-
   }
 
   ////////////
   // Methods
   ////////////
 
-// AtRestDoIt
-// ----------
-//
+  // AtRestDoIt
+  // ----------
+  //
   G4VParticleChange*
   OpFastScintillation::AtRestDoIt(const G4Track& aTrack, const G4Step& aStep)
-
   // This routine simply calls the equivalent PostStepDoIt since all the
   // necessary information resides in aStep.GetTotalEnergyDeposit()
-
   {
     return OpFastScintillation::PostStepDoIt(aTrack, aStep);
   }
 
-// PostStepDoIt
-// -------------
-//
+
+  // PostStepDoIt
+  // -------------
+  //
   G4VParticleChange*
   OpFastScintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
   // This routine is called for each tracking step of a charged particle
   // in a scintillator. A Poisson/Gauss-distributed number of photons is
   // generated according to the scintillation yield formula, distributed
   // evenly along the track segment and uniformly into 4pi.
-
   {
     aParticleChange.Initialize(aTrack);
-
     // Check that we are in a material with a properties table, if not
     // just return
     const G4Material* aMaterial = aTrack.GetMaterial();
@@ -414,10 +399,8 @@ namespace larg4{
       return G4VRestDiscreteProcess::PostStepDoIt(aTrack, aStep);
 
     G4StepPoint* pPreStepPoint  = aStep.GetPreStepPoint();
-
     G4ThreeVector x0 = pPreStepPoint->GetPosition();
     G4ThreeVector p0 = aStep.GetDeltaPosition().unit();
-
 
     ///////////////////////////////////////////////////////////////////////////////////
     //   This is the old G4 way - but we do things differently - Ben J, Oct Nov 2012.
@@ -459,20 +442,16 @@ namespace larg4{
     ////////////////////////////////////////////////////////////////////////////////////
     //
 
-
     ////////////////////////////////////////////////////////////////////////////////////
     //  The fast sim way - Ben J, Nov 2012
     ////////////////////////////////////////////////////////////////////////////////////
     //
     //
-
     // We don't want to produce any trackable G4 secondaries
     aParticleChange.SetNumberOfSecondaries(0);
 
-
     // Retrieve the Scintillation Integral for this material
     // new G4PhysicsOrderedFreeVector allocated to hold CII's
-
 
     // Some explanation for later improvements to scint yield code:
     //
@@ -492,45 +471,40 @@ namespace larg4{
     // singleton
     larg4::IonizationAndScintillation::Instance()->Reset(&aStep);
     double MeanNumberOfPhotons = larg4::IonizationAndScintillation::Instance()->NumberScintillationPhotons();
-//  double stepEnergy          = larg4::IonizationAndScintillation::Instance()->VisibleEnergyDeposit()/CLHEP::MeV;
+    // double stepEnergy          = larg4::IonizationAndScintillation::Instance()->VisibleEnergyDeposit()/CLHEP::MeV;
     RecordPhotonsProduced(aStep, MeanNumberOfPhotons);//, stepEnergy);
-
-    if (verboseLevel>0) {
+    if (verboseLevel > 0) {
       G4cout << "\n Exiting from OpFastScintillation::DoIt -- NumberOfSecondaries = "
              << aParticleChange.GetNumberOfSecondaries() << G4endl;
     }
-
-
     return G4VRestDiscreteProcess::PostStepDoIt(aTrack, aStep);
   }
 
 
-//-------------------------------------------------------------
   void OpFastScintillation::ProcessStep( const G4Step& step)
   {
     if(step.GetTotalEnergyDeposit() <= 0) return;
 
     OpDetPhotonTable::Instance()->AddEnergyDeposit
-      (-1,
-       -1,
-       1.0,  //scintillation yield
-       (double)(step.GetTotalEnergyDeposit()/CLHEP::MeV), //energy in MeV
-       (float)(step.GetPreStepPoint()->GetPosition().x()/CLHEP::cm),
-       (float)(step.GetPreStepPoint()->GetPosition().y()/CLHEP::cm),
-       (float)(step.GetPreStepPoint()->GetPosition().z()/CLHEP::cm),
-       (float)(step.GetPostStepPoint()->GetPosition().x()/CLHEP::cm),
-       (float)(step.GetPostStepPoint()->GetPosition().y()/CLHEP::cm),
-       (float)(step.GetPostStepPoint()->GetPosition().z()/CLHEP::cm),
-       (double)(step.GetPreStepPoint()->GetGlobalTime()),
-       (double)(step.GetPostStepPoint()->GetGlobalTime()),
-       //step.GetTrack()->GetTrackID(),
-       ParticleListAction::GetCurrentTrackID(),
-       step.GetTrack()->GetParticleDefinition()->GetPDGEncoding(),
-       step.GetPreStepPoint()->GetPhysicalVolume()->GetName()
-        );
+    (-1,
+     -1,
+     1.0,  //scintillation yield
+     (double)(step.GetTotalEnergyDeposit() / CLHEP::MeV), //energy in MeV
+     (float)(step.GetPreStepPoint()->GetPosition().x() / CLHEP::cm),
+     (float)(step.GetPreStepPoint()->GetPosition().y() / CLHEP::cm),
+     (float)(step.GetPreStepPoint()->GetPosition().z() / CLHEP::cm),
+     (float)(step.GetPostStepPoint()->GetPosition().x() / CLHEP::cm),
+     (float)(step.GetPostStepPoint()->GetPosition().y() / CLHEP::cm),
+     (float)(step.GetPostStepPoint()->GetPosition().z() / CLHEP::cm),
+     (double)(step.GetPreStepPoint()->GetGlobalTime()),
+     (double)(step.GetPostStepPoint()->GetGlobalTime()),
+     //step.GetTrack()->GetTrackID(),
+     ParticleListAction::GetCurrentTrackID(),
+     step.GetTrack()->GetParticleDefinition()->GetPDGEncoding(),
+     step.GetPreStepPoint()->GetPhysicalVolume()->GetName()
+    );
   }
 
-//-------------------------------------------------------------
 
   bool OpFastScintillation::RecordPhotonsProduced(const G4Step& aStep, double MeanNumberOfPhotons)//, double stepEnergy)
   {
@@ -538,7 +512,6 @@ namespace larg4{
     art::ServiceHandle<sim::LArG4Parameters const> lgp;
     if(lgp->FillSimEnergyDeposits())
       ProcessStep(aStep);
-
 
     // Get the pointer to the fast scintillation table
     OpDetPhotonTable * fst = OpDetPhotonTable::Instance();
@@ -559,7 +532,6 @@ namespace larg4{
     //G4double      t0 = pPreStepPoint->GetGlobalTime() - fGlobalTimeOffset;
     G4double      t0 = pPreStepPoint->GetGlobalTime();
 
-
     G4MaterialPropertiesTable* aMaterialPropertiesTable =
       aMaterial->GetMaterialPropertiesTable();
 
@@ -578,14 +550,11 @@ namespace larg4{
     art::ServiceHandle<phot::PhotonVisibilityService const> pvs;
     size_t const NOpChannels = pvs->NOpChannels();
 
-
     G4int nscnt = 1;
     if (Fast_Intensity && Slow_Intensity) nscnt = 2;
 
-
     double Num = 0;
-    double YieldRatio=0;
-
+    double YieldRatio = 0;
 
     if (scintillationByParticleType) {
       // The scintillation response is a function of the energy
@@ -599,84 +568,63 @@ namespace larg4{
       // energy for the current particle type
 
       // Protons
-      if(pDef==G4Proton::ProtonDefinition())
-      {
+      if(pDef == G4Proton::ProtonDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("PROTONYIELDRATIO");
-
+                     GetConstProperty("PROTONYIELDRATIO");
       }
-
       // Muons
-      else if(pDef==G4MuonPlus::MuonPlusDefinition()||pDef==G4MuonMinus::MuonMinusDefinition())
-      {
+      else if(pDef == G4MuonPlus::MuonPlusDefinition() || pDef == G4MuonMinus::MuonMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("MUONYIELDRATIO");
+                     GetConstProperty("MUONYIELDRATIO");
       }
-
       // Pions
-      else if(pDef==G4PionPlus::PionPlusDefinition()||pDef==G4PionMinus::PionMinusDefinition())
-      {
+      else if(pDef == G4PionPlus::PionPlusDefinition() || pDef == G4PionMinus::PionMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("PIONYIELDRATIO");
+                     GetConstProperty("PIONYIELDRATIO");
       }
-
       // Kaons
-      else if(pDef==G4KaonPlus::KaonPlusDefinition()||pDef==G4KaonMinus::KaonMinusDefinition())
-      {
+      else if(pDef == G4KaonPlus::KaonPlusDefinition() || pDef == G4KaonMinus::KaonMinusDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("KAONYIELDRATIO");
+                     GetConstProperty("KAONYIELDRATIO");
       }
-
       // Alphas
-      else if(pDef==G4Alpha::AlphaDefinition())
-      {
+      else if(pDef == G4Alpha::AlphaDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("ALPHAYIELDRATIO");
+                     GetConstProperty("ALPHAYIELDRATIO");
       }
-
       // Electrons (must also account for shell-binding energy
       // attributed to gamma from standard PhotoElectricEffect)
-      else if(pDef==G4Electron::ElectronDefinition() ||
-              pDef==G4Gamma::GammaDefinition())
-      {
+      else if(pDef == G4Electron::ElectronDefinition() ||
+              pDef == G4Gamma::GammaDefinition()) {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("ELECTRONYIELDRATIO");
+                     GetConstProperty("ELECTRONYIELDRATIO");
       }
-
       // Default for particles not enumerated/listed above
-      else
-      {
+      else {
         YieldRatio = aMaterialPropertiesTable->
-          GetConstProperty("ELECTRONYIELDRATIO");
+                     GetConstProperty("ELECTRONYIELDRATIO");
       }
-
       // If the user has not specified yields for (p,d,t,a,carbon)
       // then these unspecified particles will default to the
       // electron's scintillation yield
-      if(YieldRatio==0){
-        {
-
-          YieldRatio = aMaterialPropertiesTable->
-            GetConstProperty("ELECTRONYIELDRATIO");
-
-        }
+      if(YieldRatio == 0) {
+        YieldRatio = aMaterialPropertiesTable->
+          GetConstProperty("ELECTRONYIELDRATIO");
       }
     }
 
-    double const xyz[3] = { x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm };
+    double const xyz[3] = { x0[0] / CLHEP::cm, x0[1] / CLHEP::cm, x0[2] / CLHEP::cm };
     auto const& Visibilities = pvs->GetAllVisibilities(xyz);
 
     phot::MappedCounts_t ReflVisibilities;
 
-
     // Store timing information in the object for use in propagation_time method
     if(pvs->StoreReflected()) {
-      ReflVisibilities = pvs->GetAllVisibilities(xyz,true);
+      ReflVisibilities = pvs->GetAllVisibilities(xyz, true);
       if(pvs->StoreReflT0())
         ReflT0s = pvs->GetReflT0s(xyz);
     }
-    if(pvs->IncludeParPropTime())
-    {
+    if(pvs->IncludeParPropTime()) {
       ParPropTimeTF1 = pvs->GetTimingTF1(xyz);
     }
 
@@ -707,51 +655,48 @@ namespace larg4{
     double det_photon_ctr=0;
     */
     for (G4int scnt = 1; scnt <= nscnt; scnt++) {
-
       G4double ScintillationTime = 0.*CLHEP::ns;
       G4double ScintillationRiseTime = 0.*CLHEP::ns;
       G4PhysicsOrderedFreeVector* ScintillationIntegral = NULL;
-
       if (scnt == 1) {
         if (nscnt == 1) {
-          if(Fast_Intensity){
+          if(Fast_Intensity) {
             ScintillationTime   = aMaterialPropertiesTable->
-              GetConstProperty("FASTTIMECONSTANT");
+                                  GetConstProperty("FASTTIMECONSTANT");
             if (fFiniteRiseTime) {
               ScintillationRiseTime = aMaterialPropertiesTable->
-                GetConstProperty("FASTSCINTILLATIONRISETIME");
+                                      GetConstProperty("FASTSCINTILLATIONRISETIME");
             }
             ScintillationIntegral =
               (G4PhysicsOrderedFreeVector*)((*theFastIntegralTable)(materialIndex));
           }
-          if(Slow_Intensity){
+          if(Slow_Intensity) {
             ScintillationTime   = aMaterialPropertiesTable->
-              GetConstProperty("SLOWTIMECONSTANT");
+                                  GetConstProperty("SLOWTIMECONSTANT");
             if (fFiniteRiseTime) {
               ScintillationRiseTime = aMaterialPropertiesTable->
-                GetConstProperty("SLOWSCINTILLATIONRISETIME");
+                                      GetConstProperty("SLOWSCINTILLATIONRISETIME");
             }
             ScintillationIntegral =
               (G4PhysicsOrderedFreeVector*)((*theSlowIntegralTable)(materialIndex));
           }
         }//endif nscnt=1
         else {
-          if(YieldRatio==0)
+          if(YieldRatio == 0)
             YieldRatio = aMaterialPropertiesTable->
-              GetConstProperty("YIELDRATIO");
+                         GetConstProperty("YIELDRATIO");
 
-
-          if ( ExcitationRatio == 1.0 ) {
-            Num = std::min(YieldRatio,1.0)*MeanNumberOfPhotons;
+          if(ExcitationRatio == 1.0) {
+            Num = std::min(YieldRatio, 1.0) * MeanNumberOfPhotons;
           }
-          else {
-            Num = std::min(ExcitationRatio,1.0)*MeanNumberOfPhotons;
+          else{
+            Num = std::min(ExcitationRatio, 1.0) * MeanNumberOfPhotons;
           }
-          ScintillationTime   = aMaterialPropertiesTable->
-            GetConstProperty("FASTTIMECONSTANT");
-          if (fFiniteRiseTime) {
+          ScintillationTime = aMaterialPropertiesTable->
+                              GetConstProperty("FASTTIMECONSTANT");
+          if(fFiniteRiseTime) {
             ScintillationRiseTime = aMaterialPropertiesTable->
-              GetConstProperty("FASTSCINTILLATIONRISETIME");
+                                    GetConstProperty("FASTSCINTILLATIONRISETIME");
           }
           ScintillationIntegral =
             (G4PhysicsOrderedFreeVector*)((*theFastIntegralTable)(materialIndex));
@@ -761,26 +706,20 @@ namespace larg4{
       else {
         Num = MeanNumberOfPhotons - Num;
         ScintillationTime   =   aMaterialPropertiesTable->
-          GetConstProperty("SLOWTIMECONSTANT");
-        if (fFiniteRiseTime) {
+                                GetConstProperty("SLOWTIMECONSTANT");
+        if(fFiniteRiseTime) {
           ScintillationRiseTime = aMaterialPropertiesTable->
-            GetConstProperty("SLOWSCINTILLATIONRISETIME");
+                                  GetConstProperty("SLOWSCINTILLATIONRISETIME");
         }
         ScintillationIntegral =
           (G4PhysicsOrderedFreeVector*)((*theSlowIntegralTable)(materialIndex));
       }
 
-      if (!ScintillationIntegral) continue;
-
+      if(!ScintillationIntegral) continue;
       //gen_photon_ctr += Num; // CASE-DEBUG DO NOT REMOVE THIS COMMENT
-
       // Max Scintillation Integral
-
       //            G4double CIImax = ScintillationIntegral->GetMaxValue();
-
-
       //std::cout << "++++++++++++" << Num << "++++++++++" << std::endl;
-
 
       // here we go: now if visibilities are invalid, we are in trouble
       //if (!Visibilities && (NOpChannels > 0)) {
@@ -789,74 +728,63 @@ namespace larg4{
       //    << xyz[1] << ", " << xyz[2] << " ) cm.\n";
       //}
 
-      if(!Visibilities && !pvs->UseNhitsModel()){
-      }else{
+      if(!Visibilities && !pvs->UseNhitsModel()) {
+      }
+      else {
         std::map<int, int> DetectedNum;
-
         std::map<int, int> ReflDetectedNum;
 
-        for(size_t OpDet=0; OpDet!=NOpChannels; OpDet++)
-        {
+        for(size_t OpDet = 0; OpDet != NOpChannels; OpDet++) {
           G4int DetThisPMT = 0.;
-	  if(Visibilities && !pvs->UseNhitsModel()){
-	    DetThisPMT = G4int(G4Poisson(Visibilities[OpDet] * Num));
-	  }
-	  else {
-	    TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
-	    TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
-	    fydimension = fOpDetLength.at(OpDet);
-	    fzdimension = fOpDetHeight.at(OpDet);
-	    DetThisPMT = VUVHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
-	  }
+          if(Visibilities && !pvs->UseNhitsModel()) {
+            DetThisPMT = G4int(G4Poisson(Visibilities[OpDet] * Num));
+          }
+          else {
+            TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
+            TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
+            fydimension = fOpDetLength.at(OpDet);
+            fzdimension = fOpDetHeight.at(OpDet);
+            DetThisPMT = VUVHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
+          }
 
-          if(DetThisPMT>0)
-          {
-            DetectedNum[OpDet]=DetThisPMT;
-
+          if(DetThisPMT > 0) {
+            DetectedNum[OpDet] = DetThisPMT;
             //   mf::LogInfo("OpFastScintillation") << "FastScint: " <<
             //   //   it->second<<" " << Num << " " << DetThisPMT;
-
             //det_photon_ctr += DetThisPMT; // CASE-DEBUG DO NOT REMOVE THIS COMMENT
           }
           if(pvs->StoreReflected()) {
-	    G4int ReflDetThisPMT = 0;
-	    if (!pvs->UseNhitsModel()){
-	      ReflDetThisPMT = G4int(G4Poisson(ReflVisibilities[OpDet] * Num));
-	    }
-	    else {
-	      TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
-	      TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
+            G4int ReflDetThisPMT = 0;
+            if (!pvs->UseNhitsModel()) {
+              ReflDetThisPMT = G4int(G4Poisson(ReflVisibilities[OpDet] * Num));
+            }
+            else {
+              TVector3 ScintPoint( xyz[0], xyz[1], xyz[2] );
+              TVector3 OpDetPoint(fOpDetCenter.at(OpDet)[0], fOpDetCenter.at(OpDet)[1], fOpDetCenter.at(OpDet)[2]);
               ReflDetThisPMT = VISHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
-	    }
-
-            if(ReflDetThisPMT>0)
-            {
-	      ReflDetectedNum[OpDet]=ReflDetThisPMT;
-
+            }
+            if(ReflDetThisPMT > 0) {
+              ReflDetectedNum[OpDet] = ReflDetThisPMT;
             }
           }
-
         }
 
         // Now we run through each PMT figuring out num of detected photons
         for (int Reflected = 0; Reflected <= 1; Reflected++) {
           // Only do the reflected loop if we have reflected visibilities
-          if (Reflected && !pvs->StoreReflected())
-            continue;
+          if (Reflected && !pvs->StoreReflected()) continue;
 
-          std::map<int,int>::const_iterator itstart;
-          std::map<int,int>::const_iterator itend;
+          std::map<int, int>::const_iterator itstart;
+          std::map<int, int>::const_iterator itend;
           if (Reflected) {
             itstart = ReflDetectedNum.begin();
             itend   = ReflDetectedNum.end();
           }
-          else{
+          else {
             itstart = DetectedNum.begin();
             itend   = DetectedNum.end();
           }
-
-          for(std::map<int,int>::const_iterator itdetphot=itstart; itdetphot!=itend; ++itdetphot)
-          {
+          for(std::map<int, int>::const_iterator itdetphot = itstart; itdetphot != itend; ++itdetphot) {
             int OpChannel = itdetphot->first;
             int NPhotons  = itdetphot->second;
 
@@ -866,37 +794,37 @@ namespace larg4{
             double xyzPos[3];
             average_position(aStep, xyzPos);
             double Edeposited  = 0;
-            if(scintillationByParticleType){
+            if(scintillationByParticleType) {
               //We use this when it is the only sensical information. It may be of limited use to end users.
               Edeposited = aStep.GetTotalEnergyDeposit();
-            }else if(emSaturation){
+            }
+            else if(emSaturation) {
               //If Birk Coefficient used, log VisibleEnergies.
-            Edeposited = larg4::IonizationAndScintillation::Instance()->VisibleEnergyDeposit()/CLHEP::MeV;
-            }else{
+              Edeposited = larg4::IonizationAndScintillation::Instance()->VisibleEnergyDeposit() / CLHEP::MeV;
+            }
+            else {
               //We use this when it is the only sensical information. It may be of limited use to end users.
               Edeposited = aStep.GetTotalEnergyDeposit();
             }
 
             // Get the transport time distribution
-	    std::vector<double> arrival_time_dist = propagation_time(x0, OpChannel, NPhotons, Reflected);
+            std::vector<double> arrival_time_dist = propagation_time(x0, OpChannel, NPhotons, Reflected);
 
-	    //We need to split the energy up by the number of photons so that we never try to write a 0 energy.
+            //We need to split the energy up by the number of photons so that we never try to write a 0 energy.
             Edeposited = Edeposited / double(NPhotons);
 
             // Loop through the photons
-            for (G4int i = 0; i < NPhotons; ++i)
-            {
-	      //std::cout<<"VUV time correction: "<<arrival_time_dist[i]<<std::endl;
+            for (G4int i = 0; i < NPhotons; ++i) {
+              //std::cout<<"VUV time correction: "<<arrival_time_dist[i]<<std::endl;
               G4double Time = t0
-                + scint_time(aStep, ScintillationTime, ScintillationRiseTime)
-		+ arrival_time_dist[i]*CLHEP::ns;
+                              + scint_time(aStep, ScintillationTime, ScintillationRiseTime)
+                              + arrival_time_dist[i] * CLHEP::ns;
 
               // Always store the BTR
               tmpOpDetBTRecord.AddScintillationPhotons(thisG4TrackID, Time, 1, xyzPos, Edeposited);
 
               // Store as lite photon or as OnePhoton
-              if(lgp->UseLitePhotons())
-              {
+              if(lgp->UseLitePhotons()) {
                 fst->AddLitePhoton(OpChannel, static_cast<int>(Time), 1, Reflected);
               }
               else {
@@ -904,8 +832,8 @@ namespace larg4{
                 TVector3 PhotonPosition( x0[0], x0[1], x0[2] );
 
                 float PhotonEnergy = 0;
-                if (Reflected)  PhotonEnergy = reemission_energy()*CLHEP::eV;
-                else            PhotonEnergy = 9.7*CLHEP::eV;
+                if (Reflected)  PhotonEnergy = reemission_energy() * CLHEP::eV;
+                else            PhotonEnergy = 9.7 * CLHEP::eV;
 
                 // Make a photon object for the collection
                 sim::OnePhoton PhotToAdd;
@@ -918,22 +846,19 @@ namespace larg4{
                 fst->AddPhoton(OpChannel, std::move(PhotToAdd), Reflected);
               }
             }
-
             fst->AddOpDetBacktrackerRecord(tmpOpDetBTRecord, Reflected);
           }
         }
       }
     }
-
     //std::cout<<gen_photon_ctr<<","<<det_photon_ctr<<std::endl; // CASE-DEBUG DO NOT REMOVE THIS COMMENT
     return 0;
   }
 
 
-// BuildThePhysicsTable for the scintillation process
-// --------------------------------------------------
-//
-
+  // BuildThePhysicsTable for the scintillation process
+  // --------------------------------------------------
+  //
   void OpFastScintillation::BuildThePhysicsTable()
   {
     if (theFastIntegralTable && theSlowIntegralTable) return;
@@ -943,14 +868,11 @@ namespace larg4{
     G4int numOfMaterials = G4Material::GetNumberOfMaterials();
 
     // create new physics table
-
     if(!theFastIntegralTable)theFastIntegralTable = new G4PhysicsTable(numOfMaterials);
     if(!theSlowIntegralTable)theSlowIntegralTable = new G4PhysicsTable(numOfMaterials);
 
     // loop for materials
-
-    for (G4int i=0 ; i < numOfMaterials; i++)
-    {
+    for (G4int i = 0 ; i < numOfMaterials; i++) {
       G4PhysicsOrderedFreeVector* aPhysicsOrderedFreeVector =
         new G4PhysicsOrderedFreeVector();
       G4PhysicsOrderedFreeVector* bPhysicsOrderedFreeVector =
@@ -958,7 +880,6 @@ namespace larg4{
 
       // Retrieve vector of scintillation wavelength intensity for
       // the material from the material's optical properties table.
-
       G4Material* aMaterial = (*theMaterialTable)[i];
 
       G4MaterialPropertiesTable* aMaterialPropertiesTable =
@@ -970,124 +891,100 @@ namespace larg4{
           aMaterialPropertiesTable->GetProperty("FASTCOMPONENT");
 
         if (theFastLightVector) {
-
           // Retrieve the first intensity point in vector
           // of (photon energy, intensity) pairs
-
           G4double currentIN = (*theFastLightVector)[0];
-
           if (currentIN >= 0.0) {
-
             // Create first (photon energy, Scintillation
             // Integral pair
-
             G4double currentPM = theFastLightVector->Energy(0);
-
             G4double currentCII = 0.0;
 
             aPhysicsOrderedFreeVector->
-              InsertValues(currentPM , currentCII);
+            InsertValues(currentPM, currentCII);
 
             // Set previous values to current ones prior to loop
-
             G4double prevPM  = currentPM;
             G4double prevCII = currentCII;
             G4double prevIN  = currentIN;
 
             // loop over all (photon energy, intensity)
             // pairs stored for this material
-
             for (size_t i = 1;
                  i < theFastLightVector->GetVectorLength();
-                 i++)
-            {
+                 i++) {
               currentPM = theFastLightVector->Energy(i);
               currentIN = (*theFastLightVector)[i];
 
               currentCII = 0.5 * (prevIN + currentIN);
 
               currentCII = prevCII +
-                (currentPM - prevPM) * currentCII;
+                           (currentPM - prevPM) * currentCII;
 
               aPhysicsOrderedFreeVector->
-                InsertValues(currentPM, currentCII);
+              InsertValues(currentPM, currentCII);
 
               prevPM  = currentPM;
               prevCII = currentCII;
               prevIN  = currentIN;
             }
-
           }
         }
 
         G4MaterialPropertyVector* theSlowLightVector =
           aMaterialPropertiesTable->GetProperty("SLOWCOMPONENT");
-
         if (theSlowLightVector) {
-
           // Retrieve the first intensity point in vector
           // of (photon energy, intensity) pairs
-
           G4double currentIN = (*theSlowLightVector)[0];
-
           if (currentIN >= 0.0) {
-
             // Create first (photon energy, Scintillation
             // Integral pair
-
             G4double currentPM = theSlowLightVector->Energy(0);
-
             G4double currentCII = 0.0;
 
             bPhysicsOrderedFreeVector->
-              InsertValues(currentPM , currentCII);
+            InsertValues(currentPM, currentCII);
 
             // Set previous values to current ones prior to loop
-
             G4double prevPM  = currentPM;
             G4double prevCII = currentCII;
             G4double prevIN  = currentIN;
 
             // loop over all (photon energy, intensity)
             // pairs stored for this material
-
             for (size_t i = 1;
                  i < theSlowLightVector->GetVectorLength();
-                 i++)
-            {
+                 i++) {
               currentPM = theSlowLightVector->Energy(i);
               currentIN = (*theSlowLightVector)[i];
 
               currentCII = 0.5 * (prevIN + currentIN);
 
               currentCII = prevCII +
-                (currentPM - prevPM) * currentCII;
+                           (currentPM - prevPM) * currentCII;
 
               bPhysicsOrderedFreeVector->
-                InsertValues(currentPM, currentCII);
+              InsertValues(currentPM, currentCII);
 
               prevPM  = currentPM;
               prevCII = currentCII;
               prevIN  = currentIN;
             }
-
           }
         }
       }
-
       // The scintillation integral(s) for a given material
       // will be inserted in the table(s) according to the
       // position of the material in the material table.
-
-      theFastIntegralTable->insertAt(i,aPhysicsOrderedFreeVector);
-      theSlowIntegralTable->insertAt(i,bPhysicsOrderedFreeVector);
-
+      theFastIntegralTable->insertAt(i, aPhysicsOrderedFreeVector);
+      theSlowIntegralTable->insertAt(i, bPhysicsOrderedFreeVector);
     }
   }
 
-// Called by the user to set the scintillation yield as a function
-// of energy deposited by particle type
 
+  // Called by the user to set the scintillation yield as a function
+  // of energy deposited by particle type
   void OpFastScintillation::SetScintillationByParticleType(const G4bool scintType)
   {
     if (emSaturation) {
@@ -1098,49 +995,39 @@ namespace larg4{
     scintillationByParticleType = scintType;
   }
 
-// GetMeanFreePath
-// ---------------
-//
 
   G4double OpFastScintillation::GetMeanFreePath(const G4Track&,
-                                                G4double ,
-                                                G4ForceCondition* condition)
+      G4double,
+      G4ForceCondition* condition)
   {
     *condition = StronglyForced;
-
     return DBL_MAX;
-
   }
 
-// GetMeanLifeTime
-// ---------------
-//
 
   G4double OpFastScintillation::GetMeanLifeTime(const G4Track&,
-                                                G4ForceCondition* condition)
+      G4ForceCondition* condition)
   {
     *condition = Forced;
-
     return DBL_MAX;
-
   }
 
+
   G4double OpFastScintillation::scint_time(const G4Step& aStep,
-                                           G4double ScintillationTime,
-                                           G4double ScintillationRiseTime) const
+      G4double ScintillationTime,
+      G4double ScintillationRiseTime) const
   {
     G4StepPoint const* pPreStepPoint  = aStep.GetPreStepPoint();
     G4StepPoint const* pPostStepPoint = aStep.GetPostStepPoint();
-    G4double avgVelocity = (pPreStepPoint->GetVelocity() + pPostStepPoint->GetVelocity())/2.;
-
+    G4double avgVelocity = (pPreStepPoint->GetVelocity() + pPostStepPoint->GetVelocity()) / 2.;
     G4double deltaTime = aStep.GetStepLength() / avgVelocity;
-
-    if (ScintillationRiseTime==0.0) {
+    if (ScintillationRiseTime == 0.0) {
       deltaTime = deltaTime -
-        ScintillationTime * std::log( G4UniformRand() );
-    } else {
+                  ScintillationTime * std::log( G4UniformRand() );
+    }
+    else {
       deltaTime = deltaTime +
-        sample_time(ScintillationRiseTime, ScintillationTime);
+                  sample_time(ScintillationRiseTime, ScintillationTime);
     }
     return deltaTime;
   }
@@ -1148,59 +1035,45 @@ namespace larg4{
 
   std::vector<double> OpFastScintillation::propagation_time(G4ThreeVector x0, int OpChannel, int NPhotons, bool Reflected) //const
   {
-
     static art::ServiceHandle<phot::PhotonVisibilityService const> pvs;
-
     // Initialize vector of the right length with all 0's
     std::vector<double> arrival_time_dist(NPhotons, 0);
-
 
     if (pvs->IncludeParPropTime() && pvs->IncludePropTime()) {
       throw cet::exception("OpFastScintillation") << "Cannot have both propagation time models simultaneously.";
     }
-
-    else if (pvs->IncludeParPropTime() && !(ParPropTimeTF1  && (ParPropTimeTF1[OpChannel].GetNdim()==1)) )
-    {
+    else if (pvs->IncludeParPropTime() && !(ParPropTimeTF1  && (ParPropTimeTF1[OpChannel].GetNdim() == 1)) ) {
       //Warning: TF1::GetNdim()==1 will tell us if the TF1 is really defined or it is the default one.
       //This will fix a segfault when using timing and interpolation.
       G4cout << "WARNING: Requested parameterized timing, but no function found. Not applying propagation time." << G4endl;
     }
-
     else if (pvs->IncludeParPropTime()) {
       if (Reflected)
         throw cet::exception("OpFastScintillation") << "No parameterized propagation time for reflected light";
-
       for (int i = 0; i < NPhotons; i++) {
         arrival_time_dist[i] = ParPropTimeTF1[OpChannel].GetRandom();
       }
     }
-
     else if (pvs->IncludePropTime()) {
       // Get VUV photons arrival time distribution from the parametrization
-      G4ThreeVector OpDetPoint(fOpDetCenter.at(OpChannel)[0]*CLHEP::cm,fOpDetCenter.at(OpChannel)[1]*CLHEP::cm,fOpDetCenter.at(OpChannel)[2]*CLHEP::cm);
-
+      G4ThreeVector OpDetPoint(fOpDetCenter.at(OpChannel)[0]*CLHEP::cm, fOpDetCenter.at(OpChannel)[1]*CLHEP::cm, fOpDetCenter.at(OpChannel)[2]*CLHEP::cm);
       if (!Reflected) {
-        double distance_in_cm = (x0 - OpDetPoint).mag()/CLHEP::cm; // this must be in CENTIMETERS!
+        double distance_in_cm = (x0 - OpDetPoint).mag() / CLHEP::cm; // this must be in CENTIMETERS!
         arrival_time_dist = getVUVTime(distance_in_cm, NPhotons); // in ns
-
       }
       else {
-	TVector3 ScintPoint( x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm ); // in cm
-	TVector3 OpDetPoint_tv3(fOpDetCenter.at(OpChannel)[0], fOpDetCenter.at(OpChannel)[1], fOpDetCenter.at(OpChannel)[2]); // in cm
+        TVector3 ScintPoint( x0[0] / CLHEP::cm, x0[1] / CLHEP::cm, x0[2] / CLHEP::cm ); // in cm
+        TVector3 OpDetPoint_tv3(fOpDetCenter.at(OpChannel)[0], fOpDetCenter.at(OpChannel)[1], fOpDetCenter.at(OpChannel)[2]); // in cm
         arrival_time_dist = getVISTime(ScintPoint, OpDetPoint_tv3, NPhotons); // in ns
       }
     }
-
     return arrival_time_dist;
   }
 
 
-
-
   G4double OpFastScintillation::sample_time(G4double tau1, G4double tau2) const
   {
-// tau1: rise time and tau2: decay time
-
+    // tau1: rise time and tau2: decay time
     while(1) {
       // two random numbers
       G4double ran1 = G4UniformRand();
@@ -1208,12 +1081,12 @@ namespace larg4{
       //
       // exponential distribution as envelope function: very efficient
       //
-      G4double d = (tau1+tau2)/tau2;
+      G4double d = (tau1 + tau2) / tau2;
       // make sure the envelope function is
       // always larger than the bi-exponential
-      G4double t = -1.0*tau2*std::log(1-ran1);
-      G4double g = d*single_exp(t,tau2);
-      if (ran2 <= bi_exp(t,tau1,tau2)/g) return t;
+      G4double t = -1.0 * tau2 * std::log(1 - ran1);
+      G4double g = d * single_exp(t, tau2);
+      if (ran2 <= bi_exp(t, tau1, tau2) / g) return t;
     }
     return -1.0;
   }
@@ -1221,7 +1094,7 @@ namespace larg4{
 
   double OpFastScintillation::reemission_energy() const
   {
-    return rgen0->fire()*((*(--tpbemission.end())).first-(*tpbemission.begin()).first)+(*tpbemission.begin()).first;
+    return rgen0->fire() * ((*(--tpbemission.end())).first - (*tpbemission.begin()).first) + (*tpbemission.begin()).first;
   }
 
 
@@ -1235,150 +1108,149 @@ namespace larg4{
   }
 
 
+  //                         ======TIMING PARAMETRIZATION=====           //
+  /*
+  // Parametrization of the VUV light timing (result from direct transport + Rayleigh scattering ONLY)
+  // using a landau + expo function.The function below returns the arrival time distribution given the
+  // distance IN CENTIMETERS between the scintillation/ionization point and the optical detectotr.
+    std::vector<double> OpFastScintillation::GetVUVTime(double distance, int number_photons) {
 
+      //-----Distances in cm and times in ns-----//
+      //gRandom->SetSeed(0);
+      std::vector<double> arrival_time_distrb;
+      arrival_time_distrb.clear();
 
-//                         ======TIMING PARAMETRIZATION=====           //
-/*
-// Parametrization of the VUV light timing (result from direct transport + Rayleigh scattering ONLY)
-// using a landau + expo function.The function below returns the arrival time distribution given the
-// distance IN CENTIMETERS between the scintillation/ionization point and the optical detectotr.
-  std::vector<double> OpFastScintillation::GetVUVTime(double distance, int number_photons) {
+      // Parametrization data:
+      if(distance < 10 || distance > fd_max) {
+        G4cout<<"WARNING: Parametrization of Direct Light not fully reliable"<<G4endl;
+        G4cout<<"Too close/far to the PMT  -> set 0 VUV photons(?)!!!!!!"<<G4endl;
+        return arrival_time_distrb;
+      }
+      //signals (remember this is transportation) no longer than 1us
+      const double signal_t_range = 1000.;
+      const double vuv_vgroup = 10.13;//cm/ns
+      double t_direct = distance/vuv_vgroup;
+      // Defining the two functions (Landau + Exponential) describing the timing vs distance
+      double pars_landau[3] = {functions_vuv[1]->Eval(distance), functions_vuv[2]->Eval(distance),
+                               pow(10.,functions_vuv[0]->Eval(distance))};
+      if(distance > fd_break) {
+        pars_landau[0]=functions_vuv[6]->Eval(distance);
+        pars_landau[1]=functions_vuv[2]->Eval(fd_break);
+        pars_landau[2]=pow(10.,functions_vuv[5]->Eval(distance));
+      }
+      TF1 *flandau = new TF1("flandau","[2]*TMath::Landau(x,[0],[1])",0,signal_t_range/2);
+      flandau->SetParameters(pars_landau);
+      double pars_expo[2] = {functions_vuv[3]->Eval(distance), functions_vuv[4]->Eval(distance)};
+      if(distance > (fd_break - 50.)) {
+        pars_expo[0] = functions_vuv[7]->Eval(distance);
+        pars_expo[1] = functions_vuv[4]->Eval(fd_break - 50.);
+      }
+      TF1 *fexpo = new TF1("fexpo","expo",0, signal_t_range/2);
+      fexpo->SetParameters(pars_expo);
+      //this is to find the intersection point between the two functions:
+      TF1 *fint = new TF1("fint","finter_d",flandau->GetMaximumX(),3*t_direct,5);
+      double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+      fint->SetParameters(parsInt);
+      double t_int = fint->GetMinimumX();
+      double minVal = fint->Eval(t_int);
+      //the functions must intersect!!!
+      if(minVal>0.015)
+        G4cout<<"WARNING: Parametrization of Direct Light discontinuous (landau + expo)!!!!!!"<<G4endl;
 
-    //-----Distances in cm and times in ns-----//
-    //gRandom->SetSeed(0);
-    std::vector<double> arrival_time_distrb;
-    arrival_time_distrb.clear();
+      TF1 *fVUVTiming =  new TF1("fTiming","LandauPlusExpoFinal",0,signal_t_range,6);
+      double parsfinal[6] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+      fVUVTiming->SetParameters(parsfinal);
+      // Set the number of points used to sample the function
 
-    // Parametrization data:
+      int f_sampling = 1000;
+      if(distance < 50)
+        f_sampling *= ftf1_sampling_factor;
+      fVUVTiming->SetNpx(f_sampling);
 
-    if(distance < 10 || distance > fd_max) {
-      G4cout<<"WARNING: Parametrization of Direct Light not fully reliable"<<G4endl;
-      G4cout<<"Too close/far to the PMT  -> set 0 VUV photons(?)!!!!!!"<<G4endl;
+      for(int i=0; i<number_photons; i++)
+        arrival_time_distrb.push_back(fVUVTiming->GetRandom());
+
+      //deleting ...
+      delete flandau;
+      delete fexpo;
+      delete fint;
+      delete fVUVTiming;
+      //G4cout<<"BEAMAUS timing distribution hecha"<<G4endl;
       return arrival_time_distrb;
     }
-    //signals (remember this is transportation) no longer than 1us
-    const double signal_t_range = 1000.;
-    const double vuv_vgroup = 10.13;//cm/ns
-    double t_direct = distance/vuv_vgroup;
-    // Defining the two functions (Landau + Exponential) describing the timing vs distance
-    double pars_landau[3] = {functions_vuv[1]->Eval(distance), functions_vuv[2]->Eval(distance),
-                             pow(10.,functions_vuv[0]->Eval(distance))};
-    if(distance > fd_break) {
-      pars_landau[0]=functions_vuv[6]->Eval(distance);
-      pars_landau[1]=functions_vuv[2]->Eval(fd_break);
-      pars_landau[2]=pow(10.,functions_vuv[5]->Eval(distance));
-    }
-    TF1 *flandau = new TF1("flandau","[2]*TMath::Landau(x,[0],[1])",0,signal_t_range/2);
-    flandau->SetParameters(pars_landau);
-    double pars_expo[2] = {functions_vuv[3]->Eval(distance), functions_vuv[4]->Eval(distance)};
-    if(distance > (fd_break - 50.)) {
-      pars_expo[0] = functions_vuv[7]->Eval(distance);
-      pars_expo[1] = functions_vuv[4]->Eval(fd_break - 50.);
-    }
-    TF1 *fexpo = new TF1("fexpo","expo",0, signal_t_range/2);
-    fexpo->SetParameters(pars_expo);
-    //this is to find the intersection point between the two functions:
-    TF1 *fint = new TF1("fint","finter_d",flandau->GetMaximumX(),3*t_direct,5);
-    double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
-    fint->SetParameters(parsInt);
-    double t_int = fint->GetMinimumX();
-    double minVal = fint->Eval(t_int);
-    //the functions must intersect!!!
-    if(minVal>0.015)
-      G4cout<<"WARNING: Parametrization of Direct Light discontinuous (landau + expo)!!!!!!"<<G4endl;
 
-    TF1 *fVUVTiming =  new TF1("fTiming","LandauPlusExpoFinal",0,signal_t_range,6);
-    double parsfinal[6] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
-    fVUVTiming->SetParameters(parsfinal);
-    // Set the number of points used to sample the function
+  // Parametrization of the Visible light timing (result from direct transport + Rayleigh scattering ONLY)
+  // using a landau + exponential function. The function below returns the arrival time distribution given the
+  // time of the first visible photon in the PMT. The light generated has been reflected by the cathode ONLY.
+    std::vector<double> OpFastScintillation::GetVisibleTimeOnlyCathode(double t0, int number_photons) {
+      //-----Distances in cm and times in ns-----//
+      //gRandom->SetSeed(0);
 
-    int f_sampling = 1000;
-    if(distance < 50)
-      f_sampling *= ftf1_sampling_factor;
-    fVUVTiming->SetNpx(f_sampling);
+      std::vector<double> arrival_time_distrb;
+      arrival_time_distrb.clear();
+      // Parametrization data:
 
-    for(int i=0; i<number_photons; i++)
-      arrival_time_distrb.push_back(fVUVTiming->GetRandom());
+      if(t0 < 8 || t0 > ft0_max) {
+        G4cout<<"WARNING: Parametrization of Cathode-Only reflected Light not fully reliable"<<G4endl;
+        G4cout<<"Too close/far to the PMT  -> set 0 Visible photons(?)!!!!!!"<<G4endl;
+        return arrival_time_distrb;
+      }
+      //signals (remember this is transportation) no longer than 1us
+      const double signal_t_range = 1000.;
+      double pars_landau[3] = {functions_vis[1]->Eval(t0), functions_vis[2]->Eval(t0),
+                               pow(10.,functions_vis[0]->Eval(t0))};
+      double pars_expo[2] = {functions_vis[3]->Eval(t0), functions_vis[4]->Eval(t0)};
+      if(t0 > ft0_break_point) {
+        pars_landau[0] = -0.798934 + 1.06216*t0;
+        pars_landau[1] = functions_vis[2]->Eval(ft0_break_point);
+        pars_landau[2] = pow(10.,functions_vis[0]->Eval(ft0_break_point));
+        pars_expo[0] = functions_vis[3]->Eval(ft0_break_point);
+        pars_expo[1] = functions_vis[4]->Eval(ft0_break_point);
+      }
 
-    //deleting ...
-    delete flandau;
-    delete fexpo;
-    delete fint;
-    delete fVUVTiming;
-    //G4cout<<"BEAMAUS timing distribution hecha"<<G4endl;
-    return arrival_time_distrb;
-  }
+      // Defining the two functions (Landau + Exponential) describing the timing vs t0
+      TF1 *flandau = new TF1("flandau","[2]*TMath::Landau(x,[0],[1])",0,signal_t_range/2);
+      flandau->SetParameters(pars_landau);
+      TF1 *fexpo = new TF1("fexpo","expo",0, signal_t_range/2);
+      fexpo->SetParameters(pars_expo);
+      //this is to find the intersection point between the two functions:
+      TF1 *fint = new TF1("fint",finter_d,flandau->GetMaximumX(),2*t0,5);
+      double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+      fint->SetParameters(parsInt);
+      double t_int = fint->GetMinimumX();
+      double minVal = fint->Eval(t_int);
+      //the functions must intersect!!!
+      if(minVal>0.015)
+        G4cout<<"WARNING: Parametrization of Direct Light discontinuous (landau + expo)!!!!!!"<<G4endl;
 
-// Parametrization of the Visible light timing (result from direct transport + Rayleigh scattering ONLY)
-// using a landau + exponential function. The function below returns the arrival time distribution given the
-// time of the first visible photon in the PMT. The light generated has been reflected by the cathode ONLY.
-  std::vector<double> OpFastScintillation::GetVisibleTimeOnlyCathode(double t0, int number_photons) {
-    //-----Distances in cm and times in ns-----//
-    //gRandom->SetSeed(0);
+      TF1 *fVisTiming =  new TF1("fTiming",LandauPlusExpoFinal,0,signal_t_range,6);
+      double parsfinal[6] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+      fVisTiming->SetParameters(parsfinal);
+      // Set the number of points used to sample the function
 
-    std::vector<double> arrival_time_distrb;
-    arrival_time_distrb.clear();
-    // Parametrization data:
+      int f_sampling = 1000;
+      if(t0 < 20)
+        f_sampling *= ftf1_sampling_factor;
+      fVisTiming->SetNpx(f_sampling);
 
-    if(t0 < 8 || t0 > ft0_max) {
-      G4cout<<"WARNING: Parametrization of Cathode-Only reflected Light not fully reliable"<<G4endl;
-      G4cout<<"Too close/far to the PMT  -> set 0 Visible photons(?)!!!!!!"<<G4endl;
+      for(int i=0; i<number_photons; i++)
+        arrival_time_distrb.push_back(fVisTiming->GetRandom());
+
+      //deleting ...
+
+      delete flandau;
+      delete fexpo;
+      delete fint;
+      delete fVisTiming;
+      //G4cout<<"Timing distribution BEAMAUS!"<<G4endl;
       return arrival_time_distrb;
-    }
-    //signals (remember this is transportation) no longer than 1us
-    const double signal_t_range = 1000.;
-    double pars_landau[3] = {functions_vis[1]->Eval(t0), functions_vis[2]->Eval(t0),
-                             pow(10.,functions_vis[0]->Eval(t0))};
-    double pars_expo[2] = {functions_vis[3]->Eval(t0), functions_vis[4]->Eval(t0)};
-    if(t0 > ft0_break_point) {
-      pars_landau[0] = -0.798934 + 1.06216*t0;
-      pars_landau[1] = functions_vis[2]->Eval(ft0_break_point);
-      pars_landau[2] = pow(10.,functions_vis[0]->Eval(ft0_break_point));
-      pars_expo[0] = functions_vis[3]->Eval(ft0_break_point);
-      pars_expo[1] = functions_vis[4]->Eval(ft0_break_point);
-    }
+    }*/
 
-    // Defining the two functions (Landau + Exponential) describing the timing vs t0
-    TF1 *flandau = new TF1("flandau","[2]*TMath::Landau(x,[0],[1])",0,signal_t_range/2);
-    flandau->SetParameters(pars_landau);
-    TF1 *fexpo = new TF1("fexpo","expo",0, signal_t_range/2);
-    fexpo->SetParameters(pars_expo);
-    //this is to find the intersection point between the two functions:
-    TF1 *fint = new TF1("fint",finter_d,flandau->GetMaximumX(),2*t0,5);
-    double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
-    fint->SetParameters(parsInt);
-    double t_int = fint->GetMinimumX();
-    double minVal = fint->Eval(t_int);
-    //the functions must intersect!!!
-    if(minVal>0.015)
-      G4cout<<"WARNING: Parametrization of Direct Light discontinuous (landau + expo)!!!!!!"<<G4endl;
-
-    TF1 *fVisTiming =  new TF1("fTiming",LandauPlusExpoFinal,0,signal_t_range,6);
-    double parsfinal[6] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
-    fVisTiming->SetParameters(parsfinal);
-    // Set the number of points used to sample the function
-
-    int f_sampling = 1000;
-    if(t0 < 20)
-      f_sampling *= ftf1_sampling_factor;
-    fVisTiming->SetNpx(f_sampling);
-
-    for(int i=0; i<number_photons; i++)
-      arrival_time_distrb.push_back(fVisTiming->GetRandom());
-
-    //deleting ...
-
-    delete flandau;
-    delete fexpo;
-    delete fint;
-    delete fVisTiming;
-    //G4cout<<"Timing distribution BEAMAUS!"<<G4endl;
-    return arrival_time_distrb;
-  }*/
 
   // New Parametrization code
   // parameterisation generation function
-  void OpFastScintillation::generateparam(int index) {
+  void OpFastScintillation::generateparam(int index)
+  {
     // get distance
     double distance_in_cm = (index * fstep_size) + 25;
 
@@ -1389,8 +1261,8 @@ namespace larg4{
     TF1 fVUVTiming;
 
     // For very short distances the time correction is just a shift
-    double t_direct_mean = distance_in_cm/fvuv_vgroup_mean;
-    double t_direct_min = distance_in_cm/fvuv_vgroup_max;
+    double t_direct_mean = distance_in_cm / fvuv_vgroup_mean;
+    double t_direct_min = distance_in_cm / fvuv_vgroup_max;
 
     // Defining the model function(s) describing the photon transportation timing vs distance
     // Getting the landau parameters from the time parametrization
@@ -1400,12 +1272,12 @@ namespace larg4{
     if(distance_in_cm >= finflexion_point_distance) {
       double pars_far[4] = {t_direct_min, pars_landau[0], pars_landau[1], pars_landau[2]};
       // Set model: Landau
-      fVUVTiming = TF1("fVUVTiming",model_far,0,signal_t_range,4);
+      fVUVTiming = TF1("fVUVTiming", model_far, 0, signal_t_range, 4);
       fVUVTiming.SetParameters(pars_far);
     }
     else {
       // Set model: Landau + Exponential
-      fVUVTiming = TF1("fVUVTiming",model_close,0,signal_t_range,7);
+      fVUVTiming = TF1("fVUVTiming", model_close, 0, signal_t_range, 7);
       // Exponential parameters
       double pars_expo[2];
       // Getting the exponential parameters from the time parametrization
@@ -1413,19 +1285,19 @@ namespace larg4{
       //For simplicity, not considering the small dependency with the offset angle in pars_expo[0]
       //Using the value for the [30,60deg] range. fparameters[6] and fparameters[8] are the values
       //for [0,30deg] range and [60,90deg] range respectively
-      pars_expo[0] = fparameters[7].at(0) + fparameters[7].at(1)*distance_in_cm;
+      pars_expo[0] = fparameters[7].at(0) + fparameters[7].at(1) * distance_in_cm;
       pars_expo[0] *= pars_landau[2];
       pars_expo[0] = log(pars_expo[0]);
       // this is to find the intersection point between the two functions:
-      TF1 fint = TF1("fint",finter_d,pars_landau[0],4*t_direct_mean,5);
+      TF1 fint = TF1("fint", finter_d, pars_landau[0], 4 * t_direct_mean, 5);
       double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
       fint.SetParameters(parsInt);
       double t_int = fint.GetMinimumX();
       double minVal = fint.Eval(t_int);
       // the functions must intersect - output warning if they don't
-      if(minVal>0.015) {
-	std::cout<<"WARNING: Parametrization of VUV light discontinuous for distance = " << distance_in_cm << std::endl;
-	std::cout<<"WARNING: This shouldn't be happening " << std::endl;
+      if(minVal > 0.015) {
+        std::cout << "WARNING: Parametrization of VUV light discontinuous for distance = " << distance_in_cm << std::endl;
+        std::cout << "WARNING: This shouldn't be happening " << std::endl;
       }
       double parsfinal[7] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1], t_direct_min};
       fVUVTiming.SetParameters(parsfinal);
@@ -1435,18 +1307,24 @@ namespace larg4{
     // set the number of points used to sample parameterisation
     // for shorter distances, peak is sharper so more sensitive sampling required
     int f_sampling;
-    if (distance_in_cm < 50) { f_sampling = 10000; }
-    else if (distance_in_cm < 100){ f_sampling = 5000; }
-    else { f_sampling = 1000; }
+    if (distance_in_cm < 50) {
+      f_sampling = 10000;
+    }
+    else if (distance_in_cm < 100) {
+      f_sampling = 5000;
+    }
+    else {
+      f_sampling = 1000;
+    }
     fVUVTiming.SetNpx(f_sampling);
 
     // calculate max and min distance relevant to sample parameterisation
     // max
-    const int nq_max=1;
+    const int nq_max = 1;
     double xq_max[nq_max];
     double yq_max[nq_max];
     xq_max[0] = 0.99;   // include 99%
-    fVUVTiming.GetQuantiles(nq_max,yq_max,xq_max);
+    fVUVTiming.GetQuantiles(nq_max, yq_max, xq_max);
     double max = yq_max[0];
     // min
     double min = t_direct_min;
@@ -1458,12 +1336,12 @@ namespace larg4{
     VUV_timing[index] = fVUVTiming;
     VUV_max[index] = max;
     VUV_min[index] = min;
-
   }
 
-  // VUV arrival times calculation function
-  std::vector<double> OpFastScintillation::getVUVTime(double distance, int number_photons) {
 
+  // VUV arrival times calculation function
+  std::vector<double> OpFastScintillation::getVUVTime(double distance, int number_photons)
+  {
     // pre-allocate memory
     std::vector<double> arrival_time_distrb;
     arrival_time_distrb.clear();
@@ -1472,9 +1350,9 @@ namespace larg4{
     // distance < 25cm
     if (distance < 25) {
       // times are fixed shift i.e. direct path only
-      double t_prop_correction = distance/fvuv_vgroup_mean;
-      for (int i = 0; i < number_photons; i++){
-	arrival_time_distrb.push_back(t_prop_correction);
+      double t_prop_correction = distance / fvuv_vgroup_mean;
+      for (int i = 0; i < number_photons; i++) {
+        arrival_time_distrb.push_back(t_prop_correction);
       }
     }
     // distance >= 25cm
@@ -1483,19 +1361,20 @@ namespace larg4{
       int index = std::round((distance - 25) / fstep_size);
       // check whether required parameterisation has been generated, generating if not
       if (VUV_timing[index].GetNdim() == 0) {
-	generateparam(index);
+        generateparam(index);
       }
       // randomly sample parameterisation for each photon
-      for (int i = 0; i < number_photons; i++){
-	arrival_time_distrb.push_back(VUV_timing[index].GetRandom(VUV_min[index],VUV_max[index]));
+      for (int i = 0; i < number_photons; i++) {
+        arrival_time_distrb.push_back(VUV_timing[index].GetRandom(VUV_min[index], VUV_max[index]));
       }
     }
     return arrival_time_distrb;
-
   }
 
+
   // VIS arrival times calculation functions
-  std::vector<double> OpFastScintillation::getVISTime(TVector3 ScintPoint, TVector3 OpDetPoint, int number_photons) {
+  std::vector<double> OpFastScintillation::getVISTime(TVector3 ScintPoint, TVector3 OpDetPoint, int number_photons)
+  {
     // *************************************************************************************************
     //     Calculation of earliest arrival times and corresponding unsmeared distribution
     // *************************************************************************************************
@@ -1511,48 +1390,47 @@ namespace larg4{
 
     // calculate point of reflection for shortest path accounting for difference in refractive indicies
     // vectors for storing results
-    TVector3 image(0,0,0);
-    TVector3 bounce_point(0,0,0);
+    TVector3 image(0, 0, 0);
+    TVector3 bounce_point(0, 0, 0);
 
     // distance to wall
-    TVector3 v_to_wall(plane_depth-ScintPoint[0],0,0);
+    TVector3 v_to_wall(plane_depth - ScintPoint[0], 0, 0);
 
     // hotspot is point on wall where TPB is activated most intensely by the scintillation
-    TVector3 hotspot(plane_depth,ScintPoint[1],ScintPoint[2]);
+    TVector3 hotspot(plane_depth, ScintPoint[1], ScintPoint[2]);
 
     // define "image" by reflecting over plane
-    image = hotspot + v_to_wall*(fn_LAr_vis/fn_LAr_vuv);
+    image = hotspot + v_to_wall * (fn_LAr_vis / fn_LAr_vuv);
 
     // find point of intersection with plane j of ray from the PMT to the image
-    TVector3 tempvec = (OpDetPoint-image).Unit();
-    double tempnorm= ((image-hotspot).Mag())/std::abs(tempvec[0]);
-    bounce_point = image + tempvec*tempnorm;
+    TVector3 tempvec = (OpDetPoint - image).Unit();
+    double tempnorm = ((image - hotspot).Mag()) / std::abs(tempvec[0]);
+    bounce_point = image + tempvec * tempnorm;
 
     // calculate distance travelled by VUV light and by vis light
-    double VUVdist = (bounce_point-ScintPoint).Mag();
-    double Visdist = (OpDetPoint-bounce_point).Mag();
+    double VUVdist = (bounce_point - ScintPoint).Mag();
+    double Visdist = (OpDetPoint - bounce_point).Mag();
 
     // calculate times taken by each part
     std::vector<double> VUVTimes  = getVUVTime(VUVdist, number_photons);
-    std::vector<double> ReflTimes(number_photons,Visdist/fvis_vmean);
+    std::vector<double> ReflTimes(number_photons, Visdist / fvis_vmean);
 
     // sum parts to get total transport times times
-    std::vector<double> transport_time_vis(number_photons,0);
-    for (int i=0; i<number_photons; i++) {
+    std::vector<double> transport_time_vis(number_photons, 0);
+    for (int i = 0; i < number_photons; i++) {
       transport_time_vis[i] = VUVTimes[i] + ReflTimes[i];
     }
 
     // *************************************************************************************************
     //      Smearing of arrival time distribution
     // *************************************************************************************************
-
     // calculate fastest time possible
     // vis part
-    double vis_time = Visdist/fvis_vmean;
+    double vis_time = Visdist / fvis_vmean;
     // vuv part
     double vuv_time;
-    if (VUVdist < 25){
-      vuv_time = VUVdist/fvuv_vgroup_mean;
+    if (VUVdist < 25) {
+      vuv_time = VUVdist / fvuv_vgroup_mean;
     }
     else {
       // find index of required parameterisation
@@ -1564,8 +1442,8 @@ namespace larg4{
     double fastest_time = vis_time + vuv_time;
 
     // calculate angle alpha between scintillation point and reflection point
-    double cosine_alpha = sqrt(pow(ScintPoint[0] - bounce_point[0],2)) / VUVdist;
-    double alpha = acos(cosine_alpha)*180./CLHEP::pi;
+    double cosine_alpha = sqrt(pow(ScintPoint[0] - bounce_point[0], 2)) / VUVdist;
+    double alpha = acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
@@ -1577,21 +1455,21 @@ namespace larg4{
     if (alpha_bin >= ftau_pars.size()) {
       alpha_bin = ftau_pars.size() - 1;      // default to the largest available bin if alpha larger than parameterised region; i.e. last bin effectively [last bin start value, 90] deg bin
     }
-   // cut-off and tau
+    // cut-off and tau
     double cutoff = interpolate( fdistances_refl, fcut_off_pars[alpha_bin], distance_cathode_plane, true );
     double tau = interpolate( fdistances_refl, ftau_pars[alpha_bin], distance_cathode_plane, true );
 
-   // fail-safe if tau extrapolate goes wrong, drops below zero since last distance close to zero [did not occur in testing, but possible]
-    if (tau < 0){
+    // fail-safe if tau extrapolate goes wrong, drops below zero since last distance close to zero [did not occur in testing, but possible]
+    if (tau < 0) {
       tau = 0;
     }
 
     // apply smearing:
-    for (int i=0; i < number_photons; i++){
+    for (int i = 0; i < number_photons; i++) {
       double arrival_time = transport_time_vis[i];
       double arrival_time_smeared;
       // if time is already greater than cutoff or minimum smeared time would be greater than cutoff, do not apply smearing
-      if (arrival_time + (arrival_time-fastest_time)*(exp(-tau*log(1.0))-1) >= cutoff) {
+      if (arrival_time + (arrival_time - fastest_time) * (exp(-tau * log(1.0)) - 1) >= cutoff) {
         arrival_time_smeared = arrival_time;
       }
       // otherwise smear
@@ -1601,45 +1479,47 @@ namespace larg4{
         // most are within single attempt, very few take more than two
         do {
           // don't attempt smearings too many times for cases near cutoff (very few cases, not smearing these makes negigible difference)
-          if (counter >= 10){
+          if (counter >= 10) {
             arrival_time_smeared = arrival_time; // don't smear
             break;
           }
           else {
             // generate random number in appropriate range
-            double x = gRandom->Uniform(0.5,1.0);
-      	    // apply the exponential smearing
-      	    arrival_time_smeared = arrival_time + (arrival_time-fastest_time)*(exp(-tau*log(x))-1);
-	  }
-	  // increment counter
-	  counter++;
-	}  while (arrival_time_smeared > cutoff);
+            double x = gRandom->Uniform(0.5, 1.0);
+            // apply the exponential smearing
+            arrival_time_smeared = arrival_time + (arrival_time - fastest_time) * (exp(-tau * log(x)) - 1);
+          }
+          // increment counter
+          counter++;
+        }
+        while (arrival_time_smeared > cutoff);
       }
       transport_time_vis[i] = arrival_time_smeared;
     }
     return transport_time_vis;
   }
 
+
   // VUV semi-analytic hits calculation
-  int OpFastScintillation::VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type) {
+  int OpFastScintillation::VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type)
+  {
     // check optical channel is in same TPC as scintillation light, if not return 0 hits
     // temporary method working for SBND, uBooNE, DUNE 1x2x6; to be replaced to work in full DUNE geometry
     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
-    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10){
+    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {
       return 0;
     }
-
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
-       (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
+        (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
       return 0;
     }
 
     // distance and angle between ScintPoint and OpDetPoint
-    double distance = sqrt(pow(ScintPoint[0] - OpDetPoint[0],2) + pow(ScintPoint[1] - OpDetPoint[1],2) + pow(ScintPoint[2] - OpDetPoint[2],2));
-    double cosine = sqrt(pow(ScintPoint[0] - OpDetPoint[0],2)) / distance;
-    double theta = acos(cosine)*180./CLHEP::pi;
+    double distance = sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2) + pow(ScintPoint[1] - OpDetPoint[1], 2) + pow(ScintPoint[2] - OpDetPoint[2], 2));
+    double cosine = sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2)) / distance;
+    double theta = acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
     double solid_angle = 0;
@@ -1656,190 +1536,194 @@ namespace larg4{
 
       // calculate solid angle
       solid_angle = Rectangle_SolidAngle(detPoint, ScintPoint_rel);
-
     }
     // PMTs
     else if (optical_detector_type == 1) {
       // offset in z-y plane
-      d = sqrt(pow(ScintPoint[1] - OpDetPoint[1],2) + pow(ScintPoint[2] - OpDetPoint[2],2));
+      d = sqrt(pow(ScintPoint[1] - OpDetPoint[1], 2) + pow(ScintPoint[2] - OpDetPoint[2], 2));
       // drift distance (in x)
-      h =  sqrt(pow(ScintPoint[0] - OpDetPoint[0],2));
+      h =  sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2));
       // Solid angle of a disk
       solid_angle = Disk_SolidAngle(d, h, fradius);
     }
     else {
-      std::cout << "Error: Invalid optical detector type. 0 = rectangular, 1 = disk" <<std:: endl;
+      std::cout << "Error: Invalid optical detector type. 0 = rectangular, 1 = disk" << std:: endl;
     }
 
     // calculate number of photons hits by geometric acceptance: accounting for solid angle and LAr absorbtion length
-    double hits_geo = exp(-1.*distance/fL_abs_vuv) * (solid_angle / (4*CLHEP::pi)) * Nphotons_created;
+    double hits_geo = exp(-1.*distance / fL_abs_vuv) * (solid_angle / (4 * CLHEP::pi)) * Nphotons_created;
 
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
-    int j = (theta/fdelta_angulo);
+    int j = (theta / fdelta_angulo);
 
     //Accounting for border effects
     double z_to_corner = abs(ScintPoint[2] - fZactive_corner) - fZactive_corner;
     double y_to_corner = abs(ScintPoint[1]) - fYactive_corner;
-    double distance_to_corner = sqrt(y_to_corner*y_to_corner + z_to_corner*z_to_corner);// in the ph-cathode plane
+    double distance_to_corner = sqrt(y_to_corner * y_to_corner + z_to_corner * z_to_corner); // in the ph-cathode plane
     double pars_ini_[4] = {fGHvuvpars[0][j] + fborder_corr[0] * (distance_to_corner - fReference_to_corner),
-			   fGHvuvpars[1][j] + fborder_corr[1] * (distance_to_corner - fReference_to_corner),
-			   fGHvuvpars[2][j],
-			   fGHvuvpars[3][j]};
+                           fGHvuvpars[1][j] + fborder_corr[1] * (distance_to_corner - fReference_to_corner),
+                           fGHvuvpars[2][j],
+                           fGHvuvpars[3][j]
+                          };
     double GH_correction = Gaisser_Hillas(distance, pars_ini_);
-    double hits_rec = gRandom->Poisson( GH_correction*hits_geo/cosine );
+    double hits_rec = gRandom->Poisson( GH_correction * hits_geo / cosine );
     // round to integer value, cannot have non-integer number of hits
     int hits_vuv = std::round(hits_rec);
 
     return hits_vuv;
   }
 
+
   // VIS hits semi-analytic model calculation
-  int OpFastScintillation::VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type) {
-     // check optical channel is in same TPC as scintillation light, if not return 0 hits
-     // temporary method working for SBND, DUNE 1x2x6; to be replaced to work in full DUNE geometry
-     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
-     if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10){
-       return 0;
-     }
+  int OpFastScintillation::VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type)
+  {
+    // check optical channel is in same TPC as scintillation light, if not return 0 hits
+    // temporary method working for SBND, DUNE 1x2x6; to be replaced to work in full DUNE geometry
+    // check x coordinate has same sign or is close to zero, otherwise return 0 hits
+    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {
+      return 0;
+    }
 
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
-       (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
+        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
+        (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)) {
       return 0;
     }
 
     // set plane_depth for correct TPC:
-     double plane_depth;
-     if (ScintPoint[0] < 0) {
-       plane_depth = -fplane_depth;
-     }
-     else {
-       plane_depth = fplane_depth;
-     }
+    double plane_depth;
+    if (ScintPoint[0] < 0) {
+      plane_depth = -fplane_depth;
+    }
+    else {
+      plane_depth = fplane_depth;
+    }
 
-     // 1). calculate total number of hits of VUV photons on reflective foils via solid angle + Gaisser-Hillas corrections:
+    // 1). calculate total number of hits of VUV photons on reflective foils via solid angle + Gaisser-Hillas corrections:
 
-     // set cathode plane struct for solid angle function
-     acc cathode_plane;
-     cathode_plane.ax = plane_depth; cathode_plane.ay = fcathode_centre[1]; cathode_plane.az = fcathode_centre[2];       	// centre coordinates of cathode plane
-     cathode_plane.w = fcathode_ydimension; cathode_plane.h = fcathode_zdimension;                        				// width and height in cm
-     // get scintpoint coords relative to centre of cathode plane
-     TVector3 cathodeCentrePoint(plane_depth,fcathode_centre[1],fcathode_centre[2]);
-     TVector3 ScintPoint_relative = ScintPoint - cathodeCentrePoint;
-     // calculate solid angle of cathode from the scintillation point
-     double solid_angle_cathode = Rectangle_SolidAngle(cathode_plane, ScintPoint_relative);
-     // calculate distance and angle between ScintPoint and hotspot
-     // vast majority of hits in hotspot region directly infront of scintpoint,therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
-     double distance_cathode = std::abs(plane_depth - ScintPoint[0]);
-     double cosine_cathode = 1;
-     double theta_cathode = 0;
-     // calculate hits on cathode plane via geometric acceptance
-     double cathode_hits_geo = exp(-1.*distance_cathode/fL_abs_vuv) * (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
-     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
-     // offset angle bin
-     int j = (theta_cathode/fdelta_angulo);
-     double  pars_ini_[4] = {fGHvuvpars[0][j],
-                           fGHvuvpars[1][j],
-                           fGHvuvpars[2][j],
-                           fGHvuvpars[3][j]};
-     double GH_correction = Gaisser_Hillas(distance_cathode,pars_ini_);
-     double cathode_hits_rec = GH_correction*cathode_hits_geo/cosine_cathode;
+    // set cathode plane struct for solid angle function
+    acc cathode_plane;
+    cathode_plane.ax = plane_depth; cathode_plane.ay = fcathode_centre[1]; cathode_plane.az = fcathode_centre[2];       	// centre coordinates of cathode plane
+    cathode_plane.w = fcathode_ydimension; cathode_plane.h = fcathode_zdimension;                        				// width and height in cm
+    // get scintpoint coords relative to centre of cathode plane
+    TVector3 cathodeCentrePoint(plane_depth, fcathode_centre[1], fcathode_centre[2]);
+    TVector3 ScintPoint_relative = ScintPoint - cathodeCentrePoint;
+    // calculate solid angle of cathode from the scintillation point
+    double solid_angle_cathode = Rectangle_SolidAngle(cathode_plane, ScintPoint_relative);
+    // calculate distance and angle between ScintPoint and hotspot
+    // vast majority of hits in hotspot region directly infront of scintpoint,therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
+    double distance_cathode = std::abs(plane_depth - ScintPoint[0]);
+    double cosine_cathode = 1;
+    double theta_cathode = 0;
+    // calculate hits on cathode plane via geometric acceptance
+    double cathode_hits_geo = exp(-1.*distance_cathode / fL_abs_vuv) * (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
+    // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
+    // offset angle bin
+    int j = (theta_cathode / fdelta_angulo);
+    double  pars_ini_[4] = {fGHvuvpars[0][j],
+                            fGHvuvpars[1][j],
+                            fGHvuvpars[2][j],
+                            fGHvuvpars[3][j]
+                           };
+    double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini_);
+    double cathode_hits_rec = GH_correction * cathode_hits_geo / cosine_cathode;
 
-     // 2). calculate number of these hits which reach the optical detector from the hotspot via solid angle
-     // hotspot coordinates
-     TVector3 hotspot(plane_depth, ScintPoint[1], ScintPoint[2]);
+    // 2). calculate number of these hits which reach the optical detector from the hotspot via solid angle
+    // hotspot coordinates
+    TVector3 hotspot(plane_depth, ScintPoint[1], ScintPoint[2]);
 
-     // get hotspot coordinates relative to detpoint
-     TVector3 emission_relative = hotspot - OpDetPoint;
+    // get hotspot coordinates relative to detpoint
+    TVector3 emission_relative = hotspot - OpDetPoint;
 
-     // calculate solid angle of optical channel
-     double solid_angle_detector = 0;
-     // rectangular aperture
-     if (optical_detector_type == 0) {
-      	// set rectangular aperture geometry struct for solid angle function
-     	acc detPoint;
-     	detPoint.ax = OpDetPoint[0]; detPoint.ay = OpDetPoint[1]; detPoint.az = OpDetPoint[2];  	// centre coordinates of optical detector
-     	detPoint.w = fydimension; detPoint.h = fzdimension;	 						// width and height in cm of optical detector active window [rectangular aperture]
-	// calculate solid angle
-	solid_angle_detector = Rectangle_SolidAngle(detPoint, emission_relative);
-     }
-     // disk aperture
-     else if (optical_detector_type == 1) {
-	// offset in z-y plane
-      	double d = sqrt(pow(hotspot[1] - OpDetPoint[1],2) + pow(hotspot[2] - OpDetPoint[2],2));
-      	// drift distance (in x)
-      	double h =  sqrt(pow(hotspot[0] - OpDetPoint[0],2));
-	// calculate solid angle
-	solid_angle_detector = Disk_SolidAngle(d, h, fradius);
-     }
-     else {
-      std::cout << "Error: Invalid optical detector type. 0 = rectangular, 1 = disk" <<std::endl;
-     }
+    // calculate solid angle of optical channel
+    double solid_angle_detector = 0;
+    // rectangular aperture
+    if (optical_detector_type == 0) {
+      // set rectangular aperture geometry struct for solid angle function
+      acc detPoint;
+      detPoint.ax = OpDetPoint[0]; detPoint.ay = OpDetPoint[1]; detPoint.az = OpDetPoint[2];// centre coordinates of optical detector
+      detPoint.w = fydimension; detPoint.h = fzdimension; // width and height in cm of optical detector active window [rectangular aperture]
+      // calculate solid angle
+      solid_angle_detector = Rectangle_SolidAngle(detPoint, emission_relative);
+    }
+    // disk aperture
+    else if (optical_detector_type == 1) {
+      // offset in z-y plane
+      double d = sqrt(pow(hotspot[1] - OpDetPoint[1], 2) + pow(hotspot[2] - OpDetPoint[2], 2));
+      // drift distance (in x)
+      double h =  sqrt(pow(hotspot[0] - OpDetPoint[0], 2));
+      // calculate solid angle
+      solid_angle_detector = Disk_SolidAngle(d, h, fradius);
+    }
+    else {
+      std::cout << "Error: Invalid optical detector type. 0 = rectangular, 1 = disk" << std::endl;
+    }
 
-     // calculate number of hits via geometeric acceptance
-     double hits_geo = (solid_angle_detector / (2.*CLHEP::pi)) * cathode_hits_rec;	// 2*pi rather than 4*pi due to presence of reflective foils (vm2000)
+    // calculate number of hits via geometeric acceptance
+    double hits_geo = (solid_angle_detector / (2.*CLHEP::pi)) * cathode_hits_rec;	// 2*pi rather than 4*pi due to presence of reflective foils (vm2000)
 
-     // calculate distances and angles for application of corrections
-     // distance to hotspot
-     double distance_vuv = sqrt(pow(ScintPoint[0] - hotspot[0],2) + pow(ScintPoint[1] - hotspot[1],2) + pow(ScintPoint[2] - hotspot[2],2));
-     // distance from hotspot to optical detector
-     double distance_vis = sqrt(pow(hotspot[0] - OpDetPoint[0],2) + pow(hotspot[1] - OpDetPoint[1],2) + pow(hotspot[2] - OpDetPoint[2],2));
-     //  angle between hotspot and optical detector
-     double cosine_vis = sqrt(pow(hotspot[0] - OpDetPoint[0],2)) / distance_vis;
-     double theta_vis = acos(cosine_vis)*180./CLHEP::pi;
-     int k = (theta_vis/fdelta_angulo);
+    // calculate distances and angles for application of corrections
+    // distance to hotspot
+    double distance_vuv = sqrt(pow(ScintPoint[0] - hotspot[0], 2) + pow(ScintPoint[1] - hotspot[1], 2) + pow(ScintPoint[2] - hotspot[2], 2));
+    // distance from hotspot to optical detector
+    double distance_vis = sqrt(pow(hotspot[0] - OpDetPoint[0], 2) + pow(hotspot[1] - OpDetPoint[1], 2) + pow(hotspot[2] - OpDetPoint[2], 2));
+    //  angle between hotspot and optical detector
+    double cosine_vis = sqrt(pow(hotspot[0] - OpDetPoint[0], 2)) / distance_vis;
+    double theta_vis = acos(cosine_vis) * 180. / CLHEP::pi;
+    int k = (theta_vis / fdelta_angulo);
 
-     // apply geometric correction
-     double pars_ini_vis[6] = { fvispars[0][k], fvispars[1][k], fvispars[2][k], fvispars[3][k], fvispars[4][k], fvispars[5][k] };
-     double geo_correction = Pol_5(distance_vuv, pars_ini_vis);
-     double hits_rec = gRandom->Poisson(geo_correction*hits_geo/cosine_vis);
+    // apply geometric correction
+    double pars_ini_vis[6] = { fvispars[0][k], fvispars[1][k], fvispars[2][k], fvispars[3][k], fvispars[4][k], fvispars[5][k] };
+    double geo_correction = Pol_5(distance_vuv, pars_ini_vis);
+    double hits_rec = gRandom->Poisson(geo_correction * hits_geo / cosine_vis);
 
-     // apply border correction
-     int hits_vis = 0;
-     if (fApplyVisBorderCorrection){
-       // calculate distance for interpolation depending on model
-       double r = 0;
-       if (fVisBorderCorrectionType == "Radial"){
-         r = sqrt (pow(ScintPoint[1] - fcathode_centre[1],2) + pow (ScintPoint[2] - fcathode_centre[2],2));
-       }
-       else if (fVisBorderCorrectionType == "Vertical") {
-         r = std::abs(ScintPoint[1]);
-       }
-       else {
-         std::cout << "Invalid border correction type - defaulting to using central value" << std::endl;
-       }
-       // interpolate in x for each r bin
-       int nbins_r = fvis_border_correction[k].size();
-       std::vector<double> interp_vals(nbins_r, 0.0);
-       for (int i = 0; i < nbins_r; i++){
+    // apply border correction
+    int hits_vis = 0;
+    if (fApplyVisBorderCorrection) {
+      // calculate distance for interpolation depending on model
+      double r = 0;
+      if (fVisBorderCorrectionType == "Radial") {
+        r = sqrt (pow(ScintPoint[1] - fcathode_centre[1], 2) + pow (ScintPoint[2] - fcathode_centre[2], 2));
+      }
+      else if (fVisBorderCorrectionType == "Vertical") {
+        r = std::abs(ScintPoint[1]);
+      }
+      else {
+        std::cout << "Invalid border correction type - defaulting to using central value" << std::endl;
+      }
+      // interpolate in x for each r bin
+      int nbins_r = fvis_border_correction[k].size();
+      std::vector<double> interp_vals(nbins_r, 0.0);
+      for (int i = 0; i < nbins_r; i++) {
         interp_vals[i] = interpolate(fvis_border_distances_x, fvis_border_correction[k][i], std::abs(ScintPoint[0]), false);
-       }
-       // interpolate in r
-       double border_correction = interpolate(fvis_border_distances_r, interp_vals, r, false);
-       // apply border correction
-       double hits_rec_borders = border_correction * hits_rec / cosine_vis;
+      }
+      // interpolate in r
+      double border_correction = interpolate(fvis_border_distances_r, interp_vals, r, false);
+      // apply border correction
+      double hits_rec_borders = border_correction * hits_rec / cosine_vis;
 
-       // round final result
-       hits_vis = std::round(hits_rec_borders);
-     }
-     else {
-       // round final result
-       hits_vis = std::round(hits_rec);
-     }
+      // round final result
+      hits_vis = std::round(hits_rec_borders);
+    }
+    else {
+      // round final result
+      hits_vis = std::round(hits_rec);
+    }
 
-     return hits_vis;
+    return hits_vis;
   }
 
 
-  double finter_d(double *x, double *par) {
-
-    double y1 = par[2]*TMath::Landau(x[0],par[0],par[1]);
-    double y2 = TMath::Exp(par[3]+x[0]*par[4]);
-
+  double finter_d(double *x, double *par)
+  {
+    double y1 = par[2] * TMath::Landau(x[0], par[0], par[1]);
+    double y2 = TMath::Exp(par[3] + x[0] * par[4]);
     return TMath::Abs(y1 - y2);
   }
+
+
   double LandauPlusExpoFinal(double *x, double *par)
   {
     // par0 = joining point
@@ -1848,22 +1732,21 @@ namespace larg4{
     // par3 = normalization
     // par4 = Expo cte
     // par5 = Expo tau
-    double y1 = par[3]*TMath::Landau(x[0],par[1],par[2]);
-    double y2 = TMath::Exp(par[4]+x[0]*par[5]);
+    double y1 = par[3] * TMath::Landau(x[0], par[1], par[2]);
+    double y2 = TMath::Exp(par[4] + x[0] * par[5]);
     if(x[0] > par[0]) y1 = 0.;
     if(x[0] < par[0]) y2 = 0.;
-
     return (y1 + y2);
   }
 
 
-  double finter_r(double *x, double *par) {
-
-    double y1 = par[2]*TMath::Landau(x[0],par[0],par[1]);
-    double y2 = par[5]*TMath::Landau(x[0],par[3],par[4]);
-
+  double finter_r(double *x, double *par)
+  {
+    double y1 = par[2] * TMath::Landau(x[0], par[0], par[1]);
+    double y2 = par[5] * TMath::Landau(x[0], par[3], par[4]);
     return TMath::Abs(y1 - y2);
   }
+
 
   double model_close(double *x, double *par)
   {
@@ -1875,13 +1758,13 @@ namespace larg4{
     // par5 = Expo tau
     // par6 = t_min
 
-    double y1 = par[3]*TMath::Landau(x[0],par[1],par[2]);
-    double y2 = TMath::Exp(par[4]+x[0]*par[5]);
+    double y1 = par[3] * TMath::Landau(x[0], par[1], par[2]);
+    double y2 = TMath::Exp(par[4] + x[0] * par[5]);
     if(x[0] <= par[6] || x[0] > par[0]) y1 = 0.;
     if(x[0] < par[0]) y2 = 0.;
-
     return (y1 + y2);
   }
+
 
   double model_far(double *x, double *par)
   {
@@ -1889,62 +1772,62 @@ namespace larg4{
     // par2 = Landau width
     // par3 = normalization
     // par0 = t_min
-
-    double y = par[3]*TMath::Landau(x[0],par[1],par[2]);
+    double y = par[3] * TMath::Landau(x[0], par[1], par[2]);
     if(x[0] <= par[0]) y = 0.;
-
     return y;
   }
 
-  //======================================================================
 
+  //======================================================================
   //   Returns interpolated value at x from parallel arrays ( xData, yData )
   //   Assumes that xData has at least two elements, is sorted and is strictly monotonic increasing
   //   boolean argument extrapolate determines behaviour beyond ends of array (if needed)
-
   double interpolate( std::vector<double> &xData, std::vector<double> &yData, double x, bool extrapolate )
   {
     int size = xData.size();
     int i = 0;                                          // find left end of interval for interpolation
-    if ( x >= xData[size - 2] )                         // special case: beyond right end
-      {
-	i = size - 2;
-      }
-    else
-      {
-	while ( x > xData[i+1] ) i++;
-      }
-    double xL = xData[i], yL = yData[i], xR = xData[i+1], yR = yData[i+1]; // points on either side (unless beyond ends)
-    if ( !extrapolate )                                                    // if beyond ends of array and not extrapolating
-      {
-	if ( x < xL ) yR = yL;
-	if ( x > xR ) yL = yR;
-      }
+    if ( x >= xData[size - 2] ) {                       // special case: beyond right end
+      i = size - 2;
+    }
+    else {
+      while ( x > xData[i + 1] ) i++;
+    }
+    double xL = xData[i], yL = yData[i], xR = xData[i + 1], yR = yData[i + 1]; // points on either side (unless beyond ends)
+    if ( !extrapolate ) {                                                  // if beyond ends of array and not extrapolating
+      if ( x < xL ) yR = yL;
+      if ( x > xR ) yL = yR;
+    }
     double dydx = ( yR - yL ) / ( xR - xL );            // gradient
     return yL + dydx * ( x - xL );                      // linear interpolation
   }
 
+
   double* interpolate( std::vector<double> &xData, std::vector<double> &yData1, std::vector<double> &yData2,
-		       std::vector<double> &yData3, double x, bool extrapolate)
+                       std::vector<double> &yData3, double x, bool extrapolate)
   {
     int size = xData.size();
     int i = 0;                                          // find left end of interval for interpolation
-    if ( x >= xData[size - 2] )                         // special case: beyond right end
-      {
-	i = size - 2;
-      }
-    else
-      {
-	while ( x > xData[i+1] ) i++;
-      }
-    double xL = xData[i], xR = xData[i+1];// points on either side (unless beyond ends)
-    double yL1 = yData1[i], yR1 = yData1[i+1], yL2 = yData2[i], yR2 = yData2[i+1], yL3 = yData3[i], yR3 = yData3[i+1];
+    if ( x >= xData[size - 2] ) {                       // special case: beyond right end
+      i = size - 2;
+    }
+    else {
+      while ( x > xData[i + 1] ) i++;
+    }
+    double xL = xData[i], xR = xData[i + 1]; // points on either side (unless beyond ends)
+    double yL1 = yData1[i], yR1 = yData1[i + 1], yL2 = yData2[i], yR2 = yData2[i + 1], yL3 = yData3[i], yR3 = yData3[i + 1];
 
-    if ( !extrapolate )                                                    // if beyond ends of array and not extrapolating
-      {
-	if ( x < xL ) {yR1 = yL1; yR2 = yL2; yR3 = yL3;}
-	if ( x > xR ) {yL1 = yR1; yL2 = yR2; yL3 = yR3;}
+    if ( !extrapolate ) {                                                  // if beyond ends of array and not extrapolating
+      if ( x < xL ) {
+        yR1 = yL1;
+        yR2 = yL2;
+        yR3 = yL3;
       }
+      if ( x > xR ) {
+        yL1 = yR1;
+        yL2 = yR2;
+        yL3 = yR3;
+      }
+    }
     double dydx1 = ( yR1 - yL1 ) / ( xR - xL );            // gradient
     double dydx2 = ( yR2 - yL2 ) / ( xR - xL );
     double dydx3 = ( yR3 - yL3 ) / ( xR - xL );
@@ -1957,109 +1840,112 @@ namespace larg4{
     return yy;
   }
 
+
   // solid angle of circular aperture
-  double Disk_SolidAngle(double* x, double *p) {
+  double Disk_SolidAngle(double* x, double *p)
+  {
     const double d = x[0];
     const double h = x[1];
     const double b = p[0];
     if(b <= 0. || d < 0. || h <= 0.) return 0.;
-    const double aa = TMath::Sqrt(h*h/(h*h+(b+d)*(b+d)));
+    const double aa = TMath::Sqrt(h * h / (h * h + (b + d) * (b + d)));
     if(d == 0) {
-      return 2.*TMath::Pi()*(1.-aa);
+      return 2.*TMath::Pi() * (1. - aa);
     }
-    const double bb = TMath::Sqrt(4*b*d/(h*h+(b+d)*(b+d)));
-    const double cc = 4*b*d/((b+d)*(b+d));
+    const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
+    const double cc = 4 * b * d / ((b + d) * (b + d));
 
-    if(TMath::Abs(boost::math::ellint_1(bb) - bb) < 1e-10 && TMath::Abs(boost::math::ellint_3(cc,bb) - cc) <1e-10) {
+    if(TMath::Abs(boost::math::ellint_1(bb) - bb) < 1e-10 && TMath::Abs(boost::math::ellint_3(cc, bb) - cc) < 1e-10) {
       throw(std::runtime_error("Problem loading ELLIPTIC INTEGRALS running Disk_SolidAngle!"));
     }
     if(d < b) {
-     return 2.*TMath::Pi() - 2.*aa*(boost::math::ellint_1(bb) + TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc));
+      return 2.*TMath::Pi() - 2.*aa * (boost::math::ellint_1(bb) + TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc));
     }
     if(d == b) {
-      return TMath::Pi() - 2.*aa*boost::math::ellint_1(bb);
+      return TMath::Pi() - 2.*aa * boost::math::ellint_1(bb);
     }
     if(d > b) {
-      return 2.*aa*(TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc) - boost::math::ellint_1(bb));
+      return 2.*aa * (TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc) - boost::math::ellint_1(bb));
     }
     return 0.;
   }
 
-  double Disk_SolidAngle(double d, double h, double b) {
+
+  double Disk_SolidAngle(double d, double h, double b)
+  {
     double x[2] = { d, h };
     double p[1] = { b };
 
-    return Disk_SolidAngle(x,p);
-    }
-
-  // solid angle of rectanglular aperture
-
-  double Rectangle_SolidAngle(double a, double b, double d){
-
-    double aa = a/(2.0*d);
-    double bb = b/(2.0*d);
-    double aux = (1+aa*aa+bb*bb)/((1.+aa*aa)*(1.+bb*bb));
-    return 4*std::acos(std::sqrt(aux));
-
+    return Disk_SolidAngle(x, p);
   }
 
-  double Rectangle_SolidAngle(acc& out, TVector3 v){
 
+  // solid angle of rectanglular aperture
+  double Rectangle_SolidAngle(double a, double b, double d)
+  {
+    double aa = a / (2.0 * d);
+    double bb = b / (2.0 * d);
+    double aux = (1 + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
+    return 4 * std::acos(std::sqrt(aux));
+  }
+
+
+  double Rectangle_SolidAngle(acc& out, TVector3 v)
+  {
     //v is the position of the track segment with respect to
     //the center position of the arapuca window
 
     // arapuca plane fixed in x direction
-
-    if( v.Y()==0.0 && v.Z()==0.0){
-      return Rectangle_SolidAngle(out.w,out.h,v.X());
+    if( v.Y() == 0.0 && v.Z() == 0.0) {
+      return Rectangle_SolidAngle(out.w, out.h, v.X());
     }
 
-    if( (std::abs(v.Y()) > out.w/2.0) && (std::abs(v.Z()) > out.h/2.0)){
+    if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
       double A, B, a, b, d;
-      A = std::abs(v.Y())-out.w/2.0;
-      B = std::abs(v.Z())-out.h/2.0;
+      A = std::abs(v.Y()) - out.w / 2.0;
+      B = std::abs(v.Z()) - out.h / 2.0;
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2*(A+a),2*(B+b),d)-Rectangle_SolidAngle(2*A,2*(B+b),d)-Rectangle_SolidAngle(2*(A+a),2*B,d)+Rectangle_SolidAngle(2*A,2*B,d))/4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (B + b), d) - Rectangle_SolidAngle(2 * A, 2 * (B + b), d) - Rectangle_SolidAngle(2 * (A + a), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
-    if( (std::abs(v.Y()) <= out.w/2.0) && (std::abs(v.Z()) <= out.h/2.0)){
+    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
       double A, B, a, b, d;
-      A = -std::abs(v.Y())+out.w/2.0;
-      B = -std::abs(v.Z())+out.h/2.0;
+      A = -std::abs(v.Y()) + out.w / 2.0;
+      B = -std::abs(v.Z()) + out.h / 2.0;
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2*(a-A),2*(b-B),d)+Rectangle_SolidAngle(2*A,2*(b-B),d)+Rectangle_SolidAngle(2*(a-A),2*B,d)+Rectangle_SolidAngle(2*A,2*B,d))/4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) + Rectangle_SolidAngle(2 * A, 2 * (b - B), d) + Rectangle_SolidAngle(2 * (a - A), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
-    if( (std::abs(v.Y()) > out.w/2.0) && (std::abs(v.Z()) <= out.h/2.0)){
+    if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
       double A, B, a, b, d;
-      A = std::abs(v.Y())-out.w/2.0;
-      B = -std::abs(v.Z())+out.h/2.0;
+      A = std::abs(v.Y()) - out.w / 2.0;
+      B = -std::abs(v.Z()) + out.h / 2.0;
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2*(A+a),2*(b-B),d)-Rectangle_SolidAngle(2*A,2*(b-B),d)+Rectangle_SolidAngle(2*(A+a),2*B,d)-Rectangle_SolidAngle(2*A,2*B,d))/4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (b - B), d) - Rectangle_SolidAngle(2 * A, 2 * (b - B), d) + Rectangle_SolidAngle(2 * (A + a), 2 * B, d) - Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
 
-    if( (std::abs(v.Y()) <= out.w/2.0) && (std::abs(v.Z()) > out.h/2.0)){
+    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
       double A, B, a, b, d;
-      A = -std::abs(v.Y())+out.w/2.0;
-      B = std::abs(v.Z())-out.h/2.0;
+      A = -std::abs(v.Y()) + out.w / 2.0;
+      B = std::abs(v.Z()) - out.h / 2.0;
       a = out.w;
       b = out.h;
       d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2*(a-A),2*(B+b),d)-Rectangle_SolidAngle(2*(a-A),2*B,d)+Rectangle_SolidAngle(2*A,2*(B+b),d)-Rectangle_SolidAngle(2*A,2*B,d))/4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (B + b), d) - Rectangle_SolidAngle(2 * (a - A), 2 * B, d) + Rectangle_SolidAngle(2 * A, 2 * (B + b), d) - Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
     // error message if none of these cases, i.e. something has gone wrong!
     std::cout << "Warning: invalid solid angle call." << std::endl;
     return 0.0;
-    }
+  }
 
 }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1844,11 +1844,8 @@ namespace larg4 {
 
 
   // solid angle of circular aperture
-  double Disk_SolidAngle(double* x, double *p)
+  double Disk_SolidAngle(const double d, const double h, const double b)
   {
-    const double d = x[0];
-    const double h = x[1];
-    const double b = p[0];
     if(b <= 0. || d < 0. || h <= 0.) return 0.;
     const double aa = TMath::Sqrt(h * h / (h * h + (b + d) * (b + d)));
     if(d == 0) {
@@ -1867,15 +1864,6 @@ namespace larg4 {
       return 2.*aa * (TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc) - boost::math::ellint_1(bb));
     }
     return 0.;
-  }
-
-
-  double Disk_SolidAngle(double d, double h, double b)
-  {
-    double x[2] = { d, h };
-    double p[1] = { b };
-
-    return Disk_SolidAngle(x, p);
   }
 
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1567,7 +1567,7 @@ namespace larg4 {
     double distance_cathode = std::abs(plane_depth - ScintPoint[0]);
     // calculate hits on cathode plane via geometric acceptance
     double cathode_hits_geo = std::exp(-1.*distance_cathode / fL_abs_vuv) *
-      (solid_angle_cathode / (4.*CLHEP::pi)) * Num;
+      (solid_angle_cathode / (4.*CLHEP::pi)) * int(Num);
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
     // double theta_cathode = 0.;
@@ -1781,8 +1781,8 @@ namespace larg4 {
     //semi-analytic approach only works in the active volume
     if((ScintPoint[0] < fminx) || (ScintPoint[0] > fmaxx) ||
        (ScintPoint[1] < fminy) || (ScintPoint[1] > fmaxy) ||
-       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz) ||
-       (std::abs(ScintPoint[0]) <= fplane_depth)) {
+       (ScintPoint[2] < fminz) || (ScintPoint[2] > fmaxz)){
+       // (std::abs(ScintPoint[0]) <= fplane_depth)) {
       return false;
     }
     return true;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2017,7 +2017,7 @@ namespace larg4 {
 
   constexpr double fast_acos(double x) {
     double negate = double(x < 0);
-    x = abs(x);
+    x = std::abs(x);
     x -= double(x>1.0)*(x-1.0); // <- equivalent to min(1.0,x), but faster
     double ret = -0.0187293;
     ret = ret * x;
@@ -2026,7 +2026,7 @@ namespace larg4 {
     ret = ret - 0.2121144;
     ret = ret * x;
     ret = ret + 1.5707288;
-    ret = ret * sqrt(1.0-x);
+    ret = ret * std::sqrt(1.0-x);
     ret = ret - 2 * negate * ret;
     return negate * 3.14159265358979 + ret;
   }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1905,6 +1905,10 @@ namespace larg4 {
     const double bb = std::sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
+    if(isDefinitelyGreaterThan(d,b)) {
+      return 2.*aa*(std::sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) -
+                    boost::math::ellint_1(bb,noLDoublePromote()));
+    }
     if(isDefinitelyLessThan(d,b)) {
       return 2.* CLHEP::pi -
         2.*aa*(boost::math::ellint_1(bb, noLDoublePromote()) +
@@ -1912,10 +1916,6 @@ namespace larg4 {
     }
     if(isApproximatelyEqual(d,b)) {
       return CLHEP::pi - 2.*aa*boost::math::ellint_1(bb,noLDoublePromote());
-    }
-    if(isDefinitelyGreaterThan(d,b)) {
-      return 2.*aa*(std::sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) -
-                    boost::math::ellint_1(bb,noLDoublePromote()));
     }
     return 0.;
   }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1467,11 +1467,10 @@ namespace larg4 {
 
     // apply smearing:
     for (size_t i = 0; i < arrivalTimes.size(); i++) {
-      double arrival_time = arrivalTimes[i];
       double arrival_time_smeared;
-      // if time is already greater than cutoff or minimum smeared time would be greater than cutoff, do not apply smearing
-      if (arrival_time  >= cutoff) {
-        arrival_time_smeared = arrival_time;
+      // if time is already greater than cutoff, do not apply smearing
+      if (arrivalTimes[i]  >= cutoff) {
+        continue;
       }
       // otherwise smear
       else {
@@ -1479,16 +1478,16 @@ namespace larg4 {
         // loop until time generated is within cutoff limit
         // most are within single attempt, very few take more than two
         do {
-          // don't attempt smearings too many times for cases near cutoff (very few cases, not smearing these makes negigible difference)
+          // don't attempt smearings too many times
           if (counter >= 10) {
-            arrival_time_smeared = arrival_time; // don't smear
+            arrival_time_smeared = arrivalTimes[i]; // don't smear
             break;
           }
           else {
             // generate random number in appropriate range
             double x = gRandom->Uniform(0.5, 1.0);
             // apply the exponential smearing
-            arrival_time_smeared = arrival_time + (arrival_time-fastest_time)*(std::pow(x,-tau) -1);
+            arrival_time_smeared = arrivalTimes[i] + (arrivalTimes[i]-fastest_time)*(std::pow(x,-tau) -1);
           }
           // increment counter
           counter++;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1471,7 +1471,7 @@ namespace larg4 {
       double arrival_time = transport_time_vis[i];
       double arrival_time_smeared;
       // if time is already greater than cutoff or minimum smeared time would be greater than cutoff, do not apply smearing
-      if (arrival_time + (arrival_time - fastest_time) * (std::exp(-tau * std::log(1.0)) - 1) >= cutoff) {
+      if (arrival_time  >= cutoff) {
         arrival_time_smeared = arrival_time;
       }
       // otherwise smear
@@ -1489,7 +1489,7 @@ namespace larg4 {
             // generate random number in appropriate range
             double x = gRandom->Uniform(0.5, 1.0);
             // apply the exponential smearing
-            arrival_time_smeared = arrival_time + (arrival_time - fastest_time) * (std::exp(-tau * log(x)) - 1);
+            arrival_time_smeared = arrival_time + (arrival_time-fastest_time)*(std::pow(x,-tau) -1);
           }
           // increment counter
           counter++;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -140,6 +140,7 @@
 #include "TRandom3.h"
 #include "TMath.h"
 #include <cmath>
+#include <limits>
 
 #include "boost/math/special_functions/ellint_1.hpp"
 #include "boost/math/special_functions/ellint_3.hpp"
@@ -1854,14 +1855,14 @@ namespace larg4 {
     const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
-    if(d < b) {
       return 2.*TMath::Pi() - 2.*aa * (boost::math::ellint_1(bb) + TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc));
+    if(isDefinitelyLessThan(d,b)) {
     }
-    if(d == b) {
       return TMath::Pi() - 2.*aa * boost::math::ellint_1(bb);
+    if(isApproximatelyEqual(d,b)) {
     }
-    if(d > b) {
       return 2.*aa * (TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc) - boost::math::ellint_1(bb));
+    if(isDefinitelyGreaterThan(d,b)) {
     }
     return 0.;
   }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1522,7 +1522,6 @@ namespace larg4 {
 
     // calculate solid angle:
     double solid_angle = 0;
-    double d, h;
     // Arapucas
     if (optical_detector_type == 0) {
       // set Arapuca geometry struct for solid angle function
@@ -1541,7 +1540,7 @@ namespace larg4 {
       // offset in z-y plane
       double d = dist(&ScintPoint[1], &OpDetPoint[1], 2);
       // drift distance (in x)
-      h =  std::abs(ScintPoint[0] - OpDetPoint[0]);
+      double h =  std::abs(ScintPoint[0] - OpDetPoint[0]);
       // Solid angle of a disk
       solid_angle = Disk_SolidAngle(d, h, fradius);
     }
@@ -1634,13 +1633,12 @@ namespace larg4 {
     // hotspot coordinates
     TVector3 hotspot(plane_depth, ScintPoint[1], ScintPoint[2]);
 
-    // get hotspot coordinates relative to detpoint
-    TVector3 emission_relative = hotspot - OpDetPoint;
-
     // calculate solid angle of optical channel
     double solid_angle_detector = 0;
     // rectangular aperture
     if (optical_detector_type == 0) {
+      // get hotspot coordinates relative to detpoint
+      TVector3 emission_relative = hotspot - OpDetPoint;
       // set rectangular aperture geometry struct for solid angle function
       acc detPoint;
       detPoint.ax = OpDetPoint[0]; detPoint.ay = OpDetPoint[1]; detPoint.az = OpDetPoint[2];// centre coordinates of optical detector

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1459,8 +1459,7 @@ namespace larg4 {
 
     // calculate angle alpha between scintillation point and reflection point
     double cosine_alpha = std::abs(ScintPoint[0] - bounce_point[0]) / VUVdist;
-    // double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
-    double alpha = fast_acos(cosine_alpha) * 180. / CLHEP::pi;
+    double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
@@ -1607,8 +1606,7 @@ namespace larg4 {
     // distance and angle between ScintPoint and OpDetPoint
     double distance = dist(&ScintPoint[0], &OpDetPoint[0], 3);
     double cosine = std::abs(ScintPoint[0] - OpDetPoint[0]) / distance;
-    // double theta = std::acos(cosine) * 180. / CLHEP::pi;
-    double theta = fast_acos(cosine) * 180. / CLHEP::pi;
+    double theta = std::acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
     double solid_angle = 0;
@@ -1709,8 +1707,7 @@ namespace larg4 {
     double distance_vis = dist(&hotspot[0], &OpDetPoint[0], 3);
      //  angle between hotspot and optical detector
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
-    // double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
-    double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
+    double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
     const size_t k = (theta_vis / fdelta_angulo);
 
     // apply geometric correction

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1905,7 +1905,7 @@ namespace larg4 {
   {
     if(b <= 0. || d < 0. || h <= 0.) return 0.;
     const double aa = TMath::Sqrt(h * h / (h * h + (b + d) * (b + d)));
-    if(d == 0) {
+    if(isApproximatelyZero(d)) {
       return 2.*TMath::Pi() * (1. - aa);
     }
     const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
@@ -1944,7 +1944,8 @@ namespace larg4 {
     // the center position of the arapuca window
 
     // arapuca plane fixed in x direction
-    if( v.Y() == 0.0 && v.Z() == 0.0) {
+    if(isApproximatelyZero(v.Y()) &&
+       isApproximatelyZero(v.Z())) {
       return Rectangle_SolidAngle(out.w, out.h, v.X());// TODO: std::abs(v.X())?
     }
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2030,8 +2030,8 @@ namespace larg4 {
 
 
   // solid angle of rectangular aperture
-  constexpr double OpFastScintillation::Rectangle_SolidAngle(const double a, const double b,
-                                                             const double d)
+  double OpFastScintillation::Rectangle_SolidAngle(const double a, const double b,
+                                                   const double d)
   {
     double aa = a / (2. * d);
     double bb = b / (2. * d);
@@ -2042,8 +2042,8 @@ namespace larg4 {
 
 
   // TODO: allow greater tolerance in comparisons, see note above on Disk_SolidAngle()
-  constexpr double OpFastScintillation::Rectangle_SolidAngle(const dims o,
-                                                             const std::array<double, 3> v)
+  double OpFastScintillation::Rectangle_SolidAngle(const dims o,
+                                                   const std::array<double, 3> v)
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window
@@ -2109,7 +2109,7 @@ namespace larg4 {
   }
 
 
-  constexpr double fast_acos(double x) {
+  double fast_acos(double x) {
     double negate = double(x < 0);
     x = std::abs(x);
     x -= double(x>1.0)*(x-1.0); // <- equivalent to min(1.0,x), but faster

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1966,11 +1966,11 @@ namespace larg4 {
   constexpr double OpFastScintillation::Rectangle_SolidAngle(const double a, const double b,
                                                              const double d)
   {
-    double aa = a / (2.0 * d);
-    double bb = b / (2.0 * d);
-    double aux = (1 + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
+    double aa = a / (2. * d);
+    double bb = b / (2. * d);
+    double aux = (1. + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
     // return 4 * std::acos(std::sqrt(aux));
-    return 4 * fast_acos(std::sqrt(aux));
+    return 4. * fast_acos(std::sqrt(aux));
   }
 
 
@@ -1986,49 +1986,49 @@ namespace larg4 {
        isApproximatelyZero(v[2])) {
       return Rectangle_SolidAngle(o.h, o.w, v[0]);
     }
-    if(isDefinitelyGreaterThan(v[1], o.h/2.0) &&
-       isDefinitelyGreaterThan(v[2], o.w/2.0)) {
-      double A = v[1] - o.h / 2.0;
-      double B = v[2] - o.w / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (A + o.h), 2 * (B + o.w), v[0]) -
-                          Rectangle_SolidAngle(2 * A, 2 * (B + o.w), v[0]) -
-                          Rectangle_SolidAngle(2 * (A + o.h), 2 * B, v[0]) +
-                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
+    if(isDefinitelyGreaterThan(v[1], o.h/2.) &&
+       isDefinitelyGreaterThan(v[2], o.w/2.)) {
+      double A = v[1] - o.h/2.;
+      double B = v[2] - o.w/2.;
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), v[0]) -
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v[0]) -
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v[0]) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
       return to_return;
     }
-    if((v[1] <= o.h / 2.0) &&
-       (v[2] <= o.w / 2.0)) {
-      double A = -v[1] + o.h / 2.0;
-      double B = -v[2] + o.w / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (o.h - A), 2 * (o.w - B), v[0]) +
-                          Rectangle_SolidAngle(2 * A, 2 * (o.w - B), v[0]) +
-                          Rectangle_SolidAngle(2 * (o.h - A), 2 * B, v[0]) +
-                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
+    if((v[1] <= o.h/2.) &&
+       (v[2] <= o.w/2.)) {
+      double A = -v[1] + o.h/2.;
+      double B = -v[2] + o.w/2.;
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), v[0]) +
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v[0]) +
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v[0]) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
       return to_return;
     }
-    if(isDefinitelyGreaterThan(v[1], o.h/2.0) &&
-       (v[2] <= o.w / 2.0)) {
-      double A = v[1] - o.h / 2.0;
-      double B = -v[2] + o.w / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (A + o.h), 2 * (o.w - B), v[0]) -
-                          Rectangle_SolidAngle(2 * A, 2 * (o.w - B), v[0]) +
-                          Rectangle_SolidAngle(2 * (A + o.h), 2 * B, v[0]) -
-                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
+    if(isDefinitelyGreaterThan(v[1], o.h/2.) &&
+       (v[2] <= o.w/2.)) {
+      double A = v[1] - o.h/2.;
+      double B = -v[2] + o.w/2.;
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), v[0]) -
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v[0]) +
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v[0]) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
       return to_return;
     }
-    if((v[1] <= o.h / 2.0) &&
-       isDefinitelyGreaterThan(v[2], o.w/2.0)) {
-      double A = -v[1] + o.h / 2.0;
-      double B = v[2] - o.w / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (o.h - A), 2 * (B + o.w), v[0]) -
-                          Rectangle_SolidAngle(2 * (o.h - A), 2 * B, v[0]) +
-                          Rectangle_SolidAngle(2 * A, 2 * (B + o.w), v[0]) -
-                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
+    if((v[1] <= o.h/2.) &&
+       isDefinitelyGreaterThan(v[2], o.w/2.)) {
+      double A = -v[1] + o.h/2.;
+      double B = v[2] - o.w/2.;
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), v[0]) -
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v[0]) +
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v[0]) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
       return to_return;
     }
     // error message if none of these cases, i.e. something has gone wrong!
     // std::cout << "Warning: invalid solid angle call." << std::endl;
-    return 0.0;
+    return 0.;
   }
 
 
@@ -2054,7 +2054,7 @@ namespace larg4 {
     ret = ret * x;
     ret = ret + 1.5707288;
     ret = ret * std::sqrt(1.0-x);
-    ret = ret - 2 * negate * ret;
+    ret = ret - 2. * negate * ret;
     return negate * 3.14159265358979 + ret;
   }
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2014,4 +2014,21 @@ namespace larg4 {
     return acos_arr[std::round(acos_bins*x)];
   }
 
+
+  constexpr double fast_acos(double x) {
+    double negate = double(x < 0);
+    x = abs(x);
+    x -= double(x>1.0)*(x-1.0); // <- equivalent to min(1.0,x), but faster
+    double ret = -0.0187293;
+    ret = ret * x;
+    ret = ret + 0.0742610;
+    ret = ret * x;
+    ret = ret - 0.2121144;
+    ret = ret * x;
+    ret = ret + 1.5707288;
+    ret = ret * sqrt(1.0-x);
+    ret = ret - 2 * negate * ret;
+    return negate * 3.14159265358979 + ret;
+  }
+
 }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1934,68 +1934,58 @@ namespace larg4 {
   }
 
 
-  double OpFastScintillation::Rectangle_SolidAngle(dims out, TVector3 v)
+  // TODO: some potential gain could be achieved if using constexpr,
+  // but would need to change TVector to std::vector or std::array
+  double OpFastScintillation::Rectangle_SolidAngle(dims o, TVector3 v)
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window
-
+    v.SetXYZ(std::abs(v.X()), std::abs(v.Y()), std::abs(v.Z()));
     // arapuca plane fixed in x direction
     if(isApproximatelyZero(v.Y()) &&
        isApproximatelyZero(v.Z())) {
-      return Rectangle_SolidAngle(out.w, out.h, v.X());// TODO: std::abs(v.X())?
+      return Rectangle_SolidAngle(o.w, o.h, v.X());// TODO: std::abs(v.X())?
     }
 
     // TODO: shouldn't it be?
     // if ( (std::abs(v.Y()) > op.h / 2.0) && (std::abs(v.Z()) > op.w / 2.0)) {
-    if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
-      double A, B, a, b, d;
-      A = std::abs(v.Y()) - out.w / 2.0;
-      B = std::abs(v.Z()) - out.h / 2.0;
-      a = out.w;
-      b = out.h;
-      d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (B + b), d) -
-                          Rectangle_SolidAngle(2 * A, 2 * (B + b), d) -
-                          Rectangle_SolidAngle(2 * (A + a), 2 * B, d) +
+    if((v.Y() > o.w / 2.0) && (v.Z() > o.h / 2.0)) {
+      double A = v.Y() - o.w / 2.0;
+      double B = v.Z() - o.h / 2.0;
+      double d = v.X();
+      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (B + o.h), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), d) -
+                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, d) +
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
-    if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
-      double A, B, a, b, d;
-      A = std::abs(v.Y()) - out.w / 2.0;
-      B = -std::abs(v.Z()) + out.h / 2.0;
-      a = out.w;
-      b = out.h;
-      d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (A + a), 2 * (b - B), d) -
-                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
-                          Rectangle_SolidAngle(2 * (A + a), 2 * B, d) -
+    if((v.Y() > o.w / 2.0) && (v.Z() <= o.h / 2.0)) {
+      double A = v.Y() - o.w / 2.0;
+      double B = -v.Z() + o.h / 2.0;
+      double d = v.X();
+      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (o.h - B), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), d) +
+                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, d) -
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
-    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
-      double A, B, a, b, d;
-      A = -std::abs(v.Y()) + out.w / 2.0;
-      B = std::abs(v.Z()) - out.h / 2.0;
-      a = out.w;
-      b = out.h;
-      d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (B + b), d) -
-                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
-                          Rectangle_SolidAngle(2 * A, 2 * (B + b), d) -
+    if((v.Y() <= o.w / 2.0) && (v.Z() > o.h / 2.0)) {
+      double A = -v.Y() + o.w / 2.0;
+      double B = v.Z() - o.h / 2.0;
+      double d = v.X();
+      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (B + o.h), d) -
+                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, d) +
+                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), d) -
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
-    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
-      double A, B, a, b, d;
-      A = -std::abs(v.Y()) + out.w / 2.0;
-      B = -std::abs(v.Z()) + out.h / 2.0;
-      a = out.w;
-      b = out.h;
-      d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) +
-                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
-                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
+    if((v.Y() <= o.w / 2.0) && (v.Z() <= o.h / 2.0)) {
+      double A = -v.Y() + o.w / 2.0;
+      double B = -v.Z() + o.h / 2.0;
+      double d = v.X();
+      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (o.h - B), d) +
+                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), d) +
+                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, d) +
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1443,7 +1443,7 @@ namespace larg4 {
     double fastest_time = vis_time + vuv_time;
 
     // calculate angle alpha between scintillation point and reflection point
-    double cosine_alpha = std::sqrt(std::pow(ScintPoint[0] - bounce_point[0], 2)) / VUVdist;
+    double cosine_alpha = std::abs(ScintPoint[0] - bounce_point[0]) / VUVdist;
     double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
@@ -1521,7 +1521,7 @@ namespace larg4 {
     double distance = std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2) +
                                 std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
                                 std::pow(ScintPoint[2] - OpDetPoint[2], 2));
-    double cosine = std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2)) / distance;
+    double cosine = std::abs(ScintPoint[0] - OpDetPoint[0]) / distance;
     double theta = std::acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
@@ -1546,7 +1546,7 @@ namespace larg4 {
       d = std::sqrt(std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
                     std::pow(ScintPoint[2] - OpDetPoint[2], 2));
       // drift distance (in x)
-      h =  std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2));
+      h =  std::abs(ScintPoint[0] - OpDetPoint[0]);
       // Solid angle of a disk
       solid_angle = Disk_SolidAngle(d, h, fradius);
     }
@@ -1659,7 +1659,7 @@ namespace larg4 {
       double d = std::sqrt(std::pow(hotspot[1] - OpDetPoint[1], 2) +
                            std::pow(hotspot[2] - OpDetPoint[2], 2));
       // drift distance (in x)
-      double h =  std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2));
+      double h =  std::abs(hotspot[0] - OpDetPoint[0]);
       // calculate solid angle
       solid_angle_detector = Disk_SolidAngle(d, h, fradius);
     }
@@ -1679,8 +1679,8 @@ namespace larg4 {
     double distance_vis = std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2) +
                                     std::pow(hotspot[1] - OpDetPoint[1], 2) +
                                     std::pow(hotspot[2] - OpDetPoint[2], 2));
-    //  angle between hotspot and optical detector
-    double cosine_vis = std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2)) / distance_vis;
+     //  angle between hotspot and optical detector
+    double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
     double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
     int k = (theta_vis / fdelta_angulo);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -145,6 +145,12 @@
 #include "boost/math/special_functions/ellint_1.hpp"
 #include "boost/math/special_functions/ellint_3.hpp"
 
+// Define a new policy *not* internally promoting RealType to double:
+typedef boost::math::policies::policy<
+  // boost::math::policies::digits10<8>,
+  boost::math::policies::promote_double<false>
+  > noLDoublePromote;
+
 namespace larg4 {
 
   /////////////////////////
@@ -1846,14 +1852,14 @@ namespace larg4 {
     const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
-      return 2.*TMath::Pi() - 2.*aa * (boost::math::ellint_1(bb) + TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc));
     if(isDefinitelyLessThan(d,b)) {
+      return 2.*TMath::Pi() - 2.*aa*(boost::math::ellint_1(bb, noLDoublePromote()) + TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()));
     }
-      return TMath::Pi() - 2.*aa * boost::math::ellint_1(bb);
     if(isApproximatelyEqual(d,b)) {
+      return TMath::Pi() - 2.*aa*boost::math::ellint_1(bb,noLDoublePromote());
     }
-      return 2.*aa * (TMath::Sqrt(1. - cc) * boost::math::ellint_3(bb, cc) - boost::math::ellint_1(bb));
     if(isDefinitelyGreaterThan(d,b)) {
+      return 2.*aa*(TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) - boost::math::ellint_1(bb,noLDoublePromote()));
     }
     return 0.;
   }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -333,6 +333,8 @@ namespace larg4 {
           fcathode_centre[1] = (fmaxy + fminy) / 2; fcathode_centre[2] = (fmaxz + fminz) / 2; // to get full cathode dimension rather than just single tpc
           fcathode_ydimension = fmaxy - fminy;
           fcathode_zdimension = fmaxz - fminz;
+          // set cathode plane struct for solid angle function
+          cathode_plane.w = fcathode_ydimension; cathode_plane.h = fcathode_zdimension;
           fplane_depth = std::abs(fcathode_centre[0]);
         }
         else fStoreReflected = false;
@@ -769,6 +771,8 @@ namespace larg4 {
                                 fOpDetCenter.at(OpDet)[2]);
             fydimension = fOpDetLength.at(OpDet);
             fzdimension = fOpDetHeight.at(OpDet);
+            // set detector struct for solid angle function
+            detPoint.w = fydimension; detPoint.h = fzdimension;
             DetThisPMT = VUVHits(Num, ScintPoint, OpDetPoint, fOpDetType.at(OpDet));
           }
 
@@ -1545,14 +1549,8 @@ namespace larg4 {
     double solid_angle = 0;
     // Arapucas
     if (optical_detector_type == 0) {
-      // set Arapuca geometry struct for solid angle function
-      acc detPoint;
-      detPoint.ax = OpDetPoint[0]; detPoint.ay = OpDetPoint[1]; detPoint.az = OpDetPoint[2];  // centre coordinates of optical detector
-      detPoint.w = fydimension; detPoint.h = fzdimension; // width and height in cm of arapuca active window
-
       // get scintillation point coordinates relative to arapuca window centre
       TVector3 ScintPoint_rel = ScintPoint - OpDetPoint;
-
       // calculate solid angle
       solid_angle = Rectangle_SolidAngle(detPoint, ScintPoint_rel);
     }
@@ -1623,11 +1621,6 @@ namespace larg4 {
     }
 
     // 1). calculate total number of hits of VUV photons on reflective foils via solid angle + Gaisser-Hillas corrections:
-
-    // set cathode plane struct for solid angle function
-    acc cathode_plane;
-    cathode_plane.ax = plane_depth; cathode_plane.ay = fcathode_centre[1]; cathode_plane.az = fcathode_centre[2];       	// centre coordinates of cathode plane
-    cathode_plane.w = fcathode_ydimension; cathode_plane.h = fcathode_zdimension;                        				// width and height in cm
     // get scintpoint coords relative to centre of cathode plane
     TVector3 cathodeCentrePoint(plane_depth, fcathode_centre[1], fcathode_centre[2]);
     TVector3 ScintPoint_relative = ScintPoint - cathodeCentrePoint;
@@ -1662,10 +1655,6 @@ namespace larg4 {
     if (optical_detector_type == 0) {
       // get hotspot coordinates relative to detpoint
       TVector3 emission_relative = hotspot - OpDetPoint;
-      // set rectangular aperture geometry struct for solid angle function
-      acc detPoint;
-      detPoint.ax = OpDetPoint[0]; detPoint.ay = OpDetPoint[1]; detPoint.az = OpDetPoint[2];// centre coordinates of optical detector
-      detPoint.w = fydimension; detPoint.h = fzdimension; // width and height in cm of optical detector active window [rectangular aperture]
       // calculate solid angle
       solid_angle_detector = Rectangle_SolidAngle(detPoint, emission_relative);
     }
@@ -1938,7 +1927,7 @@ namespace larg4 {
   }
 
 
-  double OpFastScintillation::Rectangle_SolidAngle(acc& out, TVector3 v)
+  double OpFastScintillation::Rectangle_SolidAngle(dims out, TVector3 v)
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1459,7 +1459,8 @@ namespace larg4 {
 
     // calculate angle alpha between scintillation point and reflection point
     double cosine_alpha = std::abs(ScintPoint[0] - bounce_point[0]) / VUVdist;
-    double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
+    // double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
+    double alpha = fast_acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
@@ -1606,7 +1607,8 @@ namespace larg4 {
     // distance and angle between ScintPoint and OpDetPoint
     double distance = dist(&ScintPoint[0], &OpDetPoint[0], 3);
     double cosine = std::abs(ScintPoint[0] - OpDetPoint[0]) / distance;
-    double theta = std::acos(cosine) * 180. / CLHEP::pi;
+    // double theta = std::acos(cosine) * 180. / CLHEP::pi;
+    double theta = fast_acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
     double solid_angle = 0;
@@ -1707,7 +1709,8 @@ namespace larg4 {
     double distance_vis = dist(&hotspot[0], &OpDetPoint[0], 3);
      //  angle between hotspot and optical detector
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
-    double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
+    // double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
+    double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
     const size_t k = (theta_vis / fdelta_angulo);
 
     // apply geometric correction

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -294,8 +294,8 @@ namespace larg4 {
 
         fYcathode = Cathode_centre.Y();
         fZcathode = Cathode_centre.Z();
-        fReference_to_corner = std::sqrt(std::pow(fYactive_corner, 2) +
-                                         std::pow(fZactive_corner, 2));
+        fReference_to_corner = std::sqrt(fYactive_corner*fYactive_corner +
+                                         fZactive_corner*fZactive_corner);
 
         std::cout << "For border corrections: " << fborder_corr[0] << "  " << fborder_corr[1] << std::endl;
         std::cout << "Photocathode-plane centre (z,y) = (" << fZcathode << ", " << fYcathode << ") and corner (z, y) = (" << fZactive_corner << ", " << fYactive_corner << ")" << std::endl;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1106,7 +1106,7 @@ namespace larg4 {
   }
 
 
-  G4double OpFastScintillation::sample_time(G4double tau1, G4double tau2) const
+  G4double OpFastScintillation::sample_time(const G4double tau1, const G4double tau2) const
   {
     // tau1: rise time and tau2: decay time
     while(1) {
@@ -1731,20 +1731,22 @@ namespace larg4 {
   }
 
 
-  G4double OpFastScintillation::single_exp(G4double t, G4double tau2) const
+  constexpr G4double OpFastScintillation::single_exp(const G4double t, const G4double tau2) const
   {
     return std::exp(-1.0 * t / tau2) / tau2;
   }
 
 
-  G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
+  constexpr G4double OpFastScintillation::bi_exp(const G4double t, const G4double tau1,
+                                                 const G4double tau2) const
   {// TODO: what's up with this? ... / tau2 / tau2 ...
     return std::exp(-1.0 * t / tau2) *
       (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
   }
 
 
-  G4double OpFastScintillation::Gaisser_Hillas(double x, double *par)
+  constexpr G4double OpFastScintillation::Gaisser_Hillas(const double x,
+                                                         const double *par)
   {
     double X_mu_0 = par[3];
     double Normalization = par[0];
@@ -1755,7 +1757,7 @@ namespace larg4 {
   }
 
 
-  double OpFastScintillation::Pol_5(double x, double *par)
+  constexpr double OpFastScintillation::Pol_5(const double x, double *par)
   {
     // 5th order polynomial function
     double xpow = 1.;
@@ -1921,7 +1923,8 @@ namespace larg4 {
 
   // solid angle of rectangular aperture
   // TODO: what's up with all of that times 2, divided by 2?
-  double OpFastScintillation::Rectangle_SolidAngle(double a, double b, double d)
+  constexpr double OpFastScintillation::Rectangle_SolidAngle(const double a, const double b,
+                                                             const double d)
   {
     double aa = a / (2.0 * d);
     double bb = b / (2.0 * d);

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -297,7 +297,7 @@ namespace larg4 {
         // Load Gaisser-Hillas corrections for VUV semi-analytic hits
         std::cout << "Loading the GH corrections" << std::endl;
         pvs->LoadGHForVUVCorrection(fGHvuvpars, fborder_corr, fradius);
-        fdelta_angulo = 10.; // angle bin size
+        fdelta_angulo = 10; // angle bin size
         //Needed for Nhits-model border corrections (in cm)
         fYactive_corner = (fmaxy - fminy) / 2;
         fZactive_corner = (fmaxz - fminz) / 2;
@@ -331,7 +331,7 @@ namespace larg4 {
 
           // cathode dimensions required for corrections
           fcathode_centre = geo->TPC(0, 0).GetCathodeCenter();
-          fcathode_centre[1] = (fmaxy + fminy) / 2; fcathode_centre[2] = (fmaxz + fminz) / 2; // to get full cathode dimension rather than just single tpc
+          fcathode_centre[1] = (fmaxy + fminy) / 2.; fcathode_centre[2] = (fmaxz + fminz) / 2.; // to get full cathode dimension rather than just single tpc
           fcathode_ydimension = fmaxy - fminy;
           fcathode_zdimension = fmaxz - fminz;
           // set cathode plane struct for solid angle function
@@ -805,7 +805,7 @@ namespace larg4 {
       }
 
       for(size_t OpDet = 0; OpDet != NOpChannels; ++OpDet) {
-        G4int DetThisPMT = 0.;
+        G4int DetThisPMT = 0;
         if(Visibilities && !pvs->UseNhitsModel()) {
           DetThisPMT = G4int(G4Poisson(Visibilities[OpDet] * Num));
         }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1518,9 +1518,7 @@ namespace larg4 {
     }
 
     // distance and angle between ScintPoint and OpDetPoint
-    double distance = std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2) +
-                                std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
-                                std::pow(ScintPoint[2] - OpDetPoint[2], 2));
+    double distance = dist(&ScintPoint[0], &OpDetPoint[0], 3);
     double cosine = std::abs(ScintPoint[0] - OpDetPoint[0]) / distance;
     double theta = std::acos(cosine) * 180. / CLHEP::pi;
 
@@ -1543,8 +1541,7 @@ namespace larg4 {
     // PMTs
     else if (optical_detector_type == 1) {
       // offset in z-y plane
-      d = std::sqrt(std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
-                    std::pow(ScintPoint[2] - OpDetPoint[2], 2));
+      double d = dist(&ScintPoint[1], &OpDetPoint[1], 2);
       // drift distance (in x)
       h =  std::abs(ScintPoint[0] - OpDetPoint[0]);
       // Solid angle of a disk
@@ -1656,8 +1653,7 @@ namespace larg4 {
     // disk aperture
     else if (optical_detector_type == 1) {
       // offset in z-y plane
-      double d = std::sqrt(std::pow(hotspot[1] - OpDetPoint[1], 2) +
-                           std::pow(hotspot[2] - OpDetPoint[2], 2));
+      double d = dist(&hotspot[1], &OpDetPoint[1], 2);
       // drift distance (in x)
       double h =  std::abs(hotspot[0] - OpDetPoint[0]);
       // calculate solid angle
@@ -1672,13 +1668,9 @@ namespace larg4 {
 
     // calculate distances and angles for application of corrections
     // distance to hotspot
-    double distance_vuv = std::sqrt(std::pow(ScintPoint[0] - hotspot[0], 2) +
-                                    std::pow(ScintPoint[1] - hotspot[1], 2) +
-                                    std::pow(ScintPoint[2] - hotspot[2], 2));
+    double distance_vuv = dist(&ScintPoint[0], &hotspot[0], 3);
     // distance from hotspot to optical detector
-    double distance_vis = std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2) +
-                                    std::pow(hotspot[1] - OpDetPoint[1], 2) +
-                                    std::pow(hotspot[2] - OpDetPoint[2], 2));
+    double distance_vis = dist(&hotspot[0], &OpDetPoint[0], 3);
      //  angle between hotspot and optical detector
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
     double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
@@ -1695,8 +1687,7 @@ namespace larg4 {
       // calculate distance for interpolation depending on model
       double r = 0;
       if (fVisBorderCorrectionType == "Radial") {
-        r = std::sqrt(std::pow(ScintPoint[1] - fcathode_centre[1], 2) +
-                      std::pow (ScintPoint[2] - fcathode_centre[2], 2));
+        r = dist(&ScintPoint[1], &fcathode_centre[1], 2);
       }
       else if (fVisBorderCorrectionType == "Vertical") {
         r = std::abs(ScintPoint[1]);

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1895,26 +1895,26 @@ namespace larg4 {
 
 
   // solid angle of circular aperture
-  double OpFastScintillation::Disk_SolidAngle(const double d, const double h, const double b)
+  constexpr double OpFastScintillation::Disk_SolidAngle(const double d, const double h, const double b)
   {
     if(b <= 0. || d < 0. || h <= 0.) return 0.;
-    const double aa = TMath::Sqrt(h * h / (h * h + (b + d) * (b + d)));
+    const double aa = std::sqrt(h * h / (h * h + (b + d) * (b + d)));
     if(isApproximatelyZero(d)) {
-      return 2.*TMath::Pi() * (1. - aa);
+      return 2. * CLHEP::pi * (1. - aa);
     }
-    const double bb = TMath::Sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
+    const double bb = std::sqrt(4 * b * d / (h * h + (b + d) * (b + d)));
     const double cc = 4 * b * d / ((b + d) * (b + d));
 
     if(isDefinitelyLessThan(d,b)) {
-      return 2.*TMath::Pi() -
+      return 2.* CLHEP::pi -
         2.*aa*(boost::math::ellint_1(bb, noLDoublePromote()) +
-               TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()));
+               std::sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()));
     }
     if(isApproximatelyEqual(d,b)) {
-      return TMath::Pi() - 2.*aa*boost::math::ellint_1(bb,noLDoublePromote());
+      return CLHEP::pi - 2.*aa*boost::math::ellint_1(bb,noLDoublePromote());
     }
     if(isDefinitelyGreaterThan(d,b)) {
-      return 2.*aa*(TMath::Sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) -
+      return 2.*aa*(std::sqrt(1.-cc)*boost::math::ellint_3(bb,cc,noLDoublePromote()) -
                     boost::math::ellint_1(bb,noLDoublePromote()));
     }
     return 0.;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -292,7 +292,7 @@ namespace larg4 {
           x_v.push_back(elem.first);
           y_v.push_back(elem.second);
         }
-        fL_abs_vuv =  interpolate(x_v, y_v, 9.7, false);// TODO: unhardcode //TODO: unsafe casting double to int
+        fL_abs_vuv =  std::round(interpolate(x_v, y_v, 9.7, false));// 9.7 eV: peak of VUV emission spectrum
 
         // Load Gaisser-Hillas corrections for VUV semi-analytic hits
         std::cout << "Loading the GH corrections" << std::endl;
@@ -856,7 +856,7 @@ namespace larg4 {
 
               float PhotonEnergy = 0;
               if (Reflected)  PhotonEnergy = reemission_energy() * CLHEP::eV;
-              else            PhotonEnergy = 9.7 * CLHEP::eV;// TODO: unhardcode
+              else            PhotonEnergy = 9.7 * CLHEP::eV;// 9.7 eV peak of VUV emission spectrum
 
               // Make a photon object for the collection
               sim::OnePhoton PhotToAdd;
@@ -1345,7 +1345,6 @@ namespace larg4 {
 
     // calculate max and min distance relevant to sample parameterisation
     // max
-    // TODO: array instead of pointer? why this?
     const size_t nq_max = 1;
     double xq_max[nq_max];
     double yq_max[nq_max];
@@ -1640,7 +1639,7 @@ namespace larg4 {
 
     // apply Gaisser-Hillas correction for Rayleigh scattering distance
     // and angular dependence offset angle bin
-    const size_t j = (theta / fdelta_angulo);// TODO:: std::round?
+    const size_t j = (theta / fdelta_angulo);
 
     //Accounting for border effects
     double z_to_corner = std::abs(ScintPoint[2] - fZactive_corner) - fZactive_corner;
@@ -1712,7 +1711,7 @@ namespace larg4 {
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
     // double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
     double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
-    const size_t k = (theta_vis / fdelta_angulo);// TODO:: std::round?
+    const size_t k = (theta_vis / fdelta_angulo);
 
     // apply geometric correction
     double pars_ini_vis[6] = {fvispars[0][k], fvispars[1][k], fvispars[2][k],

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2001,7 +2001,6 @@ namespace larg4 {
 
 
   // solid angle of rectangular aperture
-  // TODO: what's up with all of that times 2, divided by 2?
   constexpr double OpFastScintillation::Rectangle_SolidAngle(const double a, const double b,
                                                              const double d)
   {
@@ -2025,44 +2024,44 @@ namespace larg4 {
        isApproximatelyZero(v[2])) {
       return Rectangle_SolidAngle(o.h, o.w, v[0]);
     }
-    if(isDefinitelyGreaterThan(v[1], o.h/2.) &&
-       isDefinitelyGreaterThan(v[2], o.w/2.)) {
-      double A = v[1] - o.h/2.;
-      double B = v[2] - o.w/2.;
+    if(isDefinitelyGreaterThan(v[1], o.h*.5) &&
+       isDefinitelyGreaterThan(v[2], o.w*.5)) {
+      double A = v[1] - o.h*.5;
+      double B = v[2] - o.w*.5;
       double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), v[0]) -
                           Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v[0]) -
                           Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v[0]) +
-                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) * .25;
       return to_return;
     }
-    if((v[1] <= o.h/2.) &&
-       (v[2] <= o.w/2.)) {
-      double A = -v[1] + o.h/2.;
-      double B = -v[2] + o.w/2.;
+    if((v[1] <= o.h*.5) &&
+       (v[2] <= o.w*.5)) {
+      double A = -v[1] + o.h*.5;
+      double B = -v[2] + o.w*.5;
       double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), v[0]) +
                           Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v[0]) +
                           Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v[0]) +
-                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) * .25;
       return to_return;
     }
-    if(isDefinitelyGreaterThan(v[1], o.h/2.) &&
-       (v[2] <= o.w/2.)) {
-      double A = v[1] - o.h/2.;
-      double B = -v[2] + o.w/2.;
+    if(isDefinitelyGreaterThan(v[1], o.h*.5) &&
+       (v[2] <= o.w*.5)) {
+      double A = v[1] - o.h*.5;
+      double B = -v[2] + o.w*.5;
       double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), v[0]) -
                           Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v[0]) +
                           Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v[0]) -
-                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) * .25;
       return to_return;
     }
-    if((v[1] <= o.h/2.) &&
-       isDefinitelyGreaterThan(v[2], o.w/2.)) {
-      double A = -v[1] + o.h/2.;
-      double B = v[2] - o.w/2.;
+    if((v[1] <= o.h*.5) &&
+       isDefinitelyGreaterThan(v[2], o.w*.5)) {
+      double A = -v[1] + o.h*.5;
+      double B = v[2] - o.w*.5;
       double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), v[0]) -
                           Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v[0]) +
                           Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v[0]) -
-                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) / 4.;
+                          Rectangle_SolidAngle(2. * A, 2. * B, v[0])) * .25;
       return to_return;
     }
     // error message if none of these cases, i.e. something has gone wrong!

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1939,8 +1939,6 @@ namespace larg4 {
   }
 
 
-  // TODO: some potential gain could be achieved if using constexpr,
-  // but would need to change TVector to std::vector or std::array
   double OpFastScintillation::Rectangle_SolidAngle(const dims o, const std::array<double, 3> v)
   {
     // v is the position of the track segment with respect to
@@ -1954,43 +1952,39 @@ namespace larg4 {
     // TODO: shouldn't it be?
     // if ( (std::abs(v[1]) > op.h / 2.0) && (std::abs(v[2]) > op.w / 2.0)) {
     if((v[1] > o.w / 2.0) && (v[2] > o.h / 2.0)) {
-      double d = v[0];
       double A = v[1] - o.w / 2.0;
       double B = v[2] - o.h / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (B + o.h), d) -
-                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), d) -
-                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, d) +
-                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (B + o.h), v[0]) -
+                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), v[0]) -
+                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, v[0]) +
+                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
       return to_return;
     }
     if((v[1] > o.w / 2.0) && (v[2] <= o.h / 2.0)) {
-      double d = v[0];
       double A = v[1] - o.w / 2.0;
       double B = -v[2] + o.h / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (o.h - B), d) -
-                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), d) +
-                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, d) -
-                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (A + o.w), 2 * (o.h - B), v[0]) -
+                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), v[0]) +
+                          Rectangle_SolidAngle(2 * (A + o.w), 2 * B, v[0]) -
+                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
       return to_return;
     }
     if((v[1] <= o.w / 2.0) && (v[2] > o.h / 2.0)) {
-      double d = v[0];
       double A = -v[1] + o.w / 2.0;
       double B = v[2] - o.h / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (B + o.h), d) -
-                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, d) +
-                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), d) -
-                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (B + o.h), v[0]) -
+                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, v[0]) +
+                          Rectangle_SolidAngle(2 * A, 2 * (B + o.h), v[0]) -
+                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
       return to_return;
     }
     if((v[1] <= o.w / 2.0) && (v[2] <= o.h / 2.0)) {
-      double d = v[0];
       double A = -v[1] + o.w / 2.0;
       double B = -v[2] + o.h / 2.0;
-      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (o.h - B), d) +
-                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), d) +
-                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, d) +
-                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      double to_return = (Rectangle_SolidAngle(2 * (o.w - A), 2 * (o.h - B), v[0]) +
+                          Rectangle_SolidAngle(2 * A, 2 * (o.h - B), v[0]) +
+                          Rectangle_SolidAngle(2 * (o.w - A), 2 * B, v[0]) +
+                          Rectangle_SolidAngle(2 * A, 2 * B, v[0])) / 4.0;
       return to_return;
     }
     // error message if none of these cases, i.e. something has gone wrong!

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -173,7 +173,7 @@ namespace larg4 {
     : G4VRestDiscreteProcess(processName, type)
     , bPropagate(!(art::ServiceHandle<sim::LArG4Parameters const>()->NoPhotonPropagation()))
   {
-    SetProcessSubType(25);
+    SetProcessSubType(25); // TODO: unhardcode
     fTrackSecondariesFirst = false;
     fFiniteRiseTime = false;
     YieldFactor = 1.0;
@@ -264,7 +264,7 @@ namespace larg4 {
 
         // create vector of empty TF1s that will be replaces with the parameterisations that are generated as they are required
         // default TF1() constructor gives function with 0 dimensions, can then check numDim to qucikly see if a parameterisation has been generated
-        const size_t num_params = (fmax_d - 25) / fstep_size;  // for d < 25cm, no parameterisaton, a delta function is used instead
+        const size_t num_params = (fmax_d - 25) / fstep_size;  // for d < 25cm, no parameterisaton, a delta function is used instead // TODO: unhardcode
         std::vector<TF1> VUV_timing_temp(num_params, TF1());
         VUV_timing = VUV_timing_temp;
 
@@ -291,7 +291,7 @@ namespace larg4 {
           x_v.push_back(elem.first);
           y_v.push_back(elem.second);
         }
-        fL_abs_vuv =  interpolate(x_v, y_v, 9.7, false);
+        fL_abs_vuv =  interpolate(x_v, y_v, 9.7, false);// TODO: unhardcode //TODO: unsafe casting double to int
 
         // Load Gaisser-Hillas corrections for VUV semi-analytic hits
         std::cout << "Loading the GH corrections" << std::endl;
@@ -862,7 +862,7 @@ namespace larg4 {
 
                 float PhotonEnergy = 0;
                 if (Reflected)  PhotonEnergy = reemission_energy() * CLHEP::eV;
-                else            PhotonEnergy = 9.7 * CLHEP::eV;
+                else            PhotonEnergy = 9.7 * CLHEP::eV;// TODO: unhardcode
 
                 // Make a photon object for the collection
                 sim::OnePhoton PhotToAdd;
@@ -1284,10 +1284,10 @@ namespace larg4 {
   void OpFastScintillation::generateParam(const size_t index)
   {
     // get distance
-    double distance_in_cm = (index * fstep_size) + 25;
+    double distance_in_cm = (index * fstep_size) + 25;// TODO: unhardcode
 
     // time range
-    const double signal_t_range = 5000.;
+    const double signal_t_range = 5000.;// TODO: unhardcode
 
     // parameterisation TF1
     TF1 fVUVTiming;
@@ -1344,7 +1344,7 @@ namespace larg4 {
 
     // set the number of points used to sample parameterisation
     // for shorter distances, peak is sharper so more sensitive sampling required
-    int fsampling;
+    int fsampling;// TODO: unhardcode
     if (distance_in_cm < 50) {fsampling = 10000;}
     else if (distance_in_cm < 100) {fsampling = 5000;}
     else {fsampling = 1000;}
@@ -1352,6 +1352,7 @@ namespace larg4 {
 
     // calculate max and min distance relevant to sample parameterisation
     // max
+    // TODO: array instead of pointer? why this?
     const size_t nq_max = 1;
     double xq_max[nq_max];
     double yq_max[nq_max];
@@ -1374,7 +1375,7 @@ namespace larg4 {
   // VUV arrival times calculation function
   void OpFastScintillation::getVUVTimes(std::vector<double>& arrivalTimes, double distance)
   {
-    if (distance < 25) {
+    if (distance < 25) {// TODO: unhardcode
       // times are fixed shift i.e. direct path only
       double t_prop_correction = distance / fvuv_vgroup_mean;
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
@@ -1383,7 +1384,7 @@ namespace larg4 {
     }
     else { // distance >= 25cm
       // determine nearest parameterisation in discretisation
-      int index = std::round((distance - 25) / fstep_size);
+      int index = std::round((distance - 25) / fstep_size);// TODO: unhardcode
       // check whether required parameterisation has been generated, generating if not
       if (VUV_timing[index].GetNdim() == 0) {
         generateParam(index);
@@ -1452,12 +1453,12 @@ namespace larg4 {
     double vis_time = Visdist / fvis_vmean;
     // vuv part
     double vuv_time;
-    if (VUVdist < 25) {
+    if (VUVdist < 25) {// TODO: unhardcode
       vuv_time = VUVdist / fvuv_vgroup_mean;
     }
     else {
       // find index of required parameterisation
-      const size_t index = std::round((VUVdist - 25) / fstep_size);
+      const size_t index = std::round((VUVdist - 25) / fstep_size);// TODO: unhardcode
       // find shortest time
       vuv_time = VUV_min[index];
     }
@@ -1474,7 +1475,7 @@ namespace larg4 {
     //     times caused by exponential distance to cathode
     double distance_cathode_plane = std::abs(plane_depth - ScintPoint[0]);
     // angular bin
-    size_t alpha_bin = alpha / 10;
+    size_t alpha_bin = alpha / 10;// TODO: unhardcode
     if (alpha_bin >= ftau_pars.size()) {
       alpha_bin = ftau_pars.size() - 1;      // default to the largest available bin if alpha larger than parameterised region; i.e. last bin effectively [last bin start value, 90] deg bin
     }
@@ -1499,13 +1500,13 @@ namespace larg4 {
         // most are within single attempt, very few take more than two
         do {
           // don't attempt smearings too many times
-          if (counter >= 10) {
+          if (counter >= 10) {// TODO: unhardcode
             arrival_time_smeared = arrivalTimes[i]; // don't smear
             break;
           }
           else {
             // generate random number in appropriate range
-            double x = gRandom->Uniform(0.5, 1.0);
+            double x = gRandom->Uniform(0.5, 1.0);// TODO: unhardcode
             // apply the exponential smearing
             arrival_time_smeared = arrivalTimes[i] +
               (arrivalTimes[i] - fastest_time)*(std::pow(x,-tau) - 1);
@@ -1525,7 +1526,7 @@ namespace larg4 {
     // check optical channel is in same TPC as scintillation light, if not return 0 hits
     // temporary method working for SBND, uBooNE, DUNE 1x2x6; to be replaced to work in full DUNE geometry
     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
-    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {
+    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {// TODO: unhardcode
       return 0;
     }
     //semi-analytic approach only works in the active volume
@@ -1573,7 +1574,7 @@ namespace larg4 {
 
     // apply Gaisser-Hillas correction for Rayleigh scattering distance
     // and angular dependence offset angle bin
-    const size_t j = (theta / fdelta_angulo);
+    const size_t j = (theta / fdelta_angulo);// TODO:: std::round?
 
     //Accounting for border effects
     double z_to_corner = std::abs(ScintPoint[2] - fZactive_corner) - fZactive_corner;
@@ -1601,7 +1602,7 @@ namespace larg4 {
     // check optical channel is in same TPC as scintillation light, if not return 0 hits
     // temporary method working for SBND, DUNE 1x2x6; to be replaced to work in full DUNE geometry
     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
-    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {
+    if (((ScintPoint[0] < 0) != (OpDetPoint[0] < 0)) && std::abs(OpDetPoint[0]) > 10) {// TODO: unhardcode
       return 0;
     }
 
@@ -1643,7 +1644,7 @@ namespace larg4 {
       (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
-    const size_t j = (theta_cathode / fdelta_angulo);
+    const size_t j = (theta_cathode / fdelta_angulo);// TODO:: std::round?
     double  pars_ini_[4] = {fGHvuvpars[0][j],
                             fGHvuvpars[1][j],
                             fGHvuvpars[2][j],
@@ -1692,7 +1693,7 @@ namespace larg4 {
      //  angle between hotspot and optical detector
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
     double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
-    const size_t k = (theta_vis / fdelta_angulo);
+    const size_t k = (theta_vis / fdelta_angulo);// TODO:: std::round?
 
     // apply geometric correction
     double pars_ini_vis[6] = {fvispars[0][k], fvispars[1][k], fvispars[2][k],
@@ -1745,7 +1746,7 @@ namespace larg4 {
 
 
   G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
-  {
+  {// TODO: what's up with this? ... / tau2 / tau2 ...
     return std::exp(-1.0 * t / tau2) *
       (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
   }
@@ -1815,7 +1816,6 @@ namespace larg4 {
     // par4 = Expo cte
     // par5 = Expo tau
     // par6 = t_min
-
     double y1 = par[3] * TMath::Landau(x[0], par[1], par[2]);
     double y2 = TMath::Exp(par[4] + x[0] * par[5]);
     if(x[0] <= par[6] || x[0] > par[0]) y1 = 0.;
@@ -1927,7 +1927,8 @@ namespace larg4 {
   }
 
 
-  // solid angle of rectanglular aperture
+  // solid angle of rectangular aperture
+  // TODO: what's up with all of that times 2, divided by 2?
   double OpFastScintillation::Rectangle_SolidAngle(double a, double b, double d)
   {
     double aa = a / (2.0 * d);
@@ -1944,9 +1945,11 @@ namespace larg4 {
 
     // arapuca plane fixed in x direction
     if( v.Y() == 0.0 && v.Z() == 0.0) {
-      return Rectangle_SolidAngle(out.w, out.h, v.X());
+      return Rectangle_SolidAngle(out.w, out.h, v.X());// TODO: std::abs(v.X())?
     }
 
+    // TODO: shouldn't it be?
+    // if ( (std::abs(v.Y()) > op.h / 2.0) && (std::abs(v.Z()) > op.w / 2.0)) {
     if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
       double A, B, a, b, d;
       A = std::abs(v.Y()) - out.w / 2.0;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -225,11 +225,11 @@ namespace larg4 {
       std::cout << "Cathode_centre: " << Cathode_centre.X()
                 << "  " << Cathode_centre.Y() << "  " << Cathode_centre.Z() << std::endl;
 
-      std::cout << "\nInitialize acos_arr with " << acos_bins+1
-                << " hence with a resolution of " << 1./acos_bins << std::endl;
-      for(size_t i=0; i<=acos_bins; ++i){
-        acos_arr[i] = std::acos(i/double(acos_bins));
-      }
+      // std::cout << "\nInitialize acos_arr with " << acos_bins+1
+      //           << " hence with a resolution of " << 1./acos_bins << std::endl;
+      // for(size_t i=0; i<=acos_bins; ++i){
+      //   acos_arr[i] = std::acos(i/double(acos_bins));
+      // }
 
       for(size_t i = 0; i != pvs->NOpChannels(); i++) {
         double OpDetCenter_i[3];
@@ -1471,7 +1471,8 @@ namespace larg4 {
 
     // calculate angle alpha between scintillation point and reflection point
     double cosine_alpha = std::abs(ScintPoint[0] - bounce_point[0]) / VUVdist;
-    double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
+    // double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
+    double alpha = fast_acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
@@ -1543,7 +1544,8 @@ namespace larg4 {
     // distance and angle between ScintPoint and OpDetPoint
     double distance = dist(&ScintPoint[0], &OpDetPoint[0], 3);
     double cosine = std::abs(ScintPoint[0] - OpDetPoint[0]) / distance;
-    double theta = std::acos(cosine) * 180. / CLHEP::pi;
+    // double theta = std::acos(cosine) * 180. / CLHEP::pi;
+    double theta = fast_acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
     double solid_angle = 0;
@@ -1681,7 +1683,8 @@ namespace larg4 {
     double distance_vis = dist(&hotspot[0], &OpDetPoint[0], 3);
      //  angle between hotspot and optical detector
     double cosine_vis = std::abs(hotspot[0] - OpDetPoint[0]) / distance_vis;
-    double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
+    // double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
+    double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
     const size_t k = (theta_vis / fdelta_angulo);// TODO:: std::round?
 
     // apply geometric correction
@@ -1923,7 +1926,8 @@ namespace larg4 {
     double aa = a / (2.0 * d);
     double bb = b / (2.0 * d);
     double aux = (1 + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
-    return 4 * std::acos(std::sqrt(aux));
+    // return 4 * std::acos(std::sqrt(aux));
+    return 4 * fast_acos(std::sqrt(aux));
   }
 
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -287,7 +287,8 @@ namespace larg4 {
 
         fYcathode = Cathode_centre.Y();
         fZcathode = Cathode_centre.Z();
-        fReference_to_corner = sqrt(pow(fYactive_corner, 2) + pow(fZactive_corner, 2));
+        fReference_to_corner = std::sqrt(std::pow(fYactive_corner, 2) +
+                                         std::pow(fZactive_corner, 2));
 
         std::cout << "For border corrections: " << fborder_corr[0] << "  " << fborder_corr[1] << std::endl;
         std::cout << "Photocathode-plane centre (z,y) = (" << fZcathode << ", " << fYcathode << ") and corner (z, y) = (" << fZactive_corner << ", " << fYactive_corner << ")" << std::endl;
@@ -1132,11 +1133,11 @@ namespace larg4 {
       double t_direct = distance/vuv_vgroup;
       // Defining the two functions (Landau + Exponential) describing the timing vs distance
       double pars_landau[3] = {functions_vuv[1]->Eval(distance), functions_vuv[2]->Eval(distance),
-                               pow(10.,functions_vuv[0]->Eval(distance))};
+                               std::pow(10.,functions_vuv[0]->Eval(distance))};
       if(distance > fd_break) {
         pars_landau[0]=functions_vuv[6]->Eval(distance);
         pars_landau[1]=functions_vuv[2]->Eval(fd_break);
-        pars_landau[2]=pow(10.,functions_vuv[5]->Eval(distance));
+        pars_landau[2]=std::pow(10.,functions_vuv[5]->Eval(distance));
       }
       TF1 *flandau = new TF1("flandau","[2]*TMath::Landau(x,[0],[1])",0,signal_t_range/2);
       flandau->SetParameters(pars_landau);
@@ -1198,12 +1199,12 @@ namespace larg4 {
       //signals (remember this is transportation) no longer than 1us
       const double signal_t_range = 1000.;
       double pars_landau[3] = {functions_vis[1]->Eval(t0), functions_vis[2]->Eval(t0),
-                               pow(10.,functions_vis[0]->Eval(t0))};
+                               std::pow(10.,functions_vis[0]->Eval(t0))};
       double pars_expo[2] = {functions_vis[3]->Eval(t0), functions_vis[4]->Eval(t0)};
       if(t0 > ft0_break_point) {
         pars_landau[0] = -0.798934 + 1.06216*t0;
         pars_landau[1] = functions_vis[2]->Eval(ft0_break_point);
-        pars_landau[2] = pow(10.,functions_vis[0]->Eval(ft0_break_point));
+        pars_landau[2] = std::pow(10.,functions_vis[0]->Eval(ft0_break_point));
         pars_expo[0] = functions_vis[3]->Eval(ft0_break_point);
         pars_expo[1] = functions_vis[4]->Eval(ft0_break_point);
       }
@@ -1287,7 +1288,7 @@ namespace larg4 {
       //for [0,30deg] range and [60,90deg] range respectively
       pars_expo[0] = fparameters[7].at(0) + fparameters[7].at(1) * distance_in_cm;
       pars_expo[0] *= pars_landau[2];
-      pars_expo[0] = log(pars_expo[0]);
+      pars_expo[0] = std::log(pars_expo[0]);
       // this is to find the intersection point between the two functions:
       TF1 fint = TF1("fint", finter_d, pars_landau[0], 4 * t_direct_mean, 5);
       double parsInt[5] = {pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
@@ -1442,8 +1443,8 @@ namespace larg4 {
     double fastest_time = vis_time + vuv_time;
 
     // calculate angle alpha between scintillation point and reflection point
-    double cosine_alpha = sqrt(pow(ScintPoint[0] - bounce_point[0], 2)) / VUVdist;
-    double alpha = acos(cosine_alpha) * 180. / CLHEP::pi;
+    double cosine_alpha = std::sqrt(std::pow(ScintPoint[0] - bounce_point[0], 2)) / VUVdist;
+    double alpha = std::acos(cosine_alpha) * 180. / CLHEP::pi;
 
     // determine smearing parameters using interpolation of generated points:
     // 1). tau = exponential smearing factor, varies with distance and angle
@@ -1469,7 +1470,7 @@ namespace larg4 {
       double arrival_time = transport_time_vis[i];
       double arrival_time_smeared;
       // if time is already greater than cutoff or minimum smeared time would be greater than cutoff, do not apply smearing
-      if (arrival_time + (arrival_time - fastest_time) * (exp(-tau * log(1.0)) - 1) >= cutoff) {
+      if (arrival_time + (arrival_time - fastest_time) * (std::exp(-tau * std::log(1.0)) - 1) >= cutoff) {
         arrival_time_smeared = arrival_time;
       }
       // otherwise smear
@@ -1487,7 +1488,7 @@ namespace larg4 {
             // generate random number in appropriate range
             double x = gRandom->Uniform(0.5, 1.0);
             // apply the exponential smearing
-            arrival_time_smeared = arrival_time + (arrival_time - fastest_time) * (exp(-tau * log(x)) - 1);
+            arrival_time_smeared = arrival_time + (arrival_time - fastest_time) * (std::exp(-tau * log(x)) - 1);
           }
           // increment counter
           counter++;
@@ -1517,9 +1518,11 @@ namespace larg4 {
     }
 
     // distance and angle between ScintPoint and OpDetPoint
-    double distance = sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2) + pow(ScintPoint[1] - OpDetPoint[1], 2) + pow(ScintPoint[2] - OpDetPoint[2], 2));
-    double cosine = sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2)) / distance;
-    double theta = acos(cosine) * 180. / CLHEP::pi;
+    double distance = std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2) +
+                                std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
+                                std::pow(ScintPoint[2] - OpDetPoint[2], 2));
+    double cosine = std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2)) / distance;
+    double theta = std::acos(cosine) * 180. / CLHEP::pi;
 
     // calculate solid angle:
     double solid_angle = 0;
@@ -1540,9 +1543,10 @@ namespace larg4 {
     // PMTs
     else if (optical_detector_type == 1) {
       // offset in z-y plane
-      d = sqrt(pow(ScintPoint[1] - OpDetPoint[1], 2) + pow(ScintPoint[2] - OpDetPoint[2], 2));
+      d = std::sqrt(std::pow(ScintPoint[1] - OpDetPoint[1], 2) +
+                    std::pow(ScintPoint[2] - OpDetPoint[2], 2));
       // drift distance (in x)
-      h =  sqrt(pow(ScintPoint[0] - OpDetPoint[0], 2));
+      h =  std::sqrt(std::pow(ScintPoint[0] - OpDetPoint[0], 2));
       // Solid angle of a disk
       solid_angle = Disk_SolidAngle(d, h, fradius);
     }
@@ -1551,16 +1555,17 @@ namespace larg4 {
     }
 
     // calculate number of photons hits by geometric acceptance: accounting for solid angle and LAr absorbtion length
-    double hits_geo = exp(-1.*distance / fL_abs_vuv) * (solid_angle / (4 * CLHEP::pi)) * Nphotons_created;
+    double hits_geo = std::exp(-1.*distance / fL_abs_vuv) * (solid_angle / (4 * CLHEP::pi)) * Nphotons_created;
 
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
     int j = (theta / fdelta_angulo);
 
     //Accounting for border effects
-    double z_to_corner = abs(ScintPoint[2] - fZactive_corner) - fZactive_corner;
-    double y_to_corner = abs(ScintPoint[1]) - fYactive_corner;
-    double distance_to_corner = sqrt(y_to_corner * y_to_corner + z_to_corner * z_to_corner); // in the ph-cathode plane
+    double z_to_corner = std::abs(ScintPoint[2] - fZactive_corner) - fZactive_corner;
+    double y_to_corner = std::abs(ScintPoint[1]) - fYactive_corner;
+    double distance_to_corner = std::sqrt(y_to_corner * y_to_corner +
+                                          z_to_corner * z_to_corner); // in the ph-cathode plane
     double pars_ini_[4] = {fGHvuvpars[0][j] + fborder_corr[0] * (distance_to_corner - fReference_to_corner),
                            fGHvuvpars[1][j] + fborder_corr[1] * (distance_to_corner - fReference_to_corner),
                            fGHvuvpars[2][j],
@@ -1618,7 +1623,7 @@ namespace larg4 {
     double cosine_cathode = 1;
     double theta_cathode = 0;
     // calculate hits on cathode plane via geometric acceptance
-    double cathode_hits_geo = exp(-1.*distance_cathode / fL_abs_vuv) * (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
+    double cathode_hits_geo = std::exp(-1.*distance_cathode / fL_abs_vuv) * (solid_angle_cathode / (4.*CLHEP::pi)) * Nphotons_created;
     // apply Gaisser-Hillas correction for Rayleigh scattering distance and angular dependence
     // offset angle bin
     int j = (theta_cathode / fdelta_angulo);
@@ -1651,9 +1656,10 @@ namespace larg4 {
     // disk aperture
     else if (optical_detector_type == 1) {
       // offset in z-y plane
-      double d = sqrt(pow(hotspot[1] - OpDetPoint[1], 2) + pow(hotspot[2] - OpDetPoint[2], 2));
+      double d = std::sqrt(std::pow(hotspot[1] - OpDetPoint[1], 2) +
+                           std::pow(hotspot[2] - OpDetPoint[2], 2));
       // drift distance (in x)
-      double h =  sqrt(pow(hotspot[0] - OpDetPoint[0], 2));
+      double h =  std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2));
       // calculate solid angle
       solid_angle_detector = Disk_SolidAngle(d, h, fradius);
     }
@@ -1666,12 +1672,16 @@ namespace larg4 {
 
     // calculate distances and angles for application of corrections
     // distance to hotspot
-    double distance_vuv = sqrt(pow(ScintPoint[0] - hotspot[0], 2) + pow(ScintPoint[1] - hotspot[1], 2) + pow(ScintPoint[2] - hotspot[2], 2));
+    double distance_vuv = std::sqrt(std::pow(ScintPoint[0] - hotspot[0], 2) +
+                                    std::pow(ScintPoint[1] - hotspot[1], 2) +
+                                    std::pow(ScintPoint[2] - hotspot[2], 2));
     // distance from hotspot to optical detector
-    double distance_vis = sqrt(pow(hotspot[0] - OpDetPoint[0], 2) + pow(hotspot[1] - OpDetPoint[1], 2) + pow(hotspot[2] - OpDetPoint[2], 2));
+    double distance_vis = std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2) +
+                                    std::pow(hotspot[1] - OpDetPoint[1], 2) +
+                                    std::pow(hotspot[2] - OpDetPoint[2], 2));
     //  angle between hotspot and optical detector
-    double cosine_vis = sqrt(pow(hotspot[0] - OpDetPoint[0], 2)) / distance_vis;
-    double theta_vis = acos(cosine_vis) * 180. / CLHEP::pi;
+    double cosine_vis = std::sqrt(std::pow(hotspot[0] - OpDetPoint[0], 2)) / distance_vis;
+    double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
     int k = (theta_vis / fdelta_angulo);
 
     // apply geometric correction
@@ -1685,7 +1695,8 @@ namespace larg4 {
       // calculate distance for interpolation depending on model
       double r = 0;
       if (fVisBorderCorrectionType == "Radial") {
-        r = sqrt (pow(ScintPoint[1] - fcathode_centre[1], 2) + pow (ScintPoint[2] - fcathode_centre[2], 2));
+        r = std::sqrt(std::pow(ScintPoint[1] - fcathode_centre[1], 2) +
+                      std::pow (ScintPoint[2] - fcathode_centre[2], 2));
       }
       else if (fVisBorderCorrectionType == "Vertical") {
         r = std::abs(ScintPoint[1]);

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -225,6 +225,12 @@ namespace larg4 {
       std::cout << "Cathode_centre: " << Cathode_centre.X()
                 << "  " << Cathode_centre.Y() << "  " << Cathode_centre.Z() << std::endl;
 
+      std::cout << "\nInitialize acos_arr with " << acos_bins+1
+                << " hence with a resolution of " << 1./acos_bins << std::endl;
+      for(size_t i=0; i<=acos_bins; ++i){
+        acos_arr[i] = std::acos(i/double(acos_bins));
+      }
+
       for(size_t i = 0; i != pvs->NOpChannels(); i++) {
         double OpDetCenter_i[3];
         std::vector<double> OpDetCenter_v;
@@ -1996,6 +2002,16 @@ namespace larg4 {
     // error message if none of these cases, i.e. something has gone wrong!
     std::cout << "Warning: invalid solid angle call." << std::endl;
     return 0.0;
+  }
+
+
+  constexpr double acos_table(const double x)
+  {
+    if(x < 0. || x > 1.){
+      std::cout << "Range out of bounds in acos_table, only defined in [0, 1]" << std::endl;
+      exit(0);
+    }
+    return acos_arr[std::round(acos_bins*x)];
   }
 
 }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1933,8 +1933,8 @@ namespace larg4 {
 
   double OpFastScintillation::Rectangle_SolidAngle(acc& out, TVector3 v)
   {
-    //v is the position of the track segment with respect to
-    //the center position of the arapuca window
+    // v is the position of the track segment with respect to
+    // the center position of the arapuca window
 
     // arapuca plane fixed in x direction
     if( v.Y() == 0.0 && v.Z() == 0.0) {
@@ -1954,21 +1954,6 @@ namespace larg4 {
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
-
-    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
-      double A, B, a, b, d;
-      A = -std::abs(v.Y()) + out.w / 2.0;
-      B = -std::abs(v.Z()) + out.h / 2.0;
-      a = out.w;
-      b = out.h;
-      d = std::abs(v.X());
-      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) +
-                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
-                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
-                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
-      return to_return;
-    }
-
     if( (std::abs(v.Y()) > out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
       double A, B, a, b, d;
       A = std::abs(v.Y()) - out.w / 2.0;
@@ -1982,7 +1967,6 @@ namespace larg4 {
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }
-
     if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) > out.h / 2.0)) {
       double A, B, a, b, d;
       A = -std::abs(v.Y()) + out.w / 2.0;
@@ -1993,6 +1977,19 @@ namespace larg4 {
       double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (B + b), d) -
                           Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
                           Rectangle_SolidAngle(2 * A, 2 * (B + b), d) -
+                          Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
+      return to_return;
+    }
+    if( (std::abs(v.Y()) <= out.w / 2.0) && (std::abs(v.Z()) <= out.h / 2.0)) {
+      double A, B, a, b, d;
+      A = -std::abs(v.Y()) + out.w / 2.0;
+      B = -std::abs(v.Z()) + out.h / 2.0;
+      a = out.w;
+      b = out.h;
+      d = std::abs(v.X());
+      double to_return = (Rectangle_SolidAngle(2 * (a - A), 2 * (b - B), d) +
+                          Rectangle_SolidAngle(2 * A, 2 * (b - B), d) +
+                          Rectangle_SolidAngle(2 * (a - A), 2 * B, d) +
                           Rectangle_SolidAngle(2 * A, 2 * B, d)) / 4.0;
       return to_return;
     }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1268,7 +1268,9 @@ namespace larg4 {
 
     // Defining the model function(s) describing the photon transportation timing vs distance
     // Getting the landau parameters from the time parametrization
-    double* pars_landau = interpolate(fparameters[0], fparameters[2], fparameters[3], fparameters[1], distance_in_cm, true);
+    double pars_landau[3];
+    interpolate(pars_landau, fparameters[0], fparameters[2], fparameters[3],
+                fparameters[1], distance_in_cm, true);
     // Deciding which time model to use (depends on the distance)
     // defining useful times for the VUV arrival time shapes
     if(distance_in_cm >= finflexion_point_distance) {
@@ -1303,7 +1305,6 @@ namespace larg4 {
       }
       double parsfinal[7] = {t_int, pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1], t_direct_min};
       fVUVTiming.SetParameters(parsfinal);
-      delete pars_landau;
     }
 
     // set the number of points used to sample parameterisation
@@ -1787,8 +1788,8 @@ namespace larg4 {
   //   boolean argument extrapolate determines behaviour beyond ends of array (if needed)
   double interpolate( std::vector<double> &xData, std::vector<double> &yData, double x, bool extrapolate )
   {
-    int size = xData.size();
-    int i = 0;                                          // find left end of interval for interpolation
+    size_t size = xData.size();
+    size_t i = 0;                                          // find left end of interval for interpolation
     if ( x >= xData[size - 2] ) {                       // special case: beyond right end
       i = size - 2;
     }
@@ -1805,11 +1806,12 @@ namespace larg4 {
   }
 
 
-  double* interpolate( std::vector<double> &xData, std::vector<double> &yData1, std::vector<double> &yData2,
-                       std::vector<double> &yData3, double x, bool extrapolate)
+  void interpolate(double inter[], std::vector<double> &xData,
+                   std::vector<double> &yData1, std::vector<double> &yData2,
+                   std::vector<double> &yData3, double x, bool extrapolate)
   {
-    int size = xData.size();
-    int i = 0;                                          // find left end of interval for interpolation
+    size_t size = xData.size();
+    size_t i = 0;                                          // find left end of interval for interpolation
     if ( x >= xData[size - 2] ) {                       // special case: beyond right end
       i = size - 2;
     }
@@ -1831,16 +1833,14 @@ namespace larg4 {
         yL3 = yR3;
       }
     }
-    double dydx1 = ( yR1 - yL1 ) / ( xR - xL );            // gradient
-    double dydx2 = ( yR2 - yL2 ) / ( xR - xL );
-    double dydx3 = ( yR3 - yL3 ) / ( xR - xL );
 
-    double *yy = new double[3];
-    yy[0] = yL1 + dydx1 * ( x - xL );// linear interpolations
-    yy[1] = yL2 + dydx2 * ( x - xL );
-    yy[2] = yL3 + dydx3 * ( x - xL );
+    inter[0] = (x - xL) * (yR1 - yL1) / (xR - xL);
+    inter[1] = (x - xL) * ( yR2 - yL2 ) / ( xR - xL );
+    inter[2] = (x - xL) * ( yR3 - yL3 ) / ( xR - xL );
 
-    return yy;
+    inter[0] += yL1;
+    inter[1] += yL2;
+    inter[2] += yL3;
   }
 
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -359,9 +359,9 @@ namespace larg4 {
       double w, h; // w = width; h = height
     };
     // solid angle of rectangular aperture calculation functions
-    constexpr double Rectangle_SolidAngle(const double a, const double b,
-                                          const double d);
-    constexpr double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
+    double Rectangle_SolidAngle(const double a, const double b,
+                                const double d);
+    double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
     // solid angle of circular aperture calculation functions
     double Disk_SolidAngle(const double d, const double h, const double b);
 
@@ -425,7 +425,7 @@ namespace larg4 {
   static const size_t acos_bins = 2000000;
   static std::array<double, acos_bins+1> acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
   constexpr double acos_table(const double x);
-  constexpr double fast_acos(const double x);
+  double fast_acos(const double x);
 
   ////////////////////
   // Inline methods

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -256,12 +256,16 @@ namespace larg4 {
                     TVector3 OpDetPoint);
     // Visible component timing parameterisation
 
-    int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint,
-                int optical_detector_type);
+    int VUVHits(const int Nphotons_created,
+                const std::array<double, 3> ScintPoint,
+                const std::array<double, 3> OpDetPoint,
+                const int optical_detector_type);
     // Calculates semi-analytic model number of hits for vuv component
 
-    int VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint,
-                int optical_detector_type);
+    int VISHits(const int Nphotons_created,
+                const std::array<double, 3> ScintPoint,
+                const std::array<double, 3> OpDetPoint,
+                const int optical_detector_type);
     // Calculates semi-analytic model number of hits for visible component
 
   protected:
@@ -380,7 +384,7 @@ namespace larg4 {
     double fydimension, fzdimension, fradius;
     dims detPoint, cathode_plane;
     int fdelta_angulo, fL_abs_vuv;
-    std::vector<std::vector<double> > fOpDetCenter;
+    std::vector<std::array<double, 3>> fOpDetCenter;
     std::vector<int>  fOpDetType;
     std::vector<double>  fOpDetLength;
     std::vector<double>  fOpDetHeight;
@@ -502,7 +506,7 @@ namespace larg4 {
   }
 
   template<typename TReal> inline constexpr
-  double dist(TReal* x, TReal* y, const unsigned int dimension)
+  double dist(const TReal* x, const TReal* y, const unsigned int dimension)
   {
     double d = 0.;
     for (unsigned int p=0; p<dimension; ++p){

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -256,20 +256,6 @@ namespace larg4 {
                     TVector3 OpDetPoint);
     // Visible component timing parameterisation
 
-    int VUVHits(const int Nphotons_created,
-                const std::array<double, 3> ScintPoint,
-                const std::array<double, 3> OpDetPoint,
-                const int optical_detector_type);
-    // Calculates semi-analytic model number of hits for vuv component
-
-    int VISHits(const int Nphotons_created,
-                const std::array<double, 3> ScintPoint,
-                const std::array<double, 3> OpDetPoint,
-                const int optical_detector_type,
-                const double cathode_hits_rec,
-                const std::array<double, 3> hotspot);
-    // Calculates semi-analytic model number of hits for visible component
-
   protected:
 
     void BuildThePhysicsTable();
@@ -299,6 +285,26 @@ namespace larg4 {
     G4bool scintillationByParticleType;
 
   private:
+    void detectedDirectHits(std::map<size_t, int>& DetectedNum,
+                            const double Num,
+                            const std::array<double, 3> ScintPoint);
+    void detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
+                            const double Num,
+                            const std::array<double, 3> ScintPoint);
+
+    int VUVHits(const int Nphotons_created,
+                const std::array<double, 3> ScintPoint,
+                const std::array<double, 3> OpDetPoint,
+                const int optical_detector_type);
+    // Calculates semi-analytic model number of hits for vuv component
+
+    int VISHits(const int Nphotons_created,
+                const std::array<double, 3> ScintPoint,
+                const std::array<double, 3> OpDetPoint,
+                const int optical_detector_type,
+                const double cathode_hits_rec,
+                const std::array<double, 3> hotspot);
+    // Calculates semi-analytic model number of hits for visible component
 
     constexpr G4double single_exp(const G4double t, const G4double tau2) const;
     constexpr G4double bi_exp(const G4double t, const G4double tau1, const G4double tau2) const;
@@ -330,6 +336,8 @@ namespace larg4 {
      double fd_max;
      double ftf1_sampling_factor;
      double ft0_max, ft0_break_point;*/
+
+    size_t NOpChannels;
 
     //For new VUV time parametrization
     double fstep_size, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -341,13 +341,12 @@ namespace larg4 {
     std::vector<std::vector<double>> ftau_pars;
 
     // structure definition for solid angle of rectangle function
-    struct acc {
-      // ax,ay,az = centre of rectangle; w = width; h = height
-      double ax, ay, az, w, h;
+    struct dims {
+      double w, h; // w = width; h = height
     };
     // solid angle of rectangular aperture calculation functions
     double Rectangle_SolidAngle(double a, double b, double d);
-    double Rectangle_SolidAngle(acc& out, TVector3 v);
+    double Rectangle_SolidAngle(dims out, TVector3 v);
     // solid angle of circular aperture calculation functions
     double Disk_SolidAngle(const double d, const double h, const double b);
 
@@ -378,6 +377,7 @@ namespace larg4 {
     // Optical detector properties for semi-analytic hits
     // int foptical_detector_type;  // unused
     double fydimension, fzdimension, fradius;
+    dims detPoint, cathode_plane;
     int fdelta_angulo, fL_abs_vuv;
     std::vector<std::vector<double> > fOpDetCenter;
     std::vector<int>  fOpDetType;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -523,6 +523,17 @@ namespace larg4 {
     return false;
   }
 
+  // supply tolerance that is meaningful in your context
+  // for example, default tolerance may not work if you are comparing double with float
+  template<typename TReal> inline
+  static bool isApproximatelyZero(TReal a, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    if (std::fabs(a) <= tolerance)
+      return true;
+    return false;
+  }
+
+
   // use this when you want to be on safe side
   // for example, don't start rover unless signal is above 1
   template<typename TReal> inline

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -532,6 +532,43 @@ namespace larg4 {
     }
     return std::sqrt(d);
   }
+
+  // implements relative method - do not use for comparing with zero
+  // use this most of the time, tolerance needs to be meaningful in your context
+  template<typename TReal> inline
+  static bool isApproximatelyEqual(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = std::fabs(a - b);
+    if (diff <= tolerance)
+      return true;
+    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance)
+      return true;
+    return false;
+  }
+
+  // use this when you want to be on safe side
+  // for example, don't start rover unless signal is above 1
+  template<typename TReal> inline
+  static bool isDefinitelyLessThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = a - b;
+    if (diff < tolerance)
+      return true;
+    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance)
+      return true;
+    return false;
+  }
+
+  template<typename TReal> inline
+  static bool isDefinitelyGreaterThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = a - b;
+    if (diff > tolerance)
+      return true;
+    if (diff > std::fmax(std::fabs(a), std::fabs(b)) * tolerance)
+      return true;
+    return false;
+  }
 } //namespace
 
 #endif /* OpFastScintillation_h */

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -294,8 +294,8 @@ namespace larg4 {
 
   private:
 
-    G4double single_exp(G4double t, G4double tau2) const;
-    G4double bi_exp(G4double t, G4double tau1, G4double tau2) const;
+    constexpr G4double single_exp(const G4double t, const G4double tau2) const;
+    constexpr G4double bi_exp(const G4double t, const G4double tau1, const G4double tau2) const;
 
     G4double scint_time(const G4Step& aStep,
                         G4double ScintillationTime,
@@ -304,7 +304,7 @@ namespace larg4 {
                          const size_t OpChannel, bool Reflected = false); //const;
 
     // emission time distribution when there is a finite rise time
-    G4double sample_time(G4double tau1, G4double tau2) const;
+    G4double sample_time(const G4double tau1, const G4double tau2) const;
 
     // Facility for TPB emission energies
     double reemission_energy() const;
@@ -345,13 +345,14 @@ namespace larg4 {
       double w, h; // w = width; h = height
     };
     // solid angle of rectangular aperture calculation functions
-    double Rectangle_SolidAngle(double a, double b, double d);
+    constexpr double Rectangle_SolidAngle(const double a, const double b,
+                                          const double d);
     double Rectangle_SolidAngle(dims out, TVector3 v);
     // solid angle of circular aperture calculation functions
     double Disk_SolidAngle(const double d, const double h, const double b);
 
     //For VUV semi-analytic hits
-    G4double Gaisser_Hillas(double x, double *par);
+    constexpr G4double Gaisser_Hillas(const double x, const double *par);
     bool fUseNhitsModel;
     //array of correction for the VUV Nhits estimation
     std::vector<std::vector<double> > fGHvuvpars;
@@ -360,7 +361,7 @@ namespace larg4 {
     double fYactive_corner, fZactive_corner, fReference_to_corner, fYcathode, fZcathode;
     double fminx, fmaxx, fminy, fmaxy, fminz, fmaxz;
     // For VIS semi-analytic hits
-    double Pol_5(double x, double *par);
+    constexpr double Pol_5(const double x, double *par);
     bool fStoreReflected;
     // array of corrections for VIS Nhits estimation
     std::vector<std::vector<double>> fvispars;
@@ -500,7 +501,7 @@ namespace larg4 {
     }
   }
 
-  template<typename TReal> inline
+  template<typename TReal> inline constexpr
   double dist(TReal* x, TReal* y, const unsigned int dimension)
   {
     double d = 0.;
@@ -512,7 +513,7 @@ namespace larg4 {
 
   // implements relative method - do not use for comparing with zero
   // use this most of the time, tolerance needs to be meaningful in your context
-  template<typename TReal> inline
+  template<typename TReal> inline constexpr
   static bool isApproximatelyEqual(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
   {
     TReal diff = std::fabs(a - b);
@@ -525,7 +526,7 @@ namespace larg4 {
 
   // supply tolerance that is meaningful in your context
   // for example, default tolerance may not work if you are comparing double with float
-  template<typename TReal> inline
+  template<typename TReal> inline constexpr
   static bool isApproximatelyZero(TReal a, TReal tolerance = std::numeric_limits<TReal>::epsilon())
   {
     if (std::fabs(a) <= tolerance)
@@ -536,7 +537,7 @@ namespace larg4 {
 
   // use this when you want to be on safe side
   // for example, don't start rover unless signal is above 1
-  template<typename TReal> inline
+  template<typename TReal> inline constexpr
   static bool isDefinitelyLessThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
   {
     TReal diff = a - b;
@@ -547,7 +548,7 @@ namespace larg4 {
     return false;
   }
 
-  template<typename TReal> inline
+  template<typename TReal> inline constexpr
   static bool isDefinitelyGreaterThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
   {
     TReal diff = a - b;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -514,10 +514,15 @@ namespace larg4 {
   }
 
   inline
-  G4double OpFastScintillation::Pol_5(double x, double *par)
+  double OpFastScintillation::Pol_5(double x, double *par)
   {
     // 5th order polynomial function
-    return par[0] + par[1] * x + par[2] * std::pow(x, 2) + par[3] * std::pow(x, 3) + par[4] * std::pow(x, 4) + par[5] * std::pow(x, 5);
+    double xpow = 1.;
+    for(unsigned i=1; i<=5; ++i){
+      xpow *= x;
+      par[0] += par[i] * xpow ;
+    }
+    return par[0];
   }
 
 } //namespace

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -402,6 +402,10 @@ namespace larg4 {
   double model_close(double*, double*);
   double model_far(double*, double*);
 
+  static const size_t acos_bins = 2000000;
+  static std::array<double, acos_bins+1> acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
+  constexpr double acos_table(const double x);
+
   ////////////////////
   // Inline methods
   ////////////////////

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -265,7 +265,9 @@ namespace larg4 {
     int VISHits(const int Nphotons_created,
                 const std::array<double, 3> ScintPoint,
                 const std::array<double, 3> OpDetPoint,
-                const int optical_detector_type);
+                const int optical_detector_type,
+                const double cathode_hits_rec,
+                const std::array<double, 3> hotspot);
     // Calculates semi-analytic model number of hits for visible component
 
   protected:

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -355,7 +355,7 @@ namespace larg4 {
                                           const double d);
     constexpr double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
     // solid angle of circular aperture calculation functions
-    constexpr double Disk_SolidAngle(const double d, const double h, const double b);
+    double Disk_SolidAngle(const double d, const double h, const double b);
 
     //For VUV semi-analytic hits
     constexpr G4double Gaisser_Hillas(const double x, const double *par);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -102,7 +102,9 @@ class G4EmSaturation;
 class G4Step;
 class G4Track;
 class G4VParticleChange;
-namespace CLHEP { class RandGeneral; }
+namespace CLHEP {
+  class RandGeneral;
+}
 
 // Class Description:
 // RestDiscrete Process - Generation of Scintillation Photons.
@@ -113,255 +115,265 @@ namespace CLHEP { class RandGeneral; }
 // Class Definition
 /////////////////////
 
-namespace larg4{
+namespace larg4 {
 
-class OpFastScintillation : public G4VRestDiscreteProcess
-{
+  class OpFastScintillation : public G4VRestDiscreteProcess {
 
-private:
+  private:
 
-        //////////////
-        // Operators
-        //////////////
+    //////////////
+    // Operators
+    //////////////
 
-        // OpFastScintillation& operator=(const OpFastScintillation &right);
+    // OpFastScintillation& operator=(const OpFastScintillation &right);
 
-public: // Without description
+  public: // Without description
 
-        ////////////////////////////////
-        // Constructors and Destructor
-        ////////////////////////////////
+    ////////////////////////////////
+    // Constructors and Destructor
+    ////////////////////////////////
 
-        OpFastScintillation(const G4String& processName = "Scintillation", G4ProcessType type = fElectromagnetic);
-        OpFastScintillation(const OpFastScintillation &right);
+    OpFastScintillation(const G4String& processName = "Scintillation", G4ProcessType type = fElectromagnetic);
+    OpFastScintillation(const OpFastScintillation &right);
 
-        ~OpFastScintillation();
+    ~OpFastScintillation();
 
-        ////////////
-        // Methods
-        ////////////
+    ////////////
+    // Methods
+    ////////////
 
-public: // With description
+  public: // With description
 
-        // OpFastScintillation Process has both PostStepDoIt (for energy
-        // deposition of particles in flight) and AtRestDoIt (for energy
-        // given to the medium by particles at rest)
+    // OpFastScintillation Process has both PostStepDoIt (for energy
+    // deposition of particles in flight) and AtRestDoIt (for energy
+    // given to the medium by particles at rest)
 
-        virtual G4bool IsApplicable(const G4ParticleDefinition& aParticleType);
-        // Returns true -> 'is applicable', for any particle type except
-        // for an 'opticalphoton' and for short-lived particles
+    virtual G4bool IsApplicable(const G4ParticleDefinition& aParticleType);
+    // Returns true -> 'is applicable', for any particle type except
+    // for an 'opticalphoton' and for short-lived particles
 
-        G4double GetMeanFreePath(const G4Track& aTrack,
-                                       G4double ,
-                                       G4ForceCondition* );
-        // Returns infinity; i. e. the process does not limit the step,
-        // but sets the 'StronglyForced' condition for the DoIt to be
-        // invoked at every step.
+    G4double GetMeanFreePath(const G4Track& aTrack,
+                             G4double,
+                             G4ForceCondition* );
+    // Returns infinity; i. e. the process does not limit the step,
+    // but sets the 'StronglyForced' condition for the DoIt to be
+    // invoked at every step.
 
 
-        G4double GetMeanLifeTime(const G4Track& aTrack,
-                                 G4ForceCondition* );
-        // Returns infinity; i. e. the process does not limit the time,
-        // but sets the 'StronglyForced' condition for the DoIt to be
-        // invoked at every step.
+    G4double GetMeanLifeTime(const G4Track& aTrack,
+                             G4ForceCondition* );
+    // Returns infinity; i. e. the process does not limit the time,
+    // but sets the 'StronglyForced' condition for the DoIt to be
+    // invoked at every step.
 
-        virtual G4VParticleChange* PostStepDoIt(const G4Track& aTrack,
-                                        const G4Step&  aStep);
-        virtual G4VParticleChange* AtRestDoIt (const G4Track& aTrack,
-                                       const G4Step& aStep);
+    virtual G4VParticleChange* PostStepDoIt(const G4Track& aTrack,
+                                            const G4Step&  aStep);
+    virtual G4VParticleChange* AtRestDoIt (const G4Track& aTrack,
+                                           const G4Step& aStep);
 
-        // These are the methods implementing the scintillation process.
+    // These are the methods implementing the scintillation process.
 
-        void SetTrackSecondariesFirst(const G4bool state);
-        // If set, the primary particle tracking is interrupted and any
-        // produced scintillation photons are tracked next. When all
-        // have been tracked, the tracking of the primary resumes.
+    void SetTrackSecondariesFirst(const G4bool state);
+    // If set, the primary particle tracking is interrupted and any
+    // produced scintillation photons are tracked next. When all
+    // have been tracked, the tracking of the primary resumes.
 
-        void SetFiniteRiseTime(const G4bool state);
-        // If set, the OpFastScintillation process expects the user to have
-        // set the constant material property FAST/SLOWSCINTILLATIONRISETIME.
+    void SetFiniteRiseTime(const G4bool state);
+    // If set, the OpFastScintillation process expects the user to have
+    // set the constant material property FAST/SLOWSCINTILLATIONRISETIME.
 
-        G4bool GetTrackSecondariesFirst() const;
-        // Returns the boolean flag for tracking secondaries first.
+    G4bool GetTrackSecondariesFirst() const;
+    // Returns the boolean flag for tracking secondaries first.
 
-        G4bool GetFiniteRiseTime() const;
-        // Returns the boolean flag for a finite scintillation rise time.
+    G4bool GetFiniteRiseTime() const;
+    // Returns the boolean flag for a finite scintillation rise time.
 
-        void SetScintillationYieldFactor(const G4double yieldfactor);
-        // Called to set the scintillation photon yield factor, needed when
-        // the yield is different for different types of particles. This
-        // scales the yield obtained from the G4MaterialPropertiesTable.
+    void SetScintillationYieldFactor(const G4double yieldfactor);
+    // Called to set the scintillation photon yield factor, needed when
+    // the yield is different for different types of particles. This
+    // scales the yield obtained from the G4MaterialPropertiesTable.
 
-        G4double GetScintillationYieldFactor() const;
-        // Returns the photon yield factor.
+    G4double GetScintillationYieldFactor() const;
+    // Returns the photon yield factor.
 
-        void SetScintillationExcitationRatio(const G4double excitationratio);
-        // Called to set the scintillation exciation ratio, needed when
-        // the scintillation level excitation is different for different
-        // types of particles. This overwrites the YieldRatio obtained
-        // from the G4MaterialPropertiesTable.
+    void SetScintillationExcitationRatio(const G4double excitationratio);
+    // Called to set the scintillation exciation ratio, needed when
+    // the scintillation level excitation is different for different
+    // types of particles. This overwrites the YieldRatio obtained
+    // from the G4MaterialPropertiesTable.
 
-        G4double GetScintillationExcitationRatio() const;
-        // Returns the scintillation level excitation ratio.
+    G4double GetScintillationExcitationRatio() const;
+    // Returns the scintillation level excitation ratio.
 
-        G4PhysicsTable* GetFastIntegralTable() const;
-        // Returns the address of the fast scintillation integral table.
+    G4PhysicsTable* GetFastIntegralTable() const;
+    // Returns the address of the fast scintillation integral table.
 
-        G4PhysicsTable* GetSlowIntegralTable() const;
-        // Returns the address of the slow scintillation integral table.
+    G4PhysicsTable* GetSlowIntegralTable() const;
+    // Returns the address of the slow scintillation integral table.
 
-        void AddSaturation(G4EmSaturation* sat) { emSaturation = sat; }
-        // Adds Birks Saturation to the process.
+    void AddSaturation(G4EmSaturation* sat)
+    {
+      emSaturation = sat;
+    }
+    // Adds Birks Saturation to the process.
 
-        void RemoveSaturation() { emSaturation = NULL; }
-        // Removes the Birks Saturation from the process.
+    void RemoveSaturation()
+    {
+      emSaturation = NULL;
+    }
+    // Removes the Birks Saturation from the process.
 
-        G4EmSaturation* GetSaturation() const { return emSaturation; }
-        // Returns the Birks Saturation.
+    G4EmSaturation* GetSaturation() const
+    {
+      return emSaturation;
+    }
+    // Returns the Birks Saturation.
 
-        void SetScintillationByParticleType(const G4bool );
-        // Called by the user to set the scintillation yield as a function
-        // of energy deposited by particle type
+    void SetScintillationByParticleType(const G4bool );
+    // Called by the user to set the scintillation yield as a function
+    // of energy deposited by particle type
 
-        G4bool GetScintillationByParticleType() const
-        { return scintillationByParticleType; }
-        // Return the boolean that determines the method of scintillation
-        // production
+    G4bool GetScintillationByParticleType() const
+    {
+      return scintillationByParticleType;
+    }
+    // Return the boolean that determines the method of scintillation
+    // production
 
-        void DumpPhysicsTable() const;
-        // Prints the fast and slow scintillation integral tables.
+    void DumpPhysicsTable() const;
+    // Prints the fast and slow scintillation integral tables.
 
-        /*std::vector<double> GetVUVTime(double, int);
-          std::vector<double> GetVisibleTimeOnlyCathode(double, int);*/
-        // old timings -- to be deleted
-
-        std::vector<double> getVUVTime(double, int);
-        void generateparam(int index);
-        // Functions for vuv component Landau + Exponential timing parameterisation, updated method
-
-        std::vector<double> getVISTime(TVector3 ScintPoint, TVector3 OpDetPoint, int Nphotons);
-        // Visible component timing parameterisation
-
-        int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
-        // Calculates semi-analytic model number of hits for vuv component
-
-        int VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
-        // Calculates semi-analytic model number of hits for visible component
-
-protected:
-
-        void BuildThePhysicsTable();
-        // It builds either the fast or slow scintillation integral table;
-        // or both.
-
-
-        bool RecordPhotonsProduced(const G4Step& aStep, double N);
-        // Note the production of N photons in at point xyz.
-        //  pass on to generate detector response, etc.
-
-
-        ///////////////////////
-        // Class Data Members
-        ///////////////////////
-
-        G4PhysicsTable* theSlowIntegralTable;
-        G4PhysicsTable* theFastIntegralTable;
-
-        G4bool fTrackSecondariesFirst;
-        G4bool fFiniteRiseTime;
-
-        G4double YieldFactor;
-
-        G4double ExcitationRatio;
-
-        G4bool scintillationByParticleType;
-
-private:
-
-        G4double single_exp(G4double t, G4double tau2) const;
-        G4double bi_exp(G4double t, G4double tau1, G4double tau2) const;
-
-        G4double scint_time(const G4Step& aStep,
-                            G4double ScintillationTime,
-                            G4double ScintillationRiseTime) const;
-  std::vector<double> propagation_time(G4ThreeVector x0, int OpChannel, int NPhotons, bool Reflected=false); //const;
-
-        // emission time distribution when there is a finite rise time
-        G4double sample_time(G4double tau1, G4double tau2) const;
-
-        // Facility for TPB emission energies
-        double reemission_energy() const;
-        std::map<double,double> tpbemission;
-        CLHEP::RandGeneral *rgen0;
-
-        void average_position(G4Step const& aStep, double *xzyPos) const;
-
-        G4EmSaturation* emSaturation;
-        // functions and parameters for the propagation time parametrization
-        phot::MappedFunctions_t ParPropTimeTF1;
-        phot::MappedT0s_t ReflT0s;
-
-       /*TF1 const* functions_vuv[8];
-        TF1 const* functions_vis[5];
-        double fd_break;
-        double fd_max;
-        double ftf1_sampling_factor;
-        double ft0_max, ft0_break_point;*/
-
-        //For new VUV time parametrization
-        double fstep_size, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance;
-        std::vector<double> fparameters[9];
-        // vector containing generated VUV timing parameterisations
-        std::vector<TF1> VUV_timing;
-        // vector containing min and max range VUV timing parameterisations are sampled to
-        std::vector<double> VUV_max;
-        std::vector<double> VUV_min;
-
-        // For new VIS time parameterisation
-        double fvis_vmean, fn_LAr_vis, fn_LAr_vuv;
-        std::vector<double> fdistances_refl;
-        std::vector<std::vector<double>> fcut_off_pars;
-        std::vector<std::vector<double>> ftau_pars;
-
-        //For VUV semi-analytic hits
-        G4double Gaisser_Hillas(double x, double *par);
-        bool fUseNhitsModel;
-        //array of correction for the VUV Nhits estimation
-        std::vector<std::vector<double> > fGHvuvpars;
-        //To account for the border effects
-        std::vector<double> fborder_corr;
-        double fYactive_corner, fZactive_corner, fReference_to_corner, fYcathode, fZcathode;
-        double fminx, fmaxx, fminy, fmaxy, fminz, fmaxz;
-        // For VIS semi-analytic hits
-        G4double Pol_5(double x, double *par);
-        bool fStoreReflected;
-        // array of corrections for VIS Nhits estimation
-        std::vector<std::vector<double>> fvispars;
-        //TF1* VIS_pol[9]; // unused
-        std::vector<double> fvis_border_distances_x;
-        std::vector<double> fvis_border_distances_r;
-        std::vector<std::vector<std::vector<double>>> fvis_border_correction;
-        bool fApplyVisBorderCorrection;
-        std::string fVisBorderCorrectionType;
-
-        double fplane_depth, fcathode_zdimension, fcathode_ydimension;
-        TVector3  fcathode_centre;
-
-        // Optical detector properties for semi-analytic hits
-        // int foptical_detector_type;  // unused
-        double fydimension, fzdimension, fradius;
-        int fdelta_angulo, fL_abs_vuv;
-        std::vector<std::vector<double> > fOpDetCenter;
-        std::vector<int>  fOpDetType;
-        std::vector<double>  fOpDetLength;
-        std::vector<double>  fOpDetHeight;
-        //double fGlobalTimeOffset;
-
-        void ProcessStep( const G4Step& step);
-
-        bool bPropagate; ///< Whether propagation of photons is enabled.
-
-};
+    /*std::vector<double> GetVUVTime(double, int);
+      std::vector<double> GetVisibleTimeOnlyCathode(double, int);*/
+    // old timings -- to be deleted
+
+    std::vector<double> getVUVTime(double, int);
+    void generateparam(int index);
+    // Functions for vuv component Landau + Exponential timing parameterisation, updated method
+
+    std::vector<double> getVISTime(TVector3 ScintPoint, TVector3 OpDetPoint, int Nphotons);
+    // Visible component timing parameterisation
+
+    int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
+    // Calculates semi-analytic model number of hits for vuv component
+
+    int VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
+    // Calculates semi-analytic model number of hits for visible component
+
+  protected:
+
+    void BuildThePhysicsTable();
+    // It builds either the fast or slow scintillation integral table;
+    // or both.
+
+
+    bool RecordPhotonsProduced(const G4Step& aStep, double N);
+    // Note the production of N photons in at point xyz.
+    //  pass on to generate detector response, etc.
+
+
+    ///////////////////////
+    // Class Data Members
+    ///////////////////////
+
+    G4PhysicsTable* theSlowIntegralTable;
+    G4PhysicsTable* theFastIntegralTable;
+
+    G4bool fTrackSecondariesFirst;
+    G4bool fFiniteRiseTime;
+
+    G4double YieldFactor;
+
+    G4double ExcitationRatio;
+
+    G4bool scintillationByParticleType;
+
+  private:
+
+    G4double single_exp(G4double t, G4double tau2) const;
+    G4double bi_exp(G4double t, G4double tau1, G4double tau2) const;
+
+    G4double scint_time(const G4Step& aStep,
+                        G4double ScintillationTime,
+                        G4double ScintillationRiseTime) const;
+    std::vector<double> propagation_time(G4ThreeVector x0, int OpChannel, int NPhotons, bool Reflected = false); //const;
+
+    // emission time distribution when there is a finite rise time
+    G4double sample_time(G4double tau1, G4double tau2) const;
+
+    // Facility for TPB emission energies
+    double reemission_energy() const;
+    std::map<double, double> tpbemission;
+    CLHEP::RandGeneral *rgen0;
+
+    void average_position(G4Step const& aStep, double *xzyPos) const;
+
+    G4EmSaturation* emSaturation;
+    // functions and parameters for the propagation time parametrization
+    phot::MappedFunctions_t ParPropTimeTF1;
+    phot::MappedT0s_t ReflT0s;
+
+    /*TF1 const* functions_vuv[8];
+     TF1 const* functions_vis[5];
+     double fd_break;
+     double fd_max;
+     double ftf1_sampling_factor;
+     double ft0_max, ft0_break_point;*/
+
+    //For new VUV time parametrization
+    double fstep_size, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance;
+    std::vector<double> fparameters[9];
+    // vector containing generated VUV timing parameterisations
+    std::vector<TF1> VUV_timing;
+    // vector containing min and max range VUV timing parameterisations are sampled to
+    std::vector<double> VUV_max;
+    std::vector<double> VUV_min;
+
+    // For new VIS time parameterisation
+    double fvis_vmean, fn_LAr_vis, fn_LAr_vuv;
+    std::vector<double> fdistances_refl;
+    std::vector<std::vector<double>> fcut_off_pars;
+    std::vector<std::vector<double>> ftau_pars;
+
+    //For VUV semi-analytic hits
+    G4double Gaisser_Hillas(double x, double *par);
+    bool fUseNhitsModel;
+    //array of correction for the VUV Nhits estimation
+    std::vector<std::vector<double> > fGHvuvpars;
+    //To account for the border effects
+    std::vector<double> fborder_corr;
+    double fYactive_corner, fZactive_corner, fReference_to_corner, fYcathode, fZcathode;
+    double fminx, fmaxx, fminy, fmaxy, fminz, fmaxz;
+    // For VIS semi-analytic hits
+    G4double Pol_5(double x, double *par);
+    bool fStoreReflected;
+    // array of corrections for VIS Nhits estimation
+    std::vector<std::vector<double>> fvispars;
+    //TF1* VIS_pol[9]; // unused
+    std::vector<double> fvis_border_distances_x;
+    std::vector<double> fvis_border_distances_r;
+    std::vector<std::vector<std::vector<double>>> fvis_border_correction;
+    bool fApplyVisBorderCorrection;
+    std::string fVisBorderCorrectionType;
+
+    double fplane_depth, fcathode_zdimension, fcathode_ydimension;
+    TVector3  fcathode_centre;
+
+    // Optical detector properties for semi-analytic hits
+    // int foptical_detector_type;  // unused
+    double fydimension, fzdimension, fradius;
+    int fdelta_angulo, fL_abs_vuv;
+    std::vector<std::vector<double> > fOpDetCenter;
+    std::vector<int>  fOpDetType;
+    std::vector<double>  fOpDetLength;
+    std::vector<double>  fOpDetHeight;
+    //double fGlobalTimeOffset;
+
+    void ProcessStep( const G4Step& step);
+
+    bool bPropagate; ///< Whether propagation of photons is enabled.
+
+  };
 
   double finter_d(double*, double*);
   double LandauPlusExpoFinal(double*, double*);
@@ -372,7 +384,7 @@ private:
   double model_close(double*, double*);
   double model_far(double*, double*);
   // structure definition for solid angle of rectangle function
-  struct acc{
+  struct acc {
     // ax,ay,az = centre of rectangle; w = width; h = height
     double ax, ay, az, w, h;
   };
@@ -384,134 +396,129 @@ private:
   double Disk_SolidAngle(double *x, double *p);
   double Disk_SolidAngle(double d, double h, double b);
 
-////////////////////
-// Inline methods
-////////////////////
+  ////////////////////
+  // Inline methods
+  ////////////////////
+  inline
+  G4bool OpFastScintillation::IsApplicable(const G4ParticleDefinition& aParticleType)
+  {
+    if (aParticleType.GetParticleName() == "opticalphoton") return false;
+    if (aParticleType.IsShortLived()) return false;
 
-inline
-G4bool OpFastScintillation::IsApplicable(const G4ParticleDefinition& aParticleType)
-{
-       if (aParticleType.GetParticleName() == "opticalphoton") return false;
-       if (aParticleType.IsShortLived()) return false;
+    return true;
+  }
 
-       return true;
-}
+  inline
+  void OpFastScintillation::SetTrackSecondariesFirst(const G4bool state)
+  {
+    fTrackSecondariesFirst = state;
+  }
 
-inline
-void OpFastScintillation::SetTrackSecondariesFirst(const G4bool state)
-{
-        fTrackSecondariesFirst = state;
-}
+  inline
+  void OpFastScintillation::SetFiniteRiseTime(const G4bool state)
+  {
+    fFiniteRiseTime = state;
+  }
 
-inline
-void OpFastScintillation::SetFiniteRiseTime(const G4bool state)
-{
-        fFiniteRiseTime = state;
-}
+  inline
+  G4bool OpFastScintillation::GetTrackSecondariesFirst() const
+  {
+    return fTrackSecondariesFirst;
+  }
 
-inline
-G4bool OpFastScintillation::GetTrackSecondariesFirst() const
-{
-        return fTrackSecondariesFirst;
-}
+  inline
+  G4bool OpFastScintillation::GetFiniteRiseTime() const
+  {
+    return fFiniteRiseTime;
+  }
 
-inline
-G4bool OpFastScintillation::GetFiniteRiseTime() const
-{
-        return fFiniteRiseTime;
-}
+  inline
+  void OpFastScintillation::SetScintillationYieldFactor(const G4double yieldfactor)
+  {
+    YieldFactor = yieldfactor;
+  }
 
-inline
-void OpFastScintillation::SetScintillationYieldFactor(const G4double yieldfactor)
-{
-        YieldFactor = yieldfactor;
-}
+  inline
+  G4double OpFastScintillation::GetScintillationYieldFactor() const
+  {
+    return YieldFactor;
+  }
 
-inline
-G4double OpFastScintillation::GetScintillationYieldFactor() const
-{
-        return YieldFactor;
-}
+  inline
+  void OpFastScintillation::SetScintillationExcitationRatio(const G4double excitationratio)
+  {
+    ExcitationRatio = excitationratio;
+  }
 
-inline
-void OpFastScintillation::SetScintillationExcitationRatio(const G4double excitationratio)
-{
-        ExcitationRatio = excitationratio;
-}
+  inline
+  G4double OpFastScintillation::GetScintillationExcitationRatio() const
+  {
+    return ExcitationRatio;
+  }
 
-inline
-G4double OpFastScintillation::GetScintillationExcitationRatio() const
-{
-        return ExcitationRatio;
-}
+  inline
+  G4PhysicsTable* OpFastScintillation::GetSlowIntegralTable() const
+  {
+    return theSlowIntegralTable;
+  }
 
-inline
-G4PhysicsTable* OpFastScintillation::GetSlowIntegralTable() const
-{
-        return theSlowIntegralTable;
-}
+  inline
+  G4PhysicsTable* OpFastScintillation::GetFastIntegralTable() const
+  {
+    return theFastIntegralTable;
+  }
 
-inline
-G4PhysicsTable* OpFastScintillation::GetFastIntegralTable() const
-{
-        return theFastIntegralTable;
-}
+  inline
+  void OpFastScintillation::DumpPhysicsTable() const
+  {
+    if (theFastIntegralTable) {
+      G4int PhysicsTableSize = theFastIntegralTable->entries();
+      G4PhysicsOrderedFreeVector *v;
+      for (G4int i = 0 ; i < PhysicsTableSize ; i++ ) {
+        v = (G4PhysicsOrderedFreeVector*)(*theFastIntegralTable)[i];
+        v->DumpValues();
+      }
+    }
+    if (theSlowIntegralTable) {
+      G4int PhysicsTableSize = theSlowIntegralTable->entries();
+      G4PhysicsOrderedFreeVector *v;
+      for (G4int i = 0 ; i < PhysicsTableSize ; i++ ) {
+        v = (G4PhysicsOrderedFreeVector*)(*theSlowIntegralTable)[i];
+        v->DumpValues();
+      }
+    }
+  }
 
-inline
-void OpFastScintillation::DumpPhysicsTable() const
-{
-        if (theFastIntegralTable) {
-           G4int PhysicsTableSize = theFastIntegralTable->entries();
-           G4PhysicsOrderedFreeVector *v;
+  inline
+  G4double OpFastScintillation::single_exp(G4double t, G4double tau2) const
+  {
+    return std::exp(-1.0 * t / tau2) / tau2;
+  }
 
-           for (G4int i = 0 ; i < PhysicsTableSize ; i++ )
-           {
-                v = (G4PhysicsOrderedFreeVector*)(*theFastIntegralTable)[i];
-                v->DumpValues();
-           }
-         }
+  inline
+  G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
+  {
+    return std::exp(-1.0 * t / tau2) * (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
+  }
 
-        if (theSlowIntegralTable) {
-           G4int PhysicsTableSize = theSlowIntegralTable->entries();
-           G4PhysicsOrderedFreeVector *v;
+  inline
+  G4double OpFastScintillation::Gaisser_Hillas(double x, double *par)
+  {
+    //This is the Gaisser-Hillas function
+    double X_mu_0 = par[3];
+    double Normalization = par[0];
+    double Diff = par[1] - X_mu_0;
+    double Term = pow((x - X_mu_0) / Diff, Diff / par[2]);
+    double Exponential = std::exp((par[1] - x) / par[2]);
+    return (Normalization * Term * Exponential);
+  }
 
-           for (G4int i = 0 ; i < PhysicsTableSize ; i++ )
-           {
-                v = (G4PhysicsOrderedFreeVector*)(*theSlowIntegralTable)[i];
-                v->DumpValues();
-           }
-         }
-}
-
-inline
-G4double OpFastScintillation::single_exp(G4double t, G4double tau2) const
-{
-         return std::exp(-1.0*t/tau2)/tau2;
-}
-
-inline
-G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
-{
-         return std::exp(-1.0*t/tau2)*(1-std::exp(-1.0*t/tau1))/tau2/tau2*(tau1+tau2);
-}
-
-inline
-G4double OpFastScintillation::Gaisser_Hillas(double x,double *par) {
-  //This is the Gaisser-Hillas function
-  double X_mu_0=par[3];
-  double Normalization=par[0];
-  double Diff=par[1]-X_mu_0;
-  double Term=pow((x-X_mu_0)/Diff,Diff/par[2]);
-  double Exponential=std::exp((par[1]-x)/par[2]);
-
-  return (Normalization*Term*Exponential);
-}
-
-inline
-G4double OpFastScintillation::Pol_5(double x, double *par) {
-  // 5th order polynomial function
-  return par[0] + par[1] * x + par[2] * pow(x,2) + par[3] * pow(x,3) + par[4] * pow(x,4) + par[5] * pow(x,5);
-}
+  inline
+  G4double OpFastScintillation::Pol_5(double x, double *par)
+  {
+    // 5th order polynomial function
+    return par[0] + par[1] * x + par[2] * pow(x, 2) + par[3] * pow(x, 3) + par[4] * pow(x, 4) + par[5] * pow(x, 5);
+  }
 
 } //namespace
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -133,7 +133,8 @@ namespace larg4 {
     // Constructors and Destructor
     ////////////////////////////////
 
-    OpFastScintillation(const G4String& processName = "Scintillation", G4ProcessType type = fElectromagnetic);
+    OpFastScintillation(const G4String& processName = "Scintillation",
+                        G4ProcessType type = fElectromagnetic);
     OpFastScintillation(const OpFastScintillation &right);
 
     ~OpFastScintillation();
@@ -255,10 +256,12 @@ namespace larg4 {
                     TVector3 OpDetPoint);
     // Visible component timing parameterisation
 
-    int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
+    int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint,
+                int optical_detector_type);
     // Calculates semi-analytic model number of hits for vuv component
 
-    int VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
+    int VISHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint,
+                int optical_detector_type);
     // Calculates semi-analytic model number of hits for visible component
 
   protected:
@@ -500,13 +503,13 @@ namespace larg4 {
   inline
   G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
   {
-    return std::exp(-1.0 * t / tau2) * (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
+    return std::exp(-1.0 * t / tau2) *
+      (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
   }
 
   inline
   G4double OpFastScintillation::Gaisser_Hillas(double x, double *par)
   {
-    //This is the Gaisser-Hillas function
     double X_mu_0 = par[3];
     double Normalization = par[0];
     double Diff = par[1] - X_mu_0;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -306,8 +306,8 @@ namespace larg4 {
                 const std::array<double, 3> hotspot);
     // Calculates semi-analytic model number of hits for visible component
 
-    constexpr G4double single_exp(const G4double t, const G4double tau2) const;
-    constexpr G4double bi_exp(const G4double t, const G4double tau1, const G4double tau2) const;
+    G4double single_exp(const G4double t, const G4double tau2) const;
+    G4double bi_exp(const G4double t, const G4double tau1, const G4double tau2) const;
 
     G4double scint_time(const G4Step& aStep,
                         G4double ScintillationTime,
@@ -366,7 +366,7 @@ namespace larg4 {
     double Disk_SolidAngle(const double d, const double h, const double b);
 
     //For VUV semi-analytic hits
-    constexpr G4double Gaisser_Hillas(const double x, const double *par);
+    G4double Gaisser_Hillas(const double x, const double *par);
     bool fUseNhitsModel;
     //array of correction for the VUV Nhits estimation
     std::vector<std::vector<double> > fGHvuvpars;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -248,7 +248,7 @@ namespace larg4 {
     // old timings -- to be deleted
 
     void getVUVTimes(std::vector<double>& arrivalTimes, double distance_in_cm);
-    void generateparam(int index);
+    void generateParam(const size_t index);
     // Functions for vuv component Landau + Exponential timing parameterisation, updated method
 
     void getVISTimes(std::vector<double>& arrivalTimes, TVector3 ScintPoint,
@@ -297,8 +297,8 @@ namespace larg4 {
     G4double scint_time(const G4Step& aStep,
                         G4double ScintillationTime,
                         G4double ScintillationRiseTime) const;
-    void propagation_time(std::vector<double>& arrival_time_dist, G4ThreeVector x0,
-                          int OpChannel, bool Reflected = false); //const;
+    void propagationTime(std::vector<double>& arrival_time_dist, G4ThreeVector x0,
+                         const size_t OpChannel, bool Reflected = false); //const;
 
     // emission time distribution when there is a finite rise time
     G4double sample_time(G4double tau1, G4double tau2) const;
@@ -528,10 +528,10 @@ namespace larg4 {
   }
 
   template<typename TReal> inline
-  double dist(TReal* x, TReal* y, const int dimension)
+  double dist(TReal* x, TReal* y, const unsigned int dimension)
   {
     double d = 0.;
-    for (int p=0; p<dimension; ++p){
+    for (unsigned int p=0; p<dimension; ++p){
       d += (*(x+p) - *(y+p)) * (*(x+p) - *(y+p));
     }
     return std::sqrt(d);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -508,7 +508,7 @@ namespace larg4 {
     double X_mu_0 = par[3];
     double Normalization = par[0];
     double Diff = par[1] - X_mu_0;
-    double Term = pow((x - X_mu_0) / Diff, Diff / par[2]);
+    double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
     double Exponential = std::exp((par[1] - x) / par[2]);
     return (Normalization * Term * Exponential);
   }
@@ -517,7 +517,7 @@ namespace larg4 {
   G4double OpFastScintillation::Pol_5(double x, double *par)
   {
     // 5th order polynomial function
-    return par[0] + par[1] * x + par[2] * pow(x, 2) + par[3] * pow(x, 3) + par[4] * pow(x, 4) + par[5] * pow(x, 5);
+    return par[0] + par[1] * x + par[2] * std::pow(x, 2) + par[3] * std::pow(x, 3) + par[4] * std::pow(x, 4) + par[5] * std::pow(x, 5);
   }
 
 } //namespace

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -247,11 +247,12 @@ namespace larg4 {
       std::vector<double> GetVisibleTimeOnlyCathode(double, int);*/
     // old timings -- to be deleted
 
-    std::vector<double> getVUVTime(double, int);
+    void getVUVTimes(std::vector<double>& arrivalTimes, double distance_in_cm);
     void generateparam(int index);
     // Functions for vuv component Landau + Exponential timing parameterisation, updated method
 
-    std::vector<double> getVISTime(TVector3 ScintPoint, TVector3 OpDetPoint, int Nphotons);
+    void getVISTimes(std::vector<double>& arrivalTimes, TVector3 ScintPoint,
+                    TVector3 OpDetPoint);
     // Visible component timing parameterisation
 
     int VUVHits(int Nphotons_created, TVector3 ScintPoint, TVector3 OpDetPoint, int optical_detector_type);
@@ -296,7 +297,8 @@ namespace larg4 {
     G4double scint_time(const G4Step& aStep,
                         G4double ScintillationTime,
                         G4double ScintillationRiseTime) const;
-    std::vector<double> propagation_time(G4ThreeVector x0, int OpChannel, int NPhotons, bool Reflected = false); //const;
+    void propagation_time(std::vector<double>& arrival_time_dist, G4ThreeVector x0,
+                          int OpChannel, bool Reflected = false); //const;
 
     // emission time distribution when there is a finite rise time
     G4double sample_time(G4double tau1, G4double tau2) const;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -378,9 +378,11 @@ namespace larg4 {
   double finter_d(double*, double*);
   double LandauPlusExpoFinal(double*, double*);
   //For new VUV time parametrization
-  double interpolate( std::vector<double> &xData, std::vector<double> &yData, double x, bool extrapolate );
-  double* interpolate( std::vector<double> &xData, std::vector<double> &yData1, std::vector<double> &yData2,
-                       std::vector<double> &yData3, double x, bool extrapolate);
+  double interpolate(std::vector<double> &xData, std::vector<double> &yData,
+                     double x, bool extrapolate);
+  void interpolate(double inter[], std::vector<double> &xData,
+                   std::vector<double> &yData1, std::vector<double> &yData2,
+                   std::vector<double> &yData3, double x, bool extrapolate);
   double model_close(double*, double*);
   double model_far(double*, double*);
   // structure definition for solid angle of rectangle function

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -558,6 +558,25 @@ namespace larg4 {
     return false;
   }
 
+    // template<typename Function, typename... Args>
+    // auto OpFastScintillation::invoke_memoized(Function function, Args... args)
+    // {
+    //   using key_type   = std::tuple<Args...>;
+    //   using value_type = std::invoke_result_t<Function, Args...>;
+    //   static_assert(! std::is_same_v<Function, std::function<value_type(Args...)>>,
+    //                 "cannot memoize on std::function (use a lambda instead)");
+    //   static_assert(! std::is_same_v<Function, value_type(*)(Args...)>,
+    //                 "cannot memoize on function pointer (use a lambda instead)");
+    //   static std::mutex mutex;
+    //   static std::map<key_type, value_type> cache;
+    //   auto key  = std::tuple(args...);
+    //   auto lock = std::lock_guard<std::mutex>(mutex);
+    //   if (cache.count(key)){
+    //     return cache[key];
+    //   }
+    //   return cache[key] = std::apply(function, key);
+    // }
+
 } // namespace larg4
 
 #endif /* OpFastScintillation_h */

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -405,6 +405,7 @@ namespace larg4 {
   static const size_t acos_bins = 2000000;
   static std::array<double, acos_bins+1> acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
   constexpr double acos_table(const double x);
+  constexpr double fast_acos(const double x);
 
   ////////////////////
   // Inline methods

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -398,16 +398,19 @@ namespace larg4 {
 
     bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
     bool isScintInActiveVolume(const std::array<double, 3> ScintPoint);
+    double interpolate(const std::vector<double> &xData,
+                       const std::vector<double> &yData,
+                       double x, bool extrapolate, size_t i=0);
+    void interpolate3(std::array<double, 3> &inter,
+                      const std::vector<double> &xData,
+                      const std::vector<double> &yData1,
+                      const std::vector<double> &yData2,
+                      const std::vector<double> &yData3,
+                      double x, bool extrapolate);
   };
 
   double finter_d(double*, double*);
   double LandauPlusExpoFinal(double*, double*);
-  //For new VUV time parametrization
-  double interpolate(std::vector<double> &xData, std::vector<double> &yData,
-                     double x, bool extrapolate);
-  void interpolate(double inter[], std::vector<double> &xData,
-                   std::vector<double> &yData1, std::vector<double> &yData2,
-                   std::vector<double> &yData3, double x, bool extrapolate);
   double model_close(double*, double*);
   double model_far(double*, double*);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -340,6 +340,17 @@ namespace larg4 {
     std::vector<std::vector<double>> fcut_off_pars;
     std::vector<std::vector<double>> ftau_pars;
 
+    // structure definition for solid angle of rectangle function
+    struct acc {
+      // ax,ay,az = centre of rectangle; w = width; h = height
+      double ax, ay, az, w, h;
+    };
+    // solid angle of rectangular aperture calculation functions
+    double Rectangle_SolidAngle(double a, double b, double d);
+    double Rectangle_SolidAngle(acc& out, TVector3 v);
+    // solid angle of circular aperture calculation functions
+    double Disk_SolidAngle(const double d, const double h, const double b);
+
     //For VUV semi-analytic hits
     G4double Gaisser_Hillas(double x, double *par);
     bool fUseNhitsModel;
@@ -350,7 +361,7 @@ namespace larg4 {
     double fYactive_corner, fZactive_corner, fReference_to_corner, fYcathode, fZcathode;
     double fminx, fmaxx, fminy, fmaxy, fminz, fmaxz;
     // For VIS semi-analytic hits
-    G4double Pol_5(double x, double *par);
+    double Pol_5(double x, double *par);
     bool fStoreReflected;
     // array of corrections for VIS Nhits estimation
     std::vector<std::vector<double>> fvispars;
@@ -390,17 +401,7 @@ namespace larg4 {
                    std::vector<double> &yData3, double x, bool extrapolate);
   double model_close(double*, double*);
   double model_far(double*, double*);
-  // structure definition for solid angle of rectangle function
-  struct acc {
-    // ax,ay,az = centre of rectangle; w = width; h = height
-    double ax, ay, az, w, h;
-  };
-  // solid angle of rectangular aperture calculation functions
-  double Rectangle_SolidAngle(double a, double b, double d);
-  double Rectangle_SolidAngle(acc& out, TVector3 v);
 
-  // solid angle of circular aperture calculation functions
-  double Disk_SolidAngle(const double d, const double h, const double b);
   ////////////////////
   // Inline methods
   ////////////////////
@@ -494,42 +495,6 @@ namespace larg4 {
     }
   }
 
-  inline
-  G4double OpFastScintillation::single_exp(G4double t, G4double tau2) const
-  {
-    return std::exp(-1.0 * t / tau2) / tau2;
-  }
-
-  inline
-  G4double OpFastScintillation::bi_exp(G4double t, G4double tau1, G4double tau2) const
-  {
-    return std::exp(-1.0 * t / tau2) *
-      (1 - std::exp(-1.0 * t / tau1)) / tau2 / tau2 * (tau1 + tau2);
-  }
-
-  inline
-  G4double OpFastScintillation::Gaisser_Hillas(double x, double *par)
-  {
-    double X_mu_0 = par[3];
-    double Normalization = par[0];
-    double Diff = par[1] - X_mu_0;
-    double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
-    double Exponential = std::exp((par[1] - x) / par[2]);
-    return (Normalization * Term * Exponential);
-  }
-
-  inline
-  double OpFastScintillation::Pol_5(double x, double *par)
-  {
-    // 5th order polynomial function
-    double xpow = 1.;
-    for(unsigned i=1; i<=5; ++i){
-      xpow *= x;
-      par[0] += par[i] * xpow ;
-    }
-    return par[0];
-  }
-
   template<typename TReal> inline
   double dist(TReal* x, TReal* y, const unsigned int dimension)
   {
@@ -576,6 +541,7 @@ namespace larg4 {
       return true;
     return false;
   }
-} //namespace
+
+} // namespace larg4
 
 #endif /* OpFastScintillation_h */

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -349,7 +349,7 @@ namespace larg4 {
                                           const double d);
     double Rectangle_SolidAngle(dims out, TVector3 v);
     // solid angle of circular aperture calculation functions
-    double Disk_SolidAngle(const double d, const double h, const double b);
+    constexpr double Disk_SolidAngle(const double d, const double h, const double b);
 
     //For VUV semi-analytic hits
     constexpr G4double Gaisser_Hillas(const double x, const double *par);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -347,7 +347,7 @@ namespace larg4 {
     // solid angle of rectangular aperture calculation functions
     constexpr double Rectangle_SolidAngle(const double a, const double b,
                                           const double d);
-    double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
+    constexpr double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
     // solid angle of circular aperture calculation functions
     constexpr double Disk_SolidAngle(const double d, const double h, const double b);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -347,7 +347,7 @@ namespace larg4 {
     // solid angle of rectangular aperture calculation functions
     constexpr double Rectangle_SolidAngle(const double a, const double b,
                                           const double d);
-    double Rectangle_SolidAngle(dims out, TVector3 v);
+    double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
     // solid angle of circular aperture calculation functions
     constexpr double Disk_SolidAngle(const double d, const double h, const double b);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -525,6 +525,15 @@ namespace larg4 {
     return par[0];
   }
 
+  template<typename TReal> inline
+  double dist(TReal* x, TReal* y, const int dimension)
+  {
+    double d = 0.;
+    for (int p=0; p<dimension; ++p){
+      d += (*(x+p) - *(y+p)) * (*(x+p) - *(y+p));
+    }
+    return std::sqrt(d);
+  }
 } //namespace
 
 #endif /* OpFastScintillation_h */

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -393,9 +393,7 @@ namespace larg4 {
   double Rectangle_SolidAngle(acc& out, TVector3 v);
 
   // solid angle of circular aperture calculation functions
-  double Disk_SolidAngle(double *x, double *p);
-  double Disk_SolidAngle(double d, double h, double b);
-
+  double Disk_SolidAngle(const double d, const double h, const double b);
   ////////////////////
   // Inline methods
   ////////////////////

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -396,6 +396,8 @@ namespace larg4 {
 
     bool bPropagate; ///< Whether propagation of photons is enabled.
 
+    bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
+    bool isScintInActiveVolume(const std::array<double, 3> ScintPoint);
   };
 
   double finter_d(double*, double*);


### PR DESCRIPTION
Have done some major refactoring of the code inside `LegacyLArG4/OpFastScintillation`. 

Testing on a sbndgpvm on Cosmics + Neutrino events; the most cpu and memory hungry of events, I have achieved close to half of running time and a comparable memory footprint.

Despite using some fast approximations to the most used functions there is no measurable bias in the OpHits.

Along the way I have also address some of the underlying potential bugs that were hidden in the code. The most salient one had to with  a domain error exception calling the boost elliptic integral functions, as far as I can tell this would happen due to a floating point error bloating. 