### PR TITLE
Update the arapuca dims every time, both for direct and reflected hits

### DIFF
--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1493,11 +1493,9 @@ namespace larg4 {
     for (size_t const OpDet : util::counter(NOpChannels)) {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
 
-      fydimension = fOpDetHeight.at(OpDet);
-      fzdimension = fOpDetLength.at(OpDet);
       // set detector struct for solid angle function
-      detPoint.h = fydimension;
-      detPoint.w = fzdimension;
+      detPoint.h = fOpDetHeight.at(OpDet);
+      detPoint.w =  fOpDetLength.at(OpDet);
       int const DetThis = VUVHits(Num, ScintPoint, fOpDetCenter[OpDet], fOpDetType[OpDet]);
       if (DetThis > 0) {
         DetectedNum[OpDet] = DetThis;
@@ -1549,6 +1547,10 @@ namespace larg4 {
 
     for (size_t const OpDet : util::counter(NOpChannels)) {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
+
+      // set detector struct for solid angle function
+      detPoint.h = fOpDetHeight.at(OpDet);
+      detPoint.w =  fOpDetLength.at(OpDet);
 
       int const ReflDetThis =
         VISHits(ScintPoint, fOpDetCenter[OpDet], fOpDetType[OpDet], cathode_hits_rec, hotspot);

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -369,14 +369,13 @@ namespace larg4 {
       }
     }
     tpbemission = lar::providerFrom<detinfo::LArPropertiesService>()->TpbEm();
-    const size_t nbins = tpbemission.size();
-    double* parent = new double[nbins];
-    size_t ii = 0;
+    std::vector<double> parent;
+    parent.reserve(tpbemission.size());
     for (auto iter = tpbemission.begin(); iter != tpbemission.end(); ++iter) {
-      parent[ii++] = (*iter).second;
+      parent.push_back(iter->second);
     }
-    rgen0 = new CLHEP::RandGeneral(parent, nbins);
-    delete[] parent;
+    fTPBEm = std::make_unique<CLHEP::RandGeneral>
+      (parent.data(), parent.size());
   }
 
   ////////////////
@@ -1077,7 +1076,7 @@ namespace larg4 {
   double
   OpFastScintillation::reemission_energy() const
   {
-    return rgen0->fire() * ((*(--tpbemission.end())).first - (*tpbemission.begin()).first) +
+    return fTPBEm->fire() * ((*(--tpbemission.end())).first - (*tpbemission.begin()).first) +
            (*tpbemission.begin()).first;
   }
 

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -360,8 +360,8 @@ namespace larg4 {
           fcathode_ydimension = fActiveVolumes[0].SizeY();
           fcathode_zdimension = fActiveVolumes[0].SizeZ();
           // set cathode plane struct for solid angle function
-          cathode_plane.h = fcathode_ydimension;
-          cathode_plane.w = fcathode_zdimension;
+          fcathode_plane.h = fcathode_ydimension;
+          fcathode_plane.w = fcathode_zdimension;
           fplane_depth = std::abs(fcathode_centre[0]);
         }
         else
@@ -1494,9 +1494,10 @@ namespace larg4 {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
 
       // set detector struct for solid angle function
-      detPoint.h = fOpDetHeight.at(OpDet);
-      detPoint.w =  fOpDetLength.at(OpDet);
-      int const DetThis = VUVHits(Num, ScintPoint, fOpDetCenter[OpDet], fOpDetType[OpDet]);
+      const OpFastScintillation::OpticalDetector op{
+        fOpDetHeight.at(OpDet), fOpDetLength.at(OpDet),
+        fOpDetCenter.at(OpDet), fOpDetType.at(OpDet)};
+      const int DetThis = VUVHits(Num, ScintPoint, op);
       if (DetThis > 0) {
         DetectedNum[OpDet] = DetThis;
         //   mf::LogInfo("OpFastScintillation") << "FastScint: " <<
@@ -1527,7 +1528,7 @@ namespace larg4 {
                                                  std::abs(ScintPoint.Y() - fcathode_centre[1]),
                                                  std::abs(ScintPoint.Z() - fcathode_centre[2])};
     // calculate solid angle of cathode from the scintillation point
-    double solid_angle_cathode = Rectangle_SolidAngle(cathode_plane, ScintPoint_relative);
+    double solid_angle_cathode = Rectangle_SolidAngle(fcathode_plane, ScintPoint_relative);
     // calculate distance and angle between ScintPoint and hotspot
     // vast majority of hits in hotspot region directly infront of scintpoint,
     // therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
@@ -1549,11 +1550,12 @@ namespace larg4 {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
 
       // set detector struct for solid angle function
-      detPoint.h = fOpDetHeight.at(OpDet);
-      detPoint.w =  fOpDetLength.at(OpDet);
+      const  OpFastScintillation::OpticalDetector op{
+        fOpDetHeight.at(OpDet), fOpDetLength.at(OpDet),
+        fOpDetCenter.at(OpDet), fOpDetType.at(OpDet)};
 
       int const ReflDetThis =
-        VISHits(ScintPoint, fOpDetCenter[OpDet], fOpDetType[OpDet], cathode_hits_rec, hotspot);
+        VISHits(ScintPoint, op, cathode_hits_rec, hotspot);
       if (ReflDetThis > 0) { ReflDetectedNum[OpDet] = ReflDetThis; }
     }
   }
@@ -1562,14 +1564,13 @@ namespace larg4 {
   int
   OpFastScintillation::VUVHits(const double Nphotons_created,
                                geo::Point_t const& ScintPoint_v,
-                               geo::Point_t const& OpDetPoint_v,
-                               const int optical_detector_type)
+                               OpticalDetector const& opDet)
   {
     // the interface has been converted into geo::Point_t, the implementation not yet
     std::array<double, 3U> ScintPoint;
     std::array<double, 3U> OpDetPoint;
     geo::vect::fillCoords(ScintPoint, ScintPoint_v);
-    geo::vect::fillCoords(OpDetPoint, OpDetPoint_v);
+    geo::vect::fillCoords(OpDetPoint, opDet.OpDetPoint);
 
     // distance and angle between ScintPoint and OpDetPoint
     double distance = dist(&ScintPoint[0], &OpDetPoint[0], 3);
@@ -1580,16 +1581,16 @@ namespace larg4 {
     // calculate solid angle:
     double solid_angle = 0;
     // Arapucas
-    if (optical_detector_type == 0) {
+    if (opDet.type == 0) {
       // get scintillation point coordinates relative to arapuca window centre
       std::array<double, 3> ScintPoint_rel = {std::abs(ScintPoint[0] - OpDetPoint[0]),
                                               std::abs(ScintPoint[1] - OpDetPoint[1]),
                                               std::abs(ScintPoint[2] - OpDetPoint[2])};
       // calculate solid angle
-      solid_angle = Rectangle_SolidAngle(detPoint, ScintPoint_rel);
+      solid_angle = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, ScintPoint_rel);
     }
     // PMTs
-    else if (optical_detector_type == 1) {
+    else if (opDet.type == 1) {
       // offset in z-y plane
       double d = dist(&ScintPoint[1], &OpDetPoint[1], 2);
       // drift distance (in x)
@@ -1629,8 +1630,7 @@ namespace larg4 {
   // VIS hits semi-analytic model calculation
   int
   OpFastScintillation::VISHits(geo::Point_t const& ScintPoint_v,
-                               geo::Point_t const& OpDetPoint_v,
-                               const int optical_detector_type,
+                               OpticalDetector const& opDet,
                                const double cathode_hits_rec,
                                const std::array<double, 3> hotspot)
   {
@@ -1645,21 +1645,21 @@ namespace larg4 {
     std::array<double, 3U> ScintPoint;
     std::array<double, 3U> OpDetPoint;
     geo::vect::fillCoords(ScintPoint, ScintPoint_v);
-    geo::vect::fillCoords(OpDetPoint, OpDetPoint_v);
+    geo::vect::fillCoords(OpDetPoint, opDet.OpDetPoint);
 
     // calculate solid angle of optical channel
     double solid_angle_detector = 0;
     // rectangular aperture
-    if (optical_detector_type == 0) {
-      // get hotspot coordinates relative to detpoint
+    if (opDet.type == 0) {
+      // get hotspot coordinates relative to opDet
       std::array<double, 3> emission_relative = {std::abs(hotspot[0] - OpDetPoint[0]),
                                                  std::abs(hotspot[1] - OpDetPoint[1]),
                                                  std::abs(hotspot[2] - OpDetPoint[2])};
       // calculate solid angle
-      solid_angle_detector = Rectangle_SolidAngle(detPoint, emission_relative);
+      solid_angle_detector = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, emission_relative);
     }
     // disk aperture
-    else if (optical_detector_type == 1) {
+    else if (opDet.type == 1) {
       // offset in z-y plane
       double d = dist(&hotspot[1], &OpDetPoint[1], 2);
       // drift distance (in x)
@@ -2022,7 +2022,7 @@ namespace larg4 {
 
   // TODO: allow greater tolerance in comparisons, see note above on Disk_SolidAngle()
   double
-  OpFastScintillation::Rectangle_SolidAngle(const dims o, const std::array<double, 3> v)
+  OpFastScintillation::Rectangle_SolidAngle(Dims const& o, const std::array<double, 3> v)
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -393,7 +393,7 @@ namespace larg4 {
 
     // Optical detector properties for semi-analytic hits
     // int foptical_detector_type;  // unused
-    double fydimension, fzdimension, fradius;
+    double fradius;
     dims detPoint, cathode_plane;
     int fdelta_angulo, fL_abs_vuv;
     std::vector<geo::Point_t> fOpDetCenter;

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -331,7 +331,7 @@ namespace larg4 {
     // Facility for TPB emission energies
     double reemission_energy() const;
     std::map<double, double> tpbemission;
-    CLHEP::RandGeneral* rgen0;
+    std::unique_ptr<CLHEP::RandGeneral> fTPBEm;
 
     void average_position(G4Step const& aStep, double* xzyPos) const;
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -285,6 +285,14 @@ namespace larg4 {
     G4bool scintillationByParticleType;
 
   private:
+
+    struct OpticalDetector {
+      double h; // height
+      double w; // width
+      geo::Point_t OpDetPoint;
+      int type;
+    };
+
     /// Returns whether the semi-analytic visibility parametrization is being used.
     bool usesSemiAnalyticModel() const;
 
@@ -297,13 +305,11 @@ namespace larg4 {
 
     int VUVHits(const double Nphotons_created,
                 geo::Point_t const& ScintPoint,
-                geo::Point_t const& OpDetPoint,
-                const int optical_detector_type);
+                OpticalDetector const& opDet);
     // Calculates semi-analytic model number of hits for vuv component
 
     int VISHits(geo::Point_t const& ScintPoint,
-                geo::Point_t const& OpDetPoint,
-                const int optical_detector_type,
+                OpticalDetector const& opDet,
                 const double cathode_hits_rec,
                 const std::array<double, 3> hotspot);
     // Calculates semi-analytic model number of hits for visible component
@@ -358,13 +364,13 @@ namespace larg4 {
     std::vector<std::vector<double>> fcut_off_pars;
     std::vector<std::vector<double>> ftau_pars;
 
-    // structure definition for solid angle of rectangle function
-    struct dims {
-      double w, h; // w = width; h = height
+    struct Dims {
+      double h, w; // height, width
     };
+
     // solid angle of rectangular aperture calculation functions
     double Rectangle_SolidAngle(const double a, const double b, const double d);
-    double Rectangle_SolidAngle(const dims o, const std::array<double, 3> v);
+    double Rectangle_SolidAngle(Dims const&  o, const std::array<double, 3> v);
     // solid angle of circular aperture calculation functions
     double Disk_SolidAngle(const double d, const double h, const double b);
 
@@ -394,7 +400,7 @@ namespace larg4 {
     // Optical detector properties for semi-analytic hits
     // int foptical_detector_type;  // unused
     double fradius;
-    dims detPoint, cathode_plane;
+    Dims fcathode_plane;
     int fdelta_angulo, fL_abs_vuv;
     std::vector<geo::Point_t> fOpDetCenter;
     std::vector<int> fOpDetType;


### PR DESCRIPTION
On SBND new geometry we're changing the sizes of XARAPUCAS such that they are not longer the same as those of the ARAPUCAS.

So now every time the dimensions need to be updated such that they reflect the actual size of the current optical detector.

I'll prepare an equivalent commit for the equivalent code that uses new geant4 on another branch and PR.

The PR on sbndcode that will need this is: https://github.com/SBNSoftware/sbndcode/pull/6