### PR TITLE
SingleGen module now adds `RunData` information as per LArSoft protocol.

### DIFF
--- a/larsim/EventGenerator/SingleGen_module.cc
+++ b/larsim/EventGenerator/SingleGen_module.cc
@@ -508,8 +508,9 @@ namespace evgen{
   //____________________________________________________________________________
   void SingleGen::beginRun(art::Run& run)
   {
-    art::ServiceHandle<geo::Geometry const> geo;
-    run.put(std::make_unique<sumdata::RunData>(geo->DetectorName()));
+    geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry>());
+    run.put
+      (std::make_unique<sumdata::RunData>(geom.DetectorName()), art::fullRun());
   }
 
 

--- a/larsim/EventGenerator/SingleGen_module.cc
+++ b/larsim/EventGenerator/SingleGen_module.cc
@@ -40,6 +40,12 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 
+// LArSoft libraries
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcoreobj/SummaryData/RunData.h"
+
+
 #include "TVector3.h"
 #include "TDatabasePDG.h"
 #include "TFile.h"
@@ -300,6 +306,10 @@ namespace evgen {
     static std::map<int, std::string> makeDistributionNames();
 
 
+    /// Act on begin of run: write "RunData" information (`sumdata::RunData`).
+    void beginRun(art::Run& run) override;
+
+
     /// Performs checks and initialization based on the current configuration.
     void setup();
 
@@ -490,6 +500,16 @@ namespace evgen{
     }
 
     produces< std::vector<simb::MCTruth> >();
+    produces< sumdata::RunData, art::InRun >();
+
+  }
+
+
+  //____________________________________________________________________________
+  void SingleGen::beginRun(art::Run& run)
+  {
+    art::ServiceHandle<geo::Geometry const> geo;
+    run.put(std::make_unique<sumdata::RunData>(geo->DetectorName()));
   }
 
 


### PR DESCRIPTION
`SingleGen` does currently not write `sumdata::RunData` data product, which foils the already loosy geometry version check.
This change makes `SingleGen` create that data product just like `GENIEGen` does (as in: I copied the code from there).
This is not a breaking change; only new samples will be affected.