### PR TITLE
Fix for POTaggregator module

### DIFF
--- a/larsim/EventGenerator/POTaccumulator_module.cc
+++ b/larsim/EventGenerator/POTaccumulator_module.cc
@@ -221,13 +221,13 @@ void sim::POTaccumulator::endJob() {
   //
   // print the total summary
   //
-  
+
   // here we skip _art_ aggregation mechanism
   // because it can't handle multiple runs
   sumdata::POTSummary totalPOT;
   for (auto const& POT: fRunPOT | ranges::view::values)
     totalPOT.aggregate(POT.value());
-  
+
   printSummary(totalPOT);
 
 } // sim::POTaccumulator::endJob()


### PR DESCRIPTION
Please review this request and the base of it.

In short, I wrote code aggregating POT summaries (a data product) from different runs using `art::SummedValue`, but it now appears to me that _art_ ranges (`art::RangeSet`) do not support ranges crossing runs.
The effect is that `R:1 S:1` and `R:2 S:1` events are treated as belonging to the same subrun, and an exception is thrown when their event number range overlaps.
In this fix I dropped `art::SummedValue` for the inter-run aggregation.
