### PR TITLE
Proposed resolution for issue #24600.

### DIFF
--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -220,7 +220,7 @@ namespace larg4 {
           << ")"
           ;
       } // local scope
-      
+
       if (usesSemiAnalyticModel() && (geom.Ncryostats() > 1U)) {
         if (fOnlyOneCryostat) {
           mf::LogWarning("OpFastScintillation")
@@ -303,7 +303,7 @@ namespace larg4 {
       if(usesSemiAnalyticModel()) {
         mf::LogVerbatim("OpFastScintillation")
           << "OpFastScintillation: using semi-analytic model for number of hits";
-        
+
         // LAr absorption length in cm
         std::map<double, double> abs_length_spectrum = lar::providerFrom<detinfo::LArPropertiesService>()->AbsLengthSpectrum();
         std::vector<double> x_v, y_v;
@@ -1505,13 +1505,13 @@ namespace larg4 {
     }
   }
 
-  
+
   // ---------------------------------------------------------------------------
   bool OpFastScintillation::usesSemiAnalyticModel() const {
     return fUseNhitsModel;
   } // OpFastScintillation::usesSemiAnalyticModel()
-  
-  
+
+
   // ---------------------------------------------------------------------------
   void OpFastScintillation::detectedDirectHits(std::map<size_t, int>& DetectedNum,
                                                const double Num,
@@ -2107,29 +2107,29 @@ namespace larg4 {
     return 0.;
   }
 
-  
+
   // ---------------------------------------------------------------------------
   std::vector<geo::BoxBoundedGeo> OpFastScintillation::extractActiveVolumes
     (geo::GeometryCore const& geom)
   {
     std::vector<geo::BoxBoundedGeo> activeVolumes;
     activeVolumes.reserve(geom.Ncryostats());
-    
+
     for (geo::CryostatGeo const& cryo: geom.IterateCryostats()) {
-      
+
       // can't use it default-constructed since it would always include origin
       geo::BoxBoundedGeo box { cryo.TPC(0).ActiveBoundingBox() };
-      
+
       for (geo::TPCGeo const& TPC: cryo.IterateTPCs())
         box.ExtendToInclude(TPC.ActiveBoundingBox());
-        
+
       activeVolumes.push_back(std::move(box));
-      
+
     } // for cryostats
-    
+
     return activeVolumes;
   } // OpFastScintillation::extractActiveVolumes()
-  
+
   // ---------------------------------------------------------------------------
 
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -349,23 +349,6 @@ namespace larg4 {
   }
 
 
-  OpFastScintillation::OpFastScintillation(const OpFastScintillation& rhs)
-    :  G4VRestDiscreteProcess(rhs.GetProcessName(), rhs.GetProcessType())
-  {
-    theSlowIntegralTable        = rhs.GetSlowIntegralTable();
-    theFastIntegralTable        = rhs.GetFastIntegralTable();
-
-    fTrackSecondariesFirst      = rhs.GetTrackSecondariesFirst();
-    fFiniteRiseTime             = rhs.GetFiniteRiseTime();
-    YieldFactor                 = rhs.GetScintillationYieldFactor();
-    ExcitationRatio             = rhs.GetScintillationExcitationRatio();
-    scintillationByParticleType = rhs.GetScintillationByParticleType();
-    emSaturation                = rhs.GetSaturation();
-
-    BuildThePhysicsTable();
-  }
-
-
   ////////////////
   // Destructors
   ////////////////

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -186,9 +186,6 @@ namespace larg4 {
 
     scintillationByParticleType = larp->ScintByParticleType();
 
-    theFastIntegralTable = NULL;
-    theSlowIntegralTable = NULL;
-
     if (verboseLevel > 0) {
       G4cout << GetProcessName() << " is created " << G4endl;
     }
@@ -354,14 +351,8 @@ namespace larg4 {
   ////////////////
   OpFastScintillation::~OpFastScintillation()
   {
-    if (theFastIntegralTable != NULL) {
-      theFastIntegralTable->clearAndDestroy();
-      delete theFastIntegralTable;
-    }
-    if (theSlowIntegralTable != NULL) {
-      theSlowIntegralTable->clearAndDestroy();
-      delete theSlowIntegralTable;
-    }
+    if (theFastIntegralTable) theFastIntegralTable->clearAndDestroy();
+    if (theSlowIntegralTable) theSlowIntegralTable->clearAndDestroy();
   }
 
   ////////////
@@ -868,8 +859,8 @@ namespace larg4 {
     G4int numOfMaterials = G4Material::GetNumberOfMaterials();
 
     // create new physics table
-    if(!theFastIntegralTable)theFastIntegralTable = new G4PhysicsTable(numOfMaterials);
-    if(!theSlowIntegralTable)theSlowIntegralTable = new G4PhysicsTable(numOfMaterials);
+    if(!theFastIntegralTable)theFastIntegralTable = std::make_unique<G4PhysicsTable>(numOfMaterials);
+    if(!theSlowIntegralTable)theSlowIntegralTable = std::make_unique<G4PhysicsTable>(numOfMaterials);
 
     // loop for materials
     for (G4int i = 0 ; i < numOfMaterials; i++) {

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -136,6 +136,7 @@
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "larcorealg/CoreUtils/counter.h"
 #include "larcorealg/Geometry/geo_vectors_utils.h" // geo::vect::fillCoords()
+#include "larcorealg/Geometry/geo_vectors_utils_TVector.h" // geo::vect::toTVector3()
 
 // support libraries
 #include "cetlib_except/exception.h"
@@ -1067,19 +1068,17 @@ namespace larg4 {
     }
     else if (fPVS->IncludePropTime()) {
       // Get VUV photons arrival time distribution from the parametrization
-      const G4ThreeVector OpDetPoint(fOpDetCenter.at(OpChannel).X()*CLHEP::cm,
-                                     fOpDetCenter.at(OpChannel).Y()*CLHEP::cm,
-                                     fOpDetCenter.at(OpChannel).Z()*CLHEP::cm);
+      geo::Point_t const& opDetCenter = fOpDetCenter.at(OpChannel);
       if (!Reflected) {
+        const G4ThreeVector OpDetPoint(opDetCenter.X() * CLHEP::cm,
+                                       opDetCenter.Y() * CLHEP::cm,
+                                       opDetCenter.Z() * CLHEP::cm);
         double distance_in_cm = (x0 - OpDetPoint).mag() / CLHEP::cm; // this must be in CENTIMETERS!
         getVUVTimes(arrival_time_dist, distance_in_cm); // in ns
       }
       else {
-        TVector3 ScintPoint( x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm ); // in cm
-        TVector3 OpDetPoint_tv3(fOpDetCenter.at(OpChannel).X(),
-                                fOpDetCenter.at(OpChannel).Y(),
-                                fOpDetCenter.at(OpChannel).Z()); // in cm
-        getVISTimes(arrival_time_dist, ScintPoint, OpDetPoint_tv3); // in ns
+        TVector3 const ScintPoint( x0[0]/CLHEP::cm, x0[1]/CLHEP::cm, x0[2]/CLHEP::cm ); // in cm
+        getVISTimes(arrival_time_dist, ScintPoint, geo::vect::toTVector3(opDetCenter)); // in ns
       }
     }
   }

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -204,7 +204,7 @@ namespace larg4 {
       assert(fPVS);
 
       // Loading the position of each optical channel, neccessary for the parametrizatiuons of Nhits and prop-time
-      static art::ServiceHandle<geo::Geometry const> geo;
+      geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry>());
 
       {
         auto log = mf::LogTrace("OpFastScintillation")
@@ -221,11 +221,11 @@ namespace larg4 {
           ;
       } // local scope
       
-      if (usesSemiAnalyticModel() && (geo->Ncryostats() > 1U)) {
+      if (usesSemiAnalyticModel() && (geom.Ncryostats() > 1U)) {
         if (fOnlyOneCryostat) {
           mf::LogWarning("OpFastScintillation")
             << std::string(80, '=')
-            << "\nA detector with " << geo->Ncryostats() << " cryostats is configured"
+            << "\nA detector with " << geom.Ncryostats() << " cryostats is configured"
             << " , and semi-analytic model is requested for scintillation photon propagation."
             << " THIS CONFIGURATION IS NOT SUPPORTED and it is open to bugs"
             << " (e.g. scintillation may be detected only in cryostat #0)."
@@ -242,7 +242,7 @@ namespace larg4 {
       } // if
 
       geo::Point_t const Cathode_centre {
-        geo->TPC(0, 0).GetCathodeCenter().X(),
+        geom.TPC(0, 0).GetCathodeCenter().X(),
         fActiveVolumes[0].CenterY(),
         fActiveVolumes[0].CenterZ()
         };
@@ -256,7 +256,7 @@ namespace larg4 {
       // }
 
       for(size_t const i: util::counter(fPVS->NOpChannels())) {
-        geo::OpDetGeo const& opDet = geo->OpDetGeoFromOpDet(i);
+        geo::OpDetGeo const& opDet = geom.OpDetGeoFromOpDet(i);
         fOpDetCenter.push_back(opDet.GetCenter());
         if (opDet.isBar()) {
           fOpDetType.push_back(0);//Arapucas
@@ -265,12 +265,12 @@ namespace larg4 {
         }
         else {
           fOpDetType.push_back(1); //PMTs
-          //    std::cout<<"Radio: "<<geo->OpDetGeoFromOpDet(i).RMax()<<std::endl;
+          //    std::cout<<"Radio: "<<geom.OpDetGeoFromOpDet(i).RMax()<<std::endl;
           fOpDetLength.push_back(-1);
           fOpDetHeight.push_back(-1);
         }
-        // std::cout <<"OpChannel: "<<i<<"  Optical_Detector_Type: "<< type_i <<"  APERTURE_height: "
-                  // <<geo->OpDetGeoFromOpDet(i).Height()<<"  APERTURE_width: "<<geo->OpDetGeoFromOpDet(i).Length()<< std::endl;
+        // std::cout <<"OpChannel: "<<i<<"  Optical_Detector_Type: "<< fOpDetType.back() <<"  APERTURE_height: "
+                  // <<opDet.Height()<<"  APERTURE_width: "<<opDet.Length()<< std::endl;
       }
 
       if(fPVS->IncludePropTime()) {
@@ -349,7 +349,7 @@ namespace larg4 {
           else fApplyVisBorderCorrection = false;
 
           // cathode dimensions required for corrections
-          fcathode_centre = geo->TPC(0, 0).GetCathodeCenter();
+          fcathode_centre = geom.TPC(0, 0).GetCathodeCenter();
           fcathode_centre[1] = fActiveVolumes[0].CenterY();
           fcathode_centre[2] = fActiveVolumes[0].CenterZ(); // to get full cathode dimension rather than just single tpc
           fcathode_ydimension = fActiveVolumes[0].SizeY();

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -99,6 +99,9 @@
 #include "TF1.h"
 #include "TVector3.h"
 
+#include <memory> // std::unique_ptr
+
+
 class G4EmSaturation;
 class G4Step;
 class G4Track;
@@ -138,18 +141,6 @@ namespace larg4 {
     OpFastScintillation(const G4String& processName = "Scintillation",
                         G4ProcessType type = fElectromagnetic);
     
-    // BUG: copy is broken since the different copies may share tables,
-    //      and each copy believes to own them;
-    //      standard C++ solution applies (`std::shared_ptr`)
-    OpFastScintillation(OpFastScintillation const &) = delete;
-    OpFastScintillation& operator= (OpFastScintillation const&)= delete;
-    
-    // BUG: move is broken since the source object destructor will destroy
-    //      the  table that has been surrendered to the right-hand operand;
-    //      standard C++ solution applies (`std::unique_ptr`)
-    OpFastScintillation(OpFastScintillation&&) = delete;
-    OpFastScintillation& operator= (OpFastScintillation&&) = delete;
-
     ~OpFastScintillation();
 
     ////////////
@@ -285,8 +276,8 @@ namespace larg4 {
     // Class Data Members
     ///////////////////////
 
-    G4PhysicsTable* theSlowIntegralTable;
-    G4PhysicsTable* theFastIntegralTable;
+    std::unique_ptr<G4PhysicsTable> theSlowIntegralTable;
+    std::unique_ptr<G4PhysicsTable> theFastIntegralTable;
 
     G4bool fTrackSecondariesFirst;
     G4bool fFiniteRiseTime;
@@ -507,13 +498,13 @@ namespace larg4 {
   inline
   G4PhysicsTable* OpFastScintillation::GetSlowIntegralTable() const
   {
-    return theSlowIntegralTable;
+    return theSlowIntegralTable.get();
   }
 
   inline
   G4PhysicsTable* OpFastScintillation::GetFastIntegralTable() const
   {
-    return theFastIntegralTable;
+    return theFastIntegralTable.get();
   }
 
   inline

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -410,13 +410,20 @@ namespace larg4 {
 
     void ProcessStep( const G4Step& step);
 
-    bool bPropagate; ///< Whether propagation of photons is enabled.
+    bool const bPropagate; ///< Whether propagation of photons is enabled.
     
     /// Photon visibility service instance.
     phot::PhotonVisibilityService const* const fPVS;
 
     /// Whether the semi-analytic model is being used for photon visibility.
     bool const fUseNhitsModel = false;
+    /// Whether photon propagation is performed only from active volumes
+    bool const fOnlyActiveVolume = false;
+    /// Allows running even if light on cryostats `C:1` and higher is not supported.
+    /// Currently hard coded "no"
+    bool const fOnlyOneCryostat = false;
+    /// Whether the cathodes are fully opaque; currently hard coded "no".
+    bool const fOpaqueCathode = false;
 
     bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
     bool isScintInActiveVolume(const std::array<double, 3>& ScintPoint);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -110,6 +110,7 @@ namespace CLHEP {
   class RandGeneral;
 }
 namespace geo { class GeometryCore; }
+namespace phot { class PhotonVisibilityService; }
 
 // Class Description:
 // RestDiscrete Process - Generation of Scintillation Photons.
@@ -407,6 +408,9 @@ namespace larg4 {
     void ProcessStep( const G4Step& step);
 
     bool bPropagate; ///< Whether propagation of photons is enabled.
+    
+    /// Photon visibility service instance.
+    phot::PhotonVisibilityService const* const fPVS;
 
     bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
     bool isScintInActiveVolume(const std::array<double, 3>& ScintPoint);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -85,6 +85,7 @@
 
 #include "larsim/PhotonPropagation/PhotonVisibilityTypes.h" // phot::MappedT0s_t
 #include "larcorealg/Geometry/BoxBoundedGeo.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h" // geo::Point_t
 
 #include "Geant4/G4ThreeVector.hh"
 #include "Geant4/G4VRestDiscreteProcess.hh"
@@ -296,20 +297,20 @@ namespace larg4 {
     
     void detectedDirectHits(std::map<size_t, int>& DetectedNum,
                             const double Num,
-                            const std::array<double, 3> ScintPoint);
+                            geo::Point_t const& ScintPoint);
     void detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
                             const double Num,
-                            const std::array<double, 3> ScintPoint);
+                            geo::Point_t const& ScintPoint);
 
     int VUVHits(const int Nphotons_created,
-                const std::array<double, 3> ScintPoint,
-                const std::array<double, 3> OpDetPoint,
+                geo::Point_t const& ScintPoint,
+                geo::Point_t const& OpDetPoint,
                 const int optical_detector_type);
     // Calculates semi-analytic model number of hits for vuv component
 
     int VISHits(const int Nphotons_created,
-                const std::array<double, 3> ScintPoint,
-                const std::array<double, 3> OpDetPoint,
+                geo::Point_t const& ScintPoint,
+                geo::Point_t const& OpDetPoint,
                 const int optical_detector_type,
                 const double cathode_hits_rec,
                 const std::array<double, 3> hotspot);
@@ -402,7 +403,7 @@ namespace larg4 {
     double fydimension, fzdimension, fradius;
     dims detPoint, cathode_plane;
     int fdelta_angulo, fL_abs_vuv;
-    std::vector<std::array<double, 3>> fOpDetCenter;
+    std::vector<geo::Point_t> fOpDetCenter;
     std::vector<int>  fOpDetType;
     std::vector<double>  fOpDetLength;
     std::vector<double>  fOpDetHeight;
@@ -425,8 +426,9 @@ namespace larg4 {
     /// Whether the cathodes are fully opaque; currently hard coded "no".
     bool const fOpaqueCathode = false;
 
-    bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
-    bool isScintInActiveVolume(const std::array<double, 3>& ScintPoint);
+    bool isOpDetInSameTPC
+      (geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
+    bool isScintInActiveVolume(geo::Point_t const& ScintPoint);
     double interpolate(const std::vector<double> &xData,
                        const std::vector<double> &yData,
                        double x, bool extrapolate, size_t i=0);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -137,7 +137,18 @@ namespace larg4 {
 
     OpFastScintillation(const G4String& processName = "Scintillation",
                         G4ProcessType type = fElectromagnetic);
-    OpFastScintillation(const OpFastScintillation &right);
+    
+    // BUG: copy is broken since the different copies may share tables,
+    //      and each copy believes to own them;
+    //      standard C++ solution applies (`std::shared_ptr`)
+    OpFastScintillation(OpFastScintillation const &) = delete;
+    OpFastScintillation& operator= (OpFastScintillation const&)= delete;
+    
+    // BUG: move is broken since the source object destructor will destroy
+    //      the  table that has been surrendered to the right-hand operand;
+    //      standard C++ solution applies (`std::unique_ptr`)
+    OpFastScintillation(OpFastScintillation&&) = delete;
+    OpFastScintillation& operator= (OpFastScintillation&&) = delete;
 
     ~OpFastScintillation();
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -290,6 +290,10 @@ namespace larg4 {
     G4bool scintillationByParticleType;
 
   private:
+    
+    /// Returns whether the semi-analytic visibility parametrization is being used.
+    bool usesSemiAnalyticModel() const;
+    
     void detectedDirectHits(std::map<size_t, int>& DetectedNum,
                             const double Num,
                             const std::array<double, 3> ScintPoint);
@@ -372,7 +376,6 @@ namespace larg4 {
 
     //For VUV semi-analytic hits
     G4double Gaisser_Hillas(const double x, const double *par);
-    bool fUseNhitsModel;
     //array of correction for the VUV Nhits estimation
     std::vector<std::vector<double> > fGHvuvpars;
     //To account for the border effects
@@ -411,6 +414,9 @@ namespace larg4 {
     
     /// Photon visibility service instance.
     phot::PhotonVisibilityService const* const fPVS;
+
+    /// Whether the semi-analytic model is being used for photon visibility.
+    bool const fUseNhitsModel = false;
 
     bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
     bool isScintInActiveVolume(const std::array<double, 3>& ScintPoint);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -142,7 +142,7 @@ namespace larg4 {
 
     OpFastScintillation(const G4String& processName = "Scintillation",
                         G4ProcessType type = fElectromagnetic);
-    
+
     ~OpFastScintillation();
 
     ////////////
@@ -291,10 +291,10 @@ namespace larg4 {
     G4bool scintillationByParticleType;
 
   private:
-    
+
     /// Returns whether the semi-analytic visibility parametrization is being used.
     bool usesSemiAnalyticModel() const;
-    
+
     void detectedDirectHits(std::map<size_t, int>& DetectedNum,
                             const double Num,
                             geo::Point_t const& ScintPoint);
@@ -412,7 +412,7 @@ namespace larg4 {
     void ProcessStep( const G4Step& step);
 
     bool const bPropagate; ///< Whether propagation of photons is enabled.
-    
+
     /// Photon visibility service instance.
     phot::PhotonVisibilityService const* const fPVS;
 
@@ -438,10 +438,10 @@ namespace larg4 {
                       const std::vector<double> &yData2,
                       const std::vector<double> &yData3,
                       double x, bool extrapolate);
-    
+
     static std::vector<geo::BoxBoundedGeo> extractActiveVolumes
       (geo::GeometryCore const& geom);
-    
+
   }; // class OpFastScintillation
 
   double finter_d(double*, double*);

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -84,6 +84,7 @@
 /////////////
 
 #include "larsim/PhotonPropagation/PhotonVisibilityTypes.h" // phot::MappedT0s_t
+#include "larcorealg/Geometry/BoxBoundedGeo.h"
 
 #include "Geant4/G4ThreeVector.hh"
 #include "Geant4/G4VRestDiscreteProcess.hh"
@@ -105,6 +106,7 @@ class G4VParticleChange;
 namespace CLHEP {
   class RandGeneral;
 }
+namespace geo { class GeometryCore; }
 
 // Class Description:
 // RestDiscrete Process - Generation of Scintillation Photons.
@@ -373,7 +375,7 @@ namespace larg4 {
     //To account for the border effects
     std::vector<double> fborder_corr;
     double fYactive_corner, fZactive_corner, fReference_to_corner, fYcathode, fZcathode;
-    double fminx, fmaxx, fminy, fmaxy, fminz, fmaxz;
+    std::vector<geo::BoxBoundedGeo> const fActiveVolumes;
     // For VIS semi-analytic hits
     constexpr double Pol_5(const double x, double *par);
     bool fStoreReflected;
@@ -405,7 +407,7 @@ namespace larg4 {
     bool bPropagate; ///< Whether propagation of photons is enabled.
 
     bool isOpDetInSameTPC(const double ScintPointX, const double OpDetPointX);
-    bool isScintInActiveVolume(const std::array<double, 3> ScintPoint);
+    bool isScintInActiveVolume(const std::array<double, 3>& ScintPoint);
     double interpolate(const std::vector<double> &xData,
                        const std::vector<double> &yData,
                        double x, bool extrapolate, size_t i=0);
@@ -415,7 +417,11 @@ namespace larg4 {
                       const std::vector<double> &yData2,
                       const std::vector<double> &yData3,
                       double x, bool extrapolate);
-  };
+    
+    static std::vector<geo::BoxBoundedGeo> extractActiveVolumes
+      (geo::GeometryCore const& geom);
+    
+  }; // class OpFastScintillation
 
   double finter_d(double*, double*);
   double LandauPlusExpoFinal(double*, double*);


### PR DESCRIPTION
This is the first version of the proposed solution to [Redmine issue #24600](https://cdcvs.fnal.gov/redmine/issues/24600).

There are two main assumptions that have been applied in general, but should have been applied only when using the semi-analytic model (or better, when using it with SBND detector and maybe ProtoDUNE, for which those assumptions are satisfied):

1. scintillation light is propagated only from the TPC active volume
    * for the way this is implemented, another assumption is required: the detector has a single monolithic active volume, e.g. it has only one cryostat
2. scintillation light does not go through the cathode, which is fully opaque

My pull request is made of several commits that can be grouped in three sets:

1. preparation (commits 731a89f109ac8afed4eb4e134ba466210ecb4309, 84ca9f375d793ec161b163ccccd2a5b7ce60e215, e2af37560b0f7e5ca994b1524fc526830d04fff6, 4b743969a88bf844817819d7208b86559fb7914b and 23f5d8011126b19578fead727122309f55a1bd8a):
    * the determination of the active volumes is corrected to extract them from all cryostats; LArSoft geometry facilities are used for this;
      _the requirement above is not lifted_: this is a change in preparation for the figure support of multi-cryostat detectors
    * `OpFastScintillation` object is copiable but the copy is bugged (both copy will attempt to destroy the same memory); I turned it into a moveable, non-copiable object, as copy was not necessary (nor is move, actually)
    * introduced an explicitly named `OpFastScintillation::usesSemiAnalyticModel()` method that will help to highlight the model-specific parts of the code
    * these changes do not change the behaviour of the code
2. fix (commit 1ab8718061dcac30182564c2435d3475c92d9fe9):
    * introduced `fOnlyActiveVolume` flag marking the implementation of light propagation only from the active volume; if this flag is not set, the implementation will avoid steps which would require light propagation only from the active volume; in other words, if `fOnlyActiveVolume` is `true` if the scintillation source is not in the active volume it is not propagated, if it is `false` the propagation is attempted no matter where the source is;
 this is automatically set to `true` only if the semi-analytic model is used (`usesSemiAnalyticModel()` is `true`)
    * introduced `fOnlyOneCryostat` option: setting this to `true` will acknowledge that the photon propagation _might_ not be performed in cryostats beyond the first one (`C:0`); if this option is `false`, the detector has more than one cryostat and semi-analytic mode is used, an exception will be thrown, otherwise run will proceed;
      this is meant as a temporary option for _testing_ the semianalytic model on a single cryostat in detectors like ICARUS, while the support to the full detector is being developed by somebody else; this flag is currently hard-coded to `false`, i.e. using semi-analytic model on multi-cryostat detectors will always throw an exception, while other models are unaffected
    * introduced `fOpaqueCathode` flag marking the code assuming cathode opaqueness; if this flag is `true`, optimisations may be enabled not to propagate the scintillation light to optical detectors that are not facing the same TPC where scintillation happens; otherwise, all optical detectors are considered for propagation (any TPC, any cryostat); this flag is currently hard-coded to `false` because LArSoft does not have a way to detect nor express whether the cathode is transparent or opaque; this is for use in future implementations.
3. some internals interacting with `GeometryCore` service provider have been converted to use `geo::Point_t` as point type instead of `std::array<double, 3>`, since the former is the recommended LArSoft interface (commits 9e07e5ae3de9ce31e5908b993f4c71e77e4d830f and bfe915b7c560113d9d4a79008fbab064488a7c3e); this change does not affect the behaviour of the class and it is not required in the resolution of the issue.

It can be noted that the "fixes" at point 2 are very little about actions and a lot about marking assumptions throughout the code.
The hope is that this will make a bit easier to have full support of semi-analytic, which the SBN program is studying as an option, model for detectors like ICARUS. That will be [Redmine issue #24601](https://cdcvs.fnal.gov/redmine/issues/24601)

I request review of these changes by @ikatza who is one of the developers of the affected code.