### PR TITLE
Bug fix on LightSource

### DIFF
--- a/larsim/EventGenerator/LightSource_module.cc
+++ b/larsim/EventGenerator/LightSource_module.cc
@@ -535,7 +535,7 @@ namespace evgen{
       //assume the position is relative to the center of the TPC
       //x += fTPCCenter;
 
-      fShotPos = TLorentzVector(fCenter.X(), fCenter.Y(), fCenter.Z(), t);
+      fShotPos = TLorentzVector(x.X(), x.Y(), x.Z(), t);
 
 
       // Choose angles


### PR DESCRIPTION
I have found a bug I introduced with my last pull request.
Normally `LightSource` module produces each photon on a randomised location offset from a central location.
I was actually always writing the central location to the event, instead of the randomised one.
The fix is quite simple. Just pick the right variable, for once.