### PR TITLE
New Sim Filter using the sim::SimPhotonsLite data product

### DIFF
--- a/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
+++ b/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
@@ -4,6 +4,11 @@
 // File:        FilterSimPhotonLiteTime_module.cc
 //
 // Author: Gray Putnam -- ported from FilterSimPhotonTime
+//
+// Module for filtering events based on the number of true photons
+// hitting optical detectors inside a time window. Uses the
+// sim::SimPhotonsLite data product as input (see FilterSimPhotonTime
+// for filtering using the sim::SimPhotons data product).
 ////////////////////////////////////////////////////////////////////////
 
 #include "art/Framework/Core/ModuleMacros.h"
@@ -38,13 +43,13 @@ public:
 private:
   bool filter(art::Event& e, art::ProcessingFrame const&) override;
 
-  std::string const fSimPhotonsLiteCollectionLabel;
-  std::vector<std::vector<int>> const fTimeWindows;
-  int const fMinTotalPhotons;
-  bool const fDebug;
-  std::size_t const fN;
-  bool fUseReflectedPhotons;
-  std::string fReflectedLabel;
+  std::string const fSimPhotonsLiteCollectionLabel; //!< Label for the sim::SimPhotonsLite data product
+  std::vector<std::vector<int>> const fTimeWindows; //!< Time windows used for filtering. Units are the same as in the sim::SimPhotonsLite
+  int const fMinTotalPhotons; //!< Minimum number of photons inside a window to pass the filter
+  bool const fDebug; //!< Set to true to print (a lot of) debug information.
+  std::size_t const fN; //!< Number of time winows.
+  bool fUseReflectedPhotons; //!< Whether to include reflected photons in the filter.
+  std::string fReflectedLabel; //!< Label for the reflected photons -- "Reflected" by default.
 
   void CheckTimeWindows() const;
 };

--- a/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
+++ b/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
@@ -1,0 +1,165 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       FilterSimPhotonLiteTime
+// Module Type: filter
+// File:        FilterSimPhotonLiteTime_module.cc
+//
+// Author: Gray Putnam -- ported from FilterSimPhotonTime
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/SharedFilter.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include <memory>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "lardataobj/Simulation/SimPhotons.h"
+#include "lardataobj/Simulation/SimPhotons.h"
+
+namespace simfilter {
+  class FilterSimPhotonLiteTime;
+}
+
+class simfilter::FilterSimPhotonLiteTime : public art::SharedFilter {
+public:
+  explicit FilterSimPhotonLiteTime(fhicl::ParameterSet const& p,
+                               art::ProcessingFrame const&);
+
+  // Plugins should not be copied or assigned.
+  FilterSimPhotonLiteTime(FilterSimPhotonLiteTime const&) = delete;
+  FilterSimPhotonLiteTime(FilterSimPhotonLiteTime&&) = delete;
+  FilterSimPhotonLiteTime& operator=(FilterSimPhotonLiteTime const&) = delete;
+  FilterSimPhotonLiteTime& operator=(FilterSimPhotonLiteTime&&) = delete;
+
+private:
+  bool filter(art::Event& e, art::ProcessingFrame const&) override;
+
+  std::string const fSimPhotonsLiteCollectionLabel;
+  std::vector<std::vector<int>> const fTimeWindows;
+  int const fMinTotalPhotons;
+  bool const fDebug;
+  std::size_t const fN;
+  bool fUseReflectedPhotons;
+  std::string fReflectedLabel;
+
+  void CheckTimeWindows() const;
+};
+
+simfilter::FilterSimPhotonLiteTime::FilterSimPhotonLiteTime(
+  fhicl::ParameterSet const& p,
+  art::ProcessingFrame const&)
+  : SharedFilter{p}
+  , fSimPhotonsLiteCollectionLabel(p.get<std::string>("SimPhotonsLiteCollectionLabel"))
+  , fTimeWindows(p.get<std::vector<std::vector<int>>>("TimeWindows"))
+  , fMinTotalPhotons(p.get<int>("MinTotalPhotons"))
+  , fDebug(p.get<bool>("Debug", false))
+  , fN(fTimeWindows.size())
+  , fUseReflectedPhotons(p.get<bool>("UseReflectedPhotons", false))
+  , fReflectedLabel(p.get<std::string>("fReflectedLabel", "Reflected"))
+{
+  CheckTimeWindows();
+
+  // For printing out debug messages, we want to serialize the
+  // event-level calls so that the messages are not garbled.
+  // Otherwise, this module works well for asynchronous event-level
+  // calls.
+  if (fDebug) {
+    serialize();
+  } else {
+    async<art::InEvent>();
+  }
+}
+
+void
+simfilter::FilterSimPhotonLiteTime::CheckTimeWindows() const
+{
+
+  if (fDebug)
+    std::cout << "\tFilterSimPhotonLiteTime: TimeWindows size is "
+              << fTimeWindows.size() << std::endl;
+
+  for (auto const& tw : fTimeWindows) {
+    if (tw.size() != 2)
+      throw cet::exception("FilterSimPhotonLiteTime::CheckTimeWindows")
+        << "Bad time window initialization: time window has wrong size (not 2)."
+        << std::endl;
+
+    if (fDebug)
+      std::cout << "\t\tTimeWindow "
+                << "[" << tw[0] << "," << tw[1] << "]" << std::endl;
+
+    if (tw[0] > tw[1])
+      throw cet::exception("FilterSimPhotonLiteTime::CheckTimeWindows")
+        << "Bad time window initialization: tw[0]>tw[1]. Reverse the order!"
+        << std::endl;
+  }
+}
+
+bool
+simfilter::FilterSimPhotonLiteTime::filter(art::Event& e,
+                                       art::ProcessingFrame const&)
+{
+  auto const& simPhotonsLiteCollection =
+    *e.getValidHandle<std::vector<sim::SimPhotonsLite>>(fSimPhotonsLiteCollectionLabel);
+
+  std::vector<int> sumNPhotonArray(fN, 0);
+
+  const std::vector<sim::SimPhotonsLite> &simPhotonsLiteCollectionReflected = fUseReflectedPhotons ?
+    *e.getValidHandle<std::vector<sim::SimPhotonsLite>>({fSimPhotonsLiteCollectionLabel, fReflectedLabel}) : std::vector<sim::SimPhotonsLite>();
+
+  size_t n_sim_photons = simPhotonsLiteCollection.size() + simPhotonsLiteCollectionReflected.size();
+
+  if (fDebug) {
+    std::cout << "New event to filter with total # sim photons: " << n_sim_photons << std::endl;
+  }
+    
+  for (size_t i_pc = 0; i_pc < n_sim_photons; i_pc++) {
+    const sim::SimPhotonsLite &simphotonslite = (i_pc < simPhotonsLiteCollection.size()) ? 
+      simPhotonsLiteCollection[i_pc] : simPhotonsLiteCollectionReflected[i_pc - simPhotonsLiteCollection.size()];
+
+    if (fDebug)
+      std::cout << "\tFilterSimPhotonLiteTime: Processing simphotonslite channel "
+                << simphotonslite.OpChannel << std::endl;
+
+    for (auto const& photon_pair: simphotonslite.DetectedPhotons) {
+      for (size_t i_tw = 0; i_tw < fN; ++i_tw) {
+        auto const& tw(fTimeWindows[i_tw]);
+        if (photon_pair.first >= tw[0] && photon_pair.first <= tw[1]) {
+
+          if (fDebug) {
+            std::string photon_string = (i_pc < simPhotonsLiteCollection.size()) ? "Photon" : "Reflected Photon";
+            std::cout << "\t\t" << photon_string << " with number " << photon_pair.second 
+                      << " at time " << photon_pair.first << " detected." << std::endl;
+          }
+
+          sumNPhotonArray[i_tw] += photon_pair.second;
+
+          if (fDebug)
+            std::cout << "\t\tTotal number of photons in this window (" << i_tw
+                      << ") is now " << sumNPhotonArray[i_tw] << std::endl;
+
+          if (sumNPhotonArray[i_tw] >= fMinTotalPhotons) 
+            return true;
+        }
+      }
+    }
+  }
+
+  if (fDebug) {
+    std::cout << "\tFilterSimPhotonLiteTime: Final total numbers are below min of "
+              << fMinTotalPhotons << ":" << std::endl;
+    for (size_t i_tw = 0; i_tw < fN; ++i_tw) {
+      std::cout << "\t\tTimeWindow "
+                << "[" << fTimeWindows[i_tw][0] << "," << fTimeWindows[i_tw][1]
+                << "]: " << sumNPhotonArray[i_tw] << std::endl;
+    }
+  }
+
+  return false;
+}
+
+DEFINE_ART_MODULE(simfilter::FilterSimPhotonLiteTime)

--- a/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
+++ b/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
@@ -48,8 +48,8 @@ private:
   int const fMinTotalPhotons; //!< Minimum number of photons inside a window to pass the filter
   bool const fDebug; //!< Set to true to print (a lot of) debug information.
   std::size_t const fN; //!< Number of time winows.
-  bool fUseReflectedPhotons; //!< Whether to include reflected photons in the filter.
-  std::string fReflectedLabel; //!< Label for the reflected photons -- "Reflected" by default.
+  bool const fUseReflectedPhotons; //!< Whether to include reflected photons in the filter.
+  std::string const fReflectedLabel; //!< Label for the reflected photons -- "Reflected" by default.
 
   void CheckTimeWindows() const;
 };
@@ -64,7 +64,7 @@ simfilter::FilterSimPhotonLiteTime::FilterSimPhotonLiteTime(
   , fDebug(p.get<bool>("Debug", false))
   , fN(fTimeWindows.size())
   , fUseReflectedPhotons(p.get<bool>("UseReflectedPhotons", false))
-  , fReflectedLabel(p.get<std::string>("fReflectedLabel", "Reflected"))
+  , fReflectedLabel(p.get<std::string>("ReflectedLabel", "Reflected"))
 {
   CheckTimeWindows();
 

--- a/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
+++ b/larsim/SimFilters/FilterSimPhotonLiteTime_module.cc
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "lardataobj/Simulation/SimPhotons.h"
-#include "lardataobj/Simulation/SimPhotons.h"
 
 namespace simfilter {
   class FilterSimPhotonLiteTime;

--- a/larsim/SimFilters/FilterSimPhotonTime_module.cc
+++ b/larsim/SimFilters/FilterSimPhotonTime_module.cc
@@ -45,8 +45,8 @@ private:
   float const fMinPhotonEnergy;
   bool const fDebug;
   std::size_t const fN;
-  bool fUseReflectedPhotons;
-  std::string fReflectedLabel;
+  bool const fUseReflectedPhotons;
+  std::string const fReflectedLabel;
 
   void CheckTimeWindows() const;
 };
@@ -62,7 +62,7 @@ simfilter::FilterSimPhotonTime::FilterSimPhotonTime(
   , fDebug(p.get<bool>("Debug", false))
   , fN(fTimeWindows.size())
   , fUseReflectedPhotons(p.get<bool>("UseReflectedPhotons", false))
-  , fReflectedLabel(p.get<std::string>("fReflectedLabel", "Reflected"))
+  , fReflectedLabel(p.get<std::string>("ReflectedLabel", "Reflected"))
 {
   CheckTimeWindows();
 


### PR DESCRIPTION
Hello!

This request incorporates a new filter into the `SimFilters/` directory. It is a module that replicates the functionality of the `FilterSimPhotonTime` filter except using `sim::SimPhotonsLite` instead of `sim::SimPhotons` as a data product.

I elected to write this as a new module (as opposed to porting `FilterSimPhotonTime` to handle both cases) because the code is minimal and mostly involves parsing the `sim::SimPhotonsLite` data product. Thus, porting `FilterSimPhotonTime` to handle both cases would mostly involve something like:

```
if (hasSimPhotons)
    FilterSimPhotons()
else
    FilterSimPhotonsLite()
```
and so I thought it would be cleaner to just write a new module. In addition, `FilterSimPhotonTime` requires cutting on the energy of the photons, which is not possible using the `sim::SimPhotonsLite` data product, and so the filter would have to be reorganized to handle both data products.

I have verified that the functionality works on a number of example input files.

I am not 100% sure on the procedure to merge content into larsoft, so please let me know what steps I should take in order to get this merged. Thank you!