### PR TITLE
Features to speed up photon library generation [1/2]

### DIFF
--- a/larsim/LegacyLArG4/LArG4_module.cc
+++ b/larsim/LegacyLArG4/LArG4_module.cc
@@ -546,7 +546,7 @@ namespace larg4 {
     pworlds.push_back(new LArVoxelReadoutGeometry
       ("LArVoxelReadoutGeometry", readoutGeomSetupData)
       );
-    pworlds.push_back( new OpDetReadoutGeometry( geom->OpDetGeoName() ));
+    pworlds.push_back( new OpDetReadoutGeometry( geom->OpDetGeoName(), "OpDetReadoutGeometry", fUseLitePhotons ));
     pworlds.push_back( new AuxDetReadoutGeometry("AuxDetReadoutGeometry") );
 
     fG4Help->SetParallelWorlds(pworlds);

--- a/larsim/LegacyLArG4/OpDetReadoutGeometry.cxx
+++ b/larsim/LegacyLArG4/OpDetReadoutGeometry.cxx
@@ -29,8 +29,10 @@
 
 namespace larg4 {
 
-  OpDetReadoutGeometry::OpDetReadoutGeometry(G4String OpDetSensitiveName, const G4String name) :
-    G4VUserParallelWorld(name)
+  OpDetReadoutGeometry::OpDetReadoutGeometry
+    (G4String OpDetSensitiveName, const G4String name, bool useLitePhotons /* = false */)
+    : G4VUserParallelWorld(name)
+    , fUseLitePhotons(useLitePhotons)
   {
     fOpDetSensitiveName = OpDetSensitiveName;
   }
@@ -65,7 +67,7 @@ namespace larg4 {
     OpDetLookup * TheOpDetLookup = OpDetLookup::Instance();
 
     // Create sensitive detector
-    OpDetSensitiveDetector * TheSD = new OpDetSensitiveDetector("OpDetSensitiveDetector");
+    OpDetSensitiveDetector * TheSD = new OpDetSensitiveDetector("OpDetSensitiveDetector", fUseLitePhotons);
 
 
     if(OpDetVolumes.size()>0)

--- a/larsim/LegacyLArG4/OpDetReadoutGeometry.h
+++ b/larsim/LegacyLArG4/OpDetReadoutGeometry.h
@@ -38,7 +38,11 @@ namespace larg4
   class OpDetReadoutGeometry : public G4VUserParallelWorld
     {
     public:
-      OpDetReadoutGeometry(G4String OpDetSensitiveName, const G4String name = "OpDetReadoutGeometry");
+      OpDetReadoutGeometry(
+        G4String OpDetSensitiveName,
+        const G4String name = "OpDetReadoutGeometry",
+        bool useLitePhotons = false
+        );
       virtual ~OpDetReadoutGeometry();
 
       virtual void Construct();
@@ -46,6 +50,7 @@ namespace larg4
       void                            FindVolumes(G4VPhysicalVolume *, G4String, std::vector<G4Transform3D>, std::vector<G4LogicalVolume*>&, std::vector<G4Transform3D>&);
       std::vector<G4LogicalVolume*>   fOpDetVolumes;
       std::vector<G4Transform3D>      fOpDetTransformations;
+      bool const fUseLitePhotons; ///< Pass-through option for sensitive detector.
       G4String fOpDetSensitiveName;
 
     };

--- a/larsim/LegacyLArG4/OpDetSensitiveDetector.cxx
+++ b/larsim/LegacyLArG4/OpDetSensitiveDetector.cxx
@@ -19,6 +19,14 @@
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h" // util::pi()
 #include "Geant4/G4SDManager.hh"
 
+namespace {
+  
+  /// Converts a photon `energy` [eV] into its Wavelength [nm]
+  constexpr double Wavelength(double energy);
+
+} // local namespace
+
+
 namespace larg4{
 
 
@@ -118,15 +126,21 @@ namespace larg4{
   }
   
   
-  //--------------------------------------------------------
-  constexpr double OpDetSensitiveDetector::Wavelength(double energy) {
+}
+
+
+//--------------------------------------------------------
+namespace {
+  
+  constexpr double Wavelength(double energy) {
     
     // SI 2019 (eV nm):
     constexpr double hc = 6.62607015e-34 * 299792458.0 / 1.602176634e-19 * 1e9;
     
     return hc / energy; // nm
     
-  } // OpDetSensitiveDetector::Wavelength()
+  } // Wavelength()
   
+} // local namespace
 
-}
+//--------------------------------------------------------

--- a/larsim/LegacyLArG4/OpDetSensitiveDetector.h
+++ b/larsim/LegacyLArG4/OpDetSensitiveDetector.h
@@ -73,9 +73,6 @@ namespace larg4 {
     /// Adds the photon at the specified step with reduced information.
     void AddLitePhoton(G4Step const* aStep, int OpDet);
     
-    /// Converts a photon `energy` [eV] into its Wavelength [nm]
-    static constexpr double Wavelength(double energy);
-
   };
 }
 

--- a/larsim/LegacyLArG4/OpDetSensitiveDetector.h
+++ b/larsim/LegacyLArG4/OpDetSensitiveDetector.h
@@ -38,7 +38,7 @@ namespace larg4 {
 
 
   public:
-    OpDetSensitiveDetector(G4String name);
+    OpDetSensitiveDetector(G4String name, bool useLitePhotons = false);
     virtual ~OpDetSensitiveDetector(){}
 
 
@@ -58,10 +58,24 @@ namespace larg4 {
     virtual void PrintAll(){}
 
   private:
+    
+    /// Fill simplified lite photons instead of full information photons.
+    bool const fUseLitePhotons;
+    
     OpDetLookup              * fTheOpDetLookup;
     OpDetPhotonTable         * fThePhotonTable;
 
     //double                     fGlobalTimeOffset;
+    
+    /// Adds the photon at the specified step with full information.
+    void AddPhoton(G4Step const* aStep, int OpDet);
+    
+    /// Adds the photon at the specified step with reduced information.
+    void AddLitePhoton(G4Step const* aStep, int OpDet);
+    
+    /// Converts a photon `energy` [eV] into its Wavelength [nm]
+    static constexpr double Wavelength(double energy);
+
   };
 }
 

--- a/larsim/LegacyLArG4/ParticleListAction.cxx
+++ b/larsim/LegacyLArG4/ParticleListAction.cxx
@@ -257,7 +257,7 @@ namespace larg4 {
                                                          polarization.z() ) );
 
       // Save the particle in the ParticleList.
-    fparticleList->Add( fCurrentParticle.particle );
+    fparticleList->Add( fCurrentParticle.particle.get() );
   }
 
   //----------------------------------------------------------------------------
@@ -269,7 +269,7 @@ namespace larg4 {
     // if we have found no reason to keep it, drop it!
     // (we might still need parentage information though)
     if (!fCurrentParticle.keep) {
-      fparticleList->Archive(fCurrentParticle.particle);
+      fparticleList->Archive(fCurrentParticle.particle.get());
       // after the particle is archived, it is deleted
       fCurrentParticle.clear();
       return;

--- a/larsim/LegacyLArG4/ParticleListAction.cxx
+++ b/larsim/LegacyLArG4/ParticleListAction.cxx
@@ -11,6 +11,7 @@
 #include "nug4/ParticleNavigation/ParticleList.h"
 
 #include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
 
 #include "Geant4/G4Track.hh"
 #include "Geant4/G4ThreeVector.hh"
@@ -26,6 +27,7 @@
 #include <TLorentzVector.h>
 
 #include <algorithm>
+#include <cassert>
 
 //const G4bool debug = false; // unused
 
@@ -53,24 +55,14 @@ namespace larg4 {
   // Constructor.
   ParticleListAction::ParticleListAction(double energyCut,
                                          bool   storeTrajectories,
-                                         bool   keepEMShowerDaughters)
+                                         bool   keepEMShowerDaughters,
+                                         bool   keepMCParticleList /* = true */
+                                         )
   : fenergyCut(energyCut * CLHEP::GeV)
-  , fparticleList(0)
+  , fparticleList(keepMCParticleList? std::make_unique<sim::ParticleList>(): nullptr)
   , fstoreTrajectories(storeTrajectories)
   , fKeepEMShowerDaughters(keepEMShowerDaughters)
   {
-    // Create the particle list that we'll (re-)use during the course
-    // of the Geant4 simulation.
-    fparticleList = new sim::ParticleList;
-    fParentIDMap.clear();
-  }
-
-  //----------------------------------------------------------------------------
-  // Destructor.
-  ParticleListAction::~ParticleListAction()
-  {
-    // Delete anything that we created with "new'.
-    delete fparticleList;
   }
 
   //----------------------------------------------------------------------------
@@ -79,7 +71,7 @@ namespace larg4 {
   {
     // Clear any previous particle information.
     fCurrentParticle.clear();
-    fparticleList->clear();
+    if (fparticleList) fparticleList->clear();
     fParentIDMap.clear();
     fCurrentTrackID = sim::NoParticleId;
     fCurrentPdgCode = 0;
@@ -127,6 +119,11 @@ namespace larg4 {
     G4int trackID = track->GetTrackID() + fTrackIDOffset;
     fCurrentTrackID = trackID;
     fCurrentPdgCode = pdgCode;
+    
+    if (!fparticleList) {
+      // the rest is about adding a new particle to the list: skip
+      return; // note that fCurrentParticle is clear()'ed
+    }
 
     // And the particle's parent (same offset as above):
     G4int parentID = track->GetParentID() + fTrackIDOffset;
@@ -267,6 +264,7 @@ namespace larg4 {
   void ParticleListAction::PostTrackingAction( const G4Track* aTrack)
   {
     if (!fCurrentParticle.hasParticle()) return;
+    assert(fparticleList);
 
     // if we have found no reason to keep it, drop it!
     // (we might still need parentage information though)
@@ -449,13 +447,15 @@ namespace larg4 {
   // daughters yet.  That's done in this method.
   void ParticleListAction::EndOfEventAction(const G4Event*)
   {
+    if (!fparticleList) return;
+    
     // Set up the utility class for the "for_each" algorithm.  (We only
     // need a separate set-up for the utility class because we need to
     // give it the pointer to the particle list.  We're using the STL
     // "for_each" instead of the C++ "for loop" because it's supposed
     // to be faster.
     UpdateDaughterInformation updateDaughterInformation;
-    updateDaughterInformation.SetParticleList( fparticleList );
+    updateDaughterInformation.SetParticleList( fparticleList.get() );
 
     // Update the daughter information for each particle in the list.
     std::for_each(fparticleList->begin(),
@@ -467,6 +467,8 @@ namespace larg4 {
   // Returns the ParticleList accumulated during the current event.
   const sim::ParticleList* ParticleListAction::GetList() const
   {
+    if (!fparticleList) return nullptr;
+    
     // check if the ParticleNavigator has entries, and if
     // so grab the highest track id value from it to
     // add to the fTrackIDOffset
@@ -477,7 +479,7 @@ namespace larg4 {
     //Only change the fTrackIDOffset if there is in fact a particle to add to the event
     if( (fparticleList->size())!=0){ fTrackIDOffset = highestID + 1; }
 
-    return fparticleList;
+    return fparticleList.get();
   }
 
   //----------------------------------------------------------------------------
@@ -494,6 +496,11 @@ namespace larg4 {
   // Yields the ParticleList accumulated during the current event.
   sim::ParticleList&& ParticleListAction::YieldList()
   {
+    if (!fparticleList) {
+      // check with `hasList()` before calling this method
+      throw cet::exception("ParticleListAction")
+        << "ParticleListAction::YieldList(): particle list not build by user request.\n";
+    }
     // check if the ParticleNavigator has entries, and if
     // so grab the highest track id value from it to
     // add to the fTrackIDOffset

--- a/larsim/LegacyLArG4/ParticleListAction.h
+++ b/larsim/LegacyLArG4/ParticleListAction.h
@@ -22,6 +22,7 @@
 #include "larcorealg/CoreUtils/ParticleFilters.h" // util::PositionInVolumeFilter
 #include "nusimdata/SimulationBase/simb.h" // simb::GeneratedParticleIndex_t
 #include "nug4/G4Base/UserAction.h"
+#include "cetlib/exempt_ptr.h"
 
 #include <map>
 #include <memory>
@@ -48,7 +49,7 @@ namespace larg4 {
 
     struct ParticleInfo_t {
 
-      simb::MCParticle* particle = nullptr;  ///< Object representing particle (not owned).
+      cet::exempt_ptr<simb::MCParticle> particle;  ///< Object representing particle.
       bool              keep = false;        ///< if there was decision to keep
       /// Index of the particle in the original generator truth record.
       GeneratedParticleIndex_t truthIndex = simb::NoGeneratedParticleIndex;
@@ -62,7 +63,7 @@ namespace larg4 {
         }
 
       /// Returns whether there is a particle
-      bool hasParticle() const { return particle; }
+      bool hasParticle() const { return !particle.empty(); }
 
       /// Returns whether there is a particle
       bool isPrimary() const { return simb::isGeneratedParticleIndex(truthIndex); }

--- a/larsim/LegacyLArG4/ParticleListAction.h
+++ b/larsim/LegacyLArG4/ParticleListAction.h
@@ -111,7 +111,7 @@ namespace larg4 {
       { return fPrimaryTruthMap; }
 
     /// Returns whether a particle list is being kept.
-    bool hasList() const { return bool(fparticleList); }
+    bool hasList() const { return static_cast<bool>(fparticleList); }
     
     /// Returns the index of primary truth (`sim::NoGeneratorIndex` if none).
     GeneratedParticleIndex_t GetPrimaryTruthIndex(int trackId) const;

--- a/larsim/LegacyLArG4/ParticleListAction.h
+++ b/larsim/LegacyLArG4/ParticleListAction.h
@@ -24,6 +24,7 @@
 #include "nug4/G4Base/UserAction.h"
 
 #include <map>
+#include <memory>
 
 // Forward declarations.
 class G4Event;
@@ -47,7 +48,7 @@ namespace larg4 {
 
     struct ParticleInfo_t {
 
-      simb::MCParticle* particle = nullptr;  ///< simple structure representing particle
+      simb::MCParticle* particle = nullptr;  ///< Object representing particle (not owned).
       bool              keep = false;        ///< if there was decision to keep
       /// Index of the particle in the original generator truth record.
       GeneratedParticleIndex_t truthIndex = simb::NoGeneratedParticleIndex;
@@ -75,8 +76,11 @@ namespace larg4 {
     }; // ParticleInfo_t
 
     // Standard constructors and destructors;
-    ParticleListAction(double energyCut, bool storeTrajectories=false, bool keepEMShowerDaughters=false);
-    virtual ~ParticleListAction();
+    ParticleListAction(double energyCut,
+                       bool storeTrajectories=false,
+                       bool keepEMShowerDaughters=false,
+                       bool keepMCParticleList=true
+                       );
 
     // UserActions method that we'll override, to obtain access to
     // Geant4's particle tracks and trajectories.
@@ -105,6 +109,9 @@ namespace larg4 {
     std::map<int, GeneratedParticleIndex_t> const& GetPrimaryTruthMap() const
       { return fPrimaryTruthMap; }
 
+    /// Returns whether a particle list is being kept.
+    bool hasList() const { return bool(fparticleList); }
+    
     /// Returns the index of primary truth (`sim::NoGeneratorIndex` if none).
     GeneratedParticleIndex_t GetPrimaryTruthIndex(int trackId) const;
 
@@ -124,7 +131,7 @@ namespace larg4 {
                                                      ///< be included in the list.
     ParticleInfo_t           fCurrentParticle;       ///< information about the particle currently being simulated
                                                      ///< for a single particle.
-    sim::ParticleList*       fparticleList;          ///< The accumulated particle information for
+    std::unique_ptr<sim::ParticleList> fparticleList; ///< The accumulated particle information for
                                                      ///< all particles in the event.
     G4bool                   fstoreTrajectories;     ///< Whether to store particle trajectories with each particle.
     std::map<int, int>       fParentIDMap;           ///< key is current track ID, value is parent ID

--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -18,6 +18,7 @@ art_make(LIB_LIBRARIES larevt_Filters
                        ROOT::Matrix
                        ROOT::Tree
                        ROOT::GenVector
+                       ROOT::RooFit
           SERVICE_LIBRARIES larsim_PhotonPropagation
                        larsim_Simulation
                        nug4_ParticleNavigation

--- a/larsim/PhotonPropagation/PhotonLibrary.cxx
+++ b/larsim/PhotonPropagation/PhotonLibrary.cxx
@@ -27,7 +27,7 @@ namespace {
     std::optional<T> operator() (std::string const& key)
       {
         RooT const* value = srcDir.Get<RooT>(key.c_str());
-        if (value) return { T(*value) };
+        if (value) return std::make_optional<T>(*value);
         missingKeys.push_back(key);
         return std::nullopt;
       }

--- a/larsim/PhotonPropagation/PhotonLibrary.cxx
+++ b/larsim/PhotonPropagation/PhotonLibrary.cxx
@@ -1,8 +1,9 @@
-#include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "art_root_io/TFileDirectory.h"
+#include "canvas/Utilities/Exception.h"
 
 #include "larsim/PhotonPropagation/PhotonLibrary.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
 
 #include "RtypesCore.h"
 #include "TFile.h"

--- a/larsim/PhotonPropagation/PhotonLibrary.h
+++ b/larsim/PhotonPropagation/PhotonLibrary.h
@@ -16,12 +16,17 @@ class TTree;
 #include <optional>
 
 
+namespace art { class TFileDirectory; }
+
+
 namespace phot{
 
   class PhotonLibrary : public IPhotonLibrary
   {
   public:
-    PhotonLibrary() = default;
+    
+    /// If no valid `pDir` is provided, storage features will not be supported.
+    PhotonLibrary(art::TFileDirectory* pDir = nullptr);
 
     TTree * ProduceTTree() const;
 
@@ -116,6 +121,10 @@ namespace phot{
     
     /// Voxel definition loaded from library metadata.
     std::optional<sim::PhotonVoxelDef> fVoxelDef;
+    
+    
+    /// ROOT directory where to write data.
+    art::TFileDirectory* fDir = nullptr;
 
     bool isVoxelValidImpl(size_t Voxel) const { return Voxel < fNVoxels; }
 

--- a/larsim/PhotonPropagation/PhotonLibrary.h
+++ b/larsim/PhotonPropagation/PhotonLibrary.h
@@ -88,7 +88,8 @@ namespace phot{
 
     /// Returns the current voxel metadata (undefined behaviour if none).
     /// @see `hasVoxelDef()`
-    sim::PhotonVoxelDef const& GetVoxelDef() const { return fVoxelDef.value(); }
+    sim::PhotonVoxelDef const& GetVoxelDef() const
+      { assert(fVoxelDef); return *fVoxelDef; }
     
     /// Copies the specified voxel definition into our own
     /// (overwrites the existing metadata if any).

--- a/larsim/PhotonPropagation/PhotonLibrary.h
+++ b/larsim/PhotonPropagation/PhotonLibrary.h
@@ -14,6 +14,7 @@ class TTree;
 #include "lardataobj/Utilities/LazyVector.h"
 
 #include <optional>
+#include <limits> // std::numeric_limits
 
 
 namespace art { class TFileDirectory; }
@@ -192,7 +193,7 @@ namespace phot{
 
     /// Converts size_t into integer
     static int size_t2int(size_t val) {
-    return (val <= INT_MAX) ? (int)((ssize_t)val) : -1; }
+    return (val <= std::numeric_limits<int>::max()) ? (int)((ssize_t)val) : -1; }
   };
 
 }

--- a/larsim/PhotonPropagation/PhotonLibrary.h
+++ b/larsim/PhotonPropagation/PhotonLibrary.h
@@ -6,10 +6,14 @@
 
 #include "larsim/PhotonPropagation/IPhotonLibrary.h"
 
+#include "larsim/Simulation/PhotonVoxels.h"
+
 #include "TF1.h"
 class TTree;
 
 #include "lardataobj/Utilities/LazyVector.h"
+
+#include <optional>
 
 
 namespace phot{
@@ -56,7 +60,10 @@ namespace phot{
     virtual bool hasReflectedT0() const override { return fHasReflectedT0; }
 
 
-    void StoreLibraryToFile(std::string LibraryFile, bool storeReflected=false, bool storeReflT0=false, size_t storeTiming=0) const;
+    void StoreLibraryToFile(
+      std::string LibraryFile,
+      bool storeReflected=false, bool storeReflT0=false, size_t storeTiming=0
+      ) const;
     void LoadLibraryFromFile(std::string LibraryFile, size_t NVoxels, bool storeReflected=false, bool storeReflT0=false, size_t storeTiming=0, int maxrange=200);
     void CreateEmptyLibrary(size_t NVoxels, size_t NChannels, bool storeReflected=false, bool storeReflT0=false, size_t storeTiming=0);
 
@@ -65,7 +72,26 @@ namespace phot{
     virtual int NVoxels() const override { return fNVoxels; }
 
     virtual bool isVoxelValid(size_t Voxel) const override { return isVoxelValidImpl(Voxel); }
+    
+    
+    // --- BEGIN --- Metadata: voxel information -------------------------------
+    /// @name Metadata: voxel information
+    /// @{
+    
+    /// Returns whether voxel metadata is available.
+    bool hasVoxelDef() const { return fVoxelDef.has_value(); }
 
+    /// Returns the current voxel metadata (undefined behaviour if none).
+    /// @see `hasVoxelDef()`
+    sim::PhotonVoxelDef const& GetVoxelDef() const { return fVoxelDef.value(); }
+    
+    /// Copies the specified voxel definition into our own
+    /// (overwrites the existing metadata if any).
+    void SetVoxelDef(sim::PhotonVoxelDef const& voxelDef)
+      { fVoxelDef = voxelDef; }
+    
+    /// @}
+    // --- END --- Metadata: voxel information ---------------------------------
 
   private:
 
@@ -87,6 +113,9 @@ namespace phot{
 
     size_t fNOpChannels;
     size_t fNVoxels;
+    
+    /// Voxel definition loaded from library metadata.
+    std::optional<sim::PhotonVoxelDef> fVoxelDef;
 
     bool isVoxelValidImpl(size_t Voxel) const { return Voxel < fNVoxels; }
 
@@ -138,6 +167,12 @@ namespace phot{
       // note that this will produce a segmentation fault if the formula is not there
       return *(fTimingParTF1LookupTable.data_address(uncheckedIndex(Voxel, OpChannel)));
     }
+    
+    /// Reads the metadata from specified ROOT directory and sets it as current.
+    void LoadMetadata(TDirectory& srcDir);
+
+    /// Writes the current metadata (if any) into the ROOT output file.
+    void StoreMetadata() const;
 
     /// Name of the optical channel number in the input tree
     static std::string const OpChannelBranchName;

--- a/larsim/PhotonPropagation/PhotonVisibilityService_service.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService_service.cc
@@ -33,6 +33,9 @@
 
 // framework libraries
 #include "art/Utilities/make_tool.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art_root_io/TFileService.h"
+#include "canvas/Utilities/Exception.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // ROOT libraries
@@ -204,7 +207,21 @@ namespace phot{
         size_t NVoxels = GetVoxelDef().GetNVoxels();
         mf::LogInfo("PhotonVisibilityService") << " Vis service running library build job.  Please ensure "
                                                << " job contains LightSource, LArG4, SimPhotonCounter"<<std::endl;
-        PhotonLibrary* lib = new PhotonLibrary;
+        
+        art::TFileDirectory* pDir = nullptr;
+        try {
+          pDir = art::ServiceHandle<art::TFileService>().get();
+        }
+        catch (art::Exception const& e) {
+          if (e.categoryCode() != art::errors::ServiceNotFound) throw;
+          if (fLibraryBuildJob) {
+            throw art::Exception(e.categoryCode(), "", e)
+              << "PhotonVisibilityService: "
+              "service `TFileService` is required when building a photon library.\n";
+          }
+        }
+        
+        PhotonLibrary* lib = new PhotonLibrary(pDir);
         fTheLibrary = lib;
 
         lib->CreateEmptyLibrary(NVoxels, NOpDets, fStoreReflected, fStoreReflT0, fParPropTime_npar);

--- a/larsim/Simulation/CMakeLists.txt
+++ b/larsim/Simulation/CMakeLists.txt
@@ -9,7 +9,9 @@ art_make(NO_PLUGINS
            ${ART_FRAMEWORK_PRINCIPAL}
            ${ART_PERSISTENCY_PROVENANCE}
            ROOT::Core
-           ROOT::Physics)
+           ROOT::Physics
+           ROOT::GenVector
+           )
 
 simple_plugin(LArVoxelCalculator "service")
 simple_plugin(LArG4Parameters "service")

--- a/larsim/Simulation/PhotonVoxels.cxx
+++ b/larsim/Simulation/PhotonVoxels.cxx
@@ -228,5 +228,30 @@ namespace sim {
 
   //----------------------------------------------------------------------------
 
+  std::ostream& operator<<
+    (std::ostream& out, sim::PhotonVoxelDef const& voxelDef)
+  {
+    
+    auto const& lower = voxelDef.GetRegionLowerCorner();
+    auto const& upper = voxelDef.GetRegionUpperCorner();
+    auto const& steps = voxelDef.GetSteps();
+    auto const& stepSize = voxelDef.GetVoxelSize();
+
+    out
+      << "Volume " << voxelDef.GetVolumeSize() << " cm^3 split in "
+        << voxelDef.GetNVoxels() << " voxels:"
+      << "\n  - x axis: [ " << lower.X() << " ; " << upper.X() << " ] split in "
+        << steps[0] << "x " << stepSize.X() << " cm steps"
+      << "\n  - y axis: [ " << lower.Y() << " ; " << upper.Y() << " ] split in "
+        << steps[1] << "x " << stepSize.Y() << " cm steps"
+      << "\n  - z axis: [ " << lower.Z() << " ; " << upper.Z() << " ] split in "
+        << steps[2] << "x " << stepSize.Z() << " cm steps"
+      << "\n";
+
+    return out;
+  } // operator<< (sim::PhotonVoxelDef)
+
+  //----------------------------------------------------------------------------
+
 
 } // namespace sim

--- a/larsim/Simulation/PhotonVoxels.h
+++ b/larsim/Simulation/PhotonVoxels.h
@@ -83,7 +83,7 @@ namespace sim {
                    int yN,
                    double zMin,
                    double zMax,
-                   int z);
+                   int zN);
 
     /// Returns the volume vertex (type `Point`) with the lowest coordinates.
     template <typename Point = DefaultPoint>
@@ -97,9 +97,16 @@ namespace sim {
     std::array<unsigned int, 3U> GetSteps() const;
 
 
+    /// Returns a vector describing the span of a single voxel in x, y an z [cm]
     template <typename Vector = DefaultVector>
     Vector GetVoxelSize() const;
 
+    /// Returns a vector describing the full span in x, y an z [cm]
+    template <typename Vector = DefaultVector, typename Point = DefaultPoint>
+    Vector GetVolumeSize() const
+      { return GetRegionUpperCorner<Point>() - GetRegionLowerCorner<Point>(); }
+
+    /// Returns the total number of voxels in the volume.
     unsigned int GetNVoxels() const;
 
     /// Returns the ID of the voxel containing `p`, or `-1` if none.
@@ -166,6 +173,11 @@ namespace sim {
     static bool isInsideRange(double value, double lower, double upper);
 
   }; // class PhotonVoxelDef
+  
+  
+  /// Prints the content of the specified voxel definition into a stream.
+  std::ostream& operator<<
+    (std::ostream& out, sim::PhotonVoxelDef const& voxelDef);
 
 } // namespace sim
 


### PR DESCRIPTION
I have added some features to the legacy `LArG4` chain to speed up the generation of a photon visibility library.
The changes in `larsim` include:
* option not to produce `simb::MCParticle` collection; this yield a major memory saving since a photon library job may generate hundred of thousand scintillation-like photons;
* option to use `sim::SimPhotonsLite` instead of `sim::SimPhotons`, which would save individual photons; the information we require for the photon library is just the total number of detected photons, and possibly a time distribution;
* as a "bonus" I have added support for some metadata in the photon library: number of voxels and volume covered.

To be valuable, these features need to be combined with improvements in `SimPhotonCounters` module, which is the target of the twin [pull request #8](https://github.com/LArSoft/larana/pull/8) for `larana`.

As a technical note: metadata is implemented via writing `RooInt` and `RooDouble` objects into the `TFileService` ROOT file: I could not find any other `TObject`-like object which would contain a single value and play well with `TFileService` registry interface (it was not obvious to me how to write non-`TObject` objects like `TVectorD`, neither.