### PR TITLE
Re-enable OpticalPhysics list

### DIFF
--- a/larsim/LegacyLArG4/CustomPhysicsLArSoft.h
+++ b/larsim/LegacyLArG4/CustomPhysicsLArSoft.h
@@ -22,7 +22,12 @@ namespace larg4 {
     }
     CustomPhysicsFactory(detinfo::DetectorPropertiesData const& detProp)
       : CustomPhysicsFactoryBase{"Optical"}, fDetProp{detProp}
-    {}
+    {
+      // register self in physics table - note, factory is actually registered
+      // in static TheCustomPhysicsTable, not the instance created below
+      // which just acts to pass information along
+      new CustomPhysicsTable(this);
+    }
 
   private:
     detinfo::DetectorPropertiesData const& fDetProp;

--- a/larsim/LegacyLArG4/LArG4_module.cc
+++ b/larsim/LegacyLArG4/LArG4_module.cc
@@ -348,6 +348,7 @@ namespace larg4 {
     CLHEP::HepRandomEngine& fEngine; ///< Random-number engine for IonizationAndScintillation
                                      ///< initialization
 
+    detinfo::DetectorPropertiesData fDetProp; ///< Must outlive fAllPhysicsLists!
     AllPhysicsLists fAllPhysicsLists;
     LArVoxelReadoutGeometry* fVoxelReadoutGeometry{
       nullptr}; /// Pointer used for correctly updating the clock data state.
@@ -413,7 +414,8 @@ namespace larg4 {
     , fSparsifyTrajectories(pset.get<bool>("SparsifyTrajectories", false))
     , fEngine(art::ServiceHandle<rndm::NuRandomService> {}
                 ->createEngine(*this, "HepJamesRandom", "propagation", pset, "PropagationSeed"))
-    , fAllPhysicsLists{art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob()}
+    , fDetProp{art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob()}
+    , fAllPhysicsLists{fDetProp}
   {
     MF_LOG_DEBUG("LArG4") << "Debug: LArG4()";
     art::ServiceHandle<art::RandomNumberGenerator const> rng;


### PR DESCRIPTION
Accidentally disabled during v09 migration (resolves https://cdcvs.fnal.gov/redmine/issues/24890).