### PR TITLE
add a hit time RMS for IDE finding

### DIFF
--- a/larsim/MCCheater/BackTracker.h
+++ b/larsim/MCCheater/BackTracker.h
@@ -65,6 +65,11 @@ namespace cheat {
         fhicl::Comment("Option when overlaying simulation on real data, to tell the "
                        "backtracker to continue even if event looks like data."),
         false};
+      fhicl::Atom<double> HitTimeRMS{
+        fhicl::Name("HitTimeRMS"),
+        fhicl::Comment("The number of RMS units to move away"
+                       "from a Hit peak time for searching IDE."),
+        1.0};
     };
 
     BackTracker(const fhiclConfig& config,
@@ -245,6 +250,7 @@ namespace cheat {
     const art::InputTag fHitLabel;
     const double fMinHitEnergyFraction;
     const bool fOverrideRealData;
+    const double fHitTimeRMS;
 
     mutable std::vector<art::Ptr<sim::SimChannel>> fSimChannels;
 


### PR DESCRIPTION
When searching for IDE from a Hit, the default time start is defined as `hit->PeakTimeMinusRMS()` in MCCheater::BackTracker. However, both the longitudinal and transverse diffusion will broaden the hit width in a more realistic simulation. As a result, 1-RMS is not enough to cover all charges of an IDE. I suggest that we can change this time window in the configuration. The default value is still 1-RMS, while we suggest 3.5-RMS when it's necessary.

To chnge the default value, please add this line to your fhicl: 
`services.BackTrackerService.BackTracker.HitTimeRMS: 	      3.5`