### PR TITLE
Feature/wgu prior sce depo

### DIFF
--- a/larsim/IonizationScintillation/IonAndScint_module.cc
+++ b/larsim/IonizationScintillation/IonAndScint_module.cc
@@ -70,7 +70,7 @@ namespace larg4 {
     , Instances{
         pset.get<string>("Instances", "LArG4DetectorServicevolTPCActive"),
       }
-    , fSavePriorSCE{pset.get<bool>("SavePriorSCE",  true)}
+    , fSavePriorSCE{pset.get<bool>("SavePriorSCE",  false)}
   {
     std::cout << "IonAndScint Module Construct" << std::endl;
 


### PR DESCRIPTION
This PR is related to the other recent PR: https://github.com/LArSoft/larwirecell/pull/7

An additional option "fSavePriorSCE" is available now, once the option is "true", the module will produce an extra instance of std::vector<SimEnergyDeposit>. This additional std::vector<SimEnergyDeposit> is for saving the information without the space charge effect (SCE).

