### PR TITLE
To access OpFastScintillation class from sbncode

### DIFF
--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2192,15 +2192,15 @@ namespace larg4 {
 
   // ---------------------------------------------------------------------------
 
-  constexpr double
-  acos_table(const double x)
-  {
-    if (x < 0. || x > 1.) {
-      std::cout << "Range out of bounds in acos_table, only defined in [0, 1]" << std::endl;
-      exit(0);
-    }
-    return acos_arr[std::round(acos_bins * x)];
-  }
+  // constexpr double
+  // acos_table(const double x)
+  // {
+  //   if (x < 0. || x > 1.) {
+  //     std::cout << "Range out of bounds in acos_table, only defined in [0, 1]" << std::endl;
+  //     exit(0);
+  //   }
+  //   return acos_arr[std::round(acos_bins * x)];
+  // }
 
   double
   fast_acos(double x)

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -581,7 +581,6 @@ namespace larg4 {
 
     // Get the visibility vector for this point
     assert(fPVS);
-    NOpChannels = fPVS->NOpChannels();
 
     G4int nscnt = 1;
     if (Fast_Intensity && Slow_Intensity) nscnt = 2;
@@ -740,7 +739,7 @@ namespace larg4 {
       //std::cout << "++++++++++++" << Num << "++++++++++" << std::endl;
 
       // here we go: now if visibilities are invalid, we are in trouble
-      //if (!Visibilities && (NOpChannels > 0)) {
+      //if (!Visibilities && (fPVS->NOpChannels() > 0)) {
       //  throw cet::exception("OpFastScintillator")
       //    << "Photon library does not cover point " << ScintPoint << " cm.\n";
       //}
@@ -750,7 +749,7 @@ namespace larg4 {
       // detected photons from direct light
       std::map<size_t, int> DetectedNum;
       if (Visibilities && !usesSemiAnalyticModel()) {
-        for (size_t const OpDet : util::counter(NOpChannels)) {
+        for (size_t const OpDet : util::counter(fPVS->NOpChannels())) {
           if (fOpaqueCathode && !isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
           int const DetThis = std::round(G4Poisson(Visibilities[OpDet] * Num));
           if (DetThis > 0) DetectedNum[OpDet] = DetThis;
@@ -764,7 +763,7 @@ namespace larg4 {
       std::map<size_t, int> ReflDetectedNum;
       if (fPVS->StoreReflected()) {
         if (!usesSemiAnalyticModel()) {
-          for (size_t const OpDet : util::counter(NOpChannels)) {
+          for (size_t const OpDet : util::counter(fPVS->NOpChannels())) {
             if (fOpaqueCathode && !isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
             int const ReflDetThis = std::round(G4Poisson(ReflVisibilities[OpDet] * Num));
             if (ReflDetThis > 0) ReflDetectedNum[OpDet] = ReflDetThis;

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1501,7 +1501,7 @@ namespace larg4 {
                                           const double Num,
                                           geo::Point_t const& ScintPoint)
   {
-    for (size_t const OpDet : util::counter(NOpChannels)) {
+    for (size_t const OpDet : util::counter(fPVS->NOpChannels())) {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
 
       // set detector struct for solid angle function
@@ -1577,7 +1577,7 @@ namespace larg4 {
 
     // detemine hits on each PD
     const std::array<double, 3> hotspot = {plane_depth, ScintPoint.Y(), ScintPoint.Z()};
-    for (size_t const OpDet : util::counter(NOpChannels)) {
+    for (size_t const OpDet : util::counter(fPVS->NOpChannels())) {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
 
       // set detector struct for solid angle function

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -2192,16 +2192,6 @@ namespace larg4 {
 
   // ---------------------------------------------------------------------------
 
-  // constexpr double
-  // acos_table(const double x)
-  // {
-  //   if (x < 0. || x > 1.) {
-  //     std::cout << "Range out of bounds in acos_table, only defined in [0, 1]" << std::endl;
-  //     exit(0);
-  //   }
-  //   return acos_arr[std::round(acos_bins * x)];
-  // }
-
   double
   fast_acos(double x)
   {

--- a/larsim/LegacyLArG4/OpFastScintillation.cxx
+++ b/larsim/LegacyLArG4/OpFastScintillation.cxx
@@ -1499,7 +1499,7 @@ namespace larg4 {
   void
   OpFastScintillation::detectedDirectHits(std::map<size_t, int>& DetectedNum,
                                           const double Num,
-                                          geo::Point_t const& ScintPoint)
+                                          geo::Point_t const& ScintPoint) const
   {
     for (size_t const OpDet : util::counter(fPVS->NOpChannels())) {
       if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter.at(OpDet))) continue;
@@ -1521,7 +1521,7 @@ namespace larg4 {
   void
   OpFastScintillation::detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
                                           const double Num,
-                                          geo::Point_t const& ScintPoint)
+                                          geo::Point_t const& ScintPoint) const
   {
     // 1). calculate total number of hits of VUV photons on
     // reflective foils via solid angle + Gaisser-Hillas
@@ -1595,7 +1595,7 @@ namespace larg4 {
   int
   OpFastScintillation::VUVHits(const double Nphotons_created,
                                geo::Point_t const& ScintPoint_v,
-                               OpticalDetector const& opDet)
+                               OpticalDetector const& opDet) const
   {
     // the interface has been converted into geo::Point_t, the implementation not yet
     std::array<double, 3U> ScintPoint;
@@ -1646,7 +1646,7 @@ namespace larg4 {
 
     // determine GH parameters, accounting for border effects
     // radial distance from centre of detector (Y-Z)
-    double r = dist(&ScintPoint[1], &fcathode_centre[1], 2);
+    double r = dist(ScintPoint, fcathode_centre, 2, 1);
     double pars_ini[4] = {0, 0, 0, 0};
     double s1 = 0; double s2 = 0; double s3 = 0;
     // flat PDs
@@ -1692,7 +1692,7 @@ namespace larg4 {
   OpFastScintillation::VISHits(geo::Point_t const& ScintPoint_v,
                                OpticalDetector const& opDet,
                                const double cathode_hits_rec,
-                               const std::array<double, 3> hotspot)
+                               const std::array<double, 3> hotspot) const
   {
     // 1). calculate total number of hits of VUV photons on reflective
     // foils via solid angle + Gaisser-Hillas corrections.
@@ -1755,7 +1755,7 @@ namespace larg4 {
 
     // determine correction factor, depending on PD type
     const size_t k = (theta_vis / fdelta_angulo_vis);         // off-set angle bin
-    double r = dist(&ScintPoint[1], &fcathode_centre[1], 2);  // radial distance from centre of detector (Y-Z)
+    double r = dist(ScintPoint, fcathode_centre, 2, 1);      // radial distance from centre of detector (Y-Z)
     double d_c = std::abs(ScintPoint[0] - plane_depth);      // distance to cathode
     double border_correction = 0;
     // flat PDs
@@ -1854,7 +1854,7 @@ namespace larg4 {
   }
 
   G4double
-  OpFastScintillation::Gaisser_Hillas(const double x, const double* par)
+  OpFastScintillation::Gaisser_Hillas(const double x, const double* par) const
   {
     double X_mu_0 = par[3];
     double Normalization = par[0];
@@ -1934,7 +1934,7 @@ namespace larg4 {
                                    const std::vector<double>& yData,
                                    double x,
                                    bool extrapolate,
-                                   size_t i)
+                                   size_t i) const
   {
     if (i == 0) {
       size_t size = xData.size();
@@ -1965,7 +1965,7 @@ namespace larg4 {
                                     const std::vector<double>& yData2,
                                     const std::vector<double>& yData3,
                                     double x,
-                                    bool extrapolate)
+                                    bool extrapolate) const
   {
     size_t size = xData.size();
     size_t i = 0;               // find left end of interval for interpolation
@@ -2011,7 +2011,7 @@ namespace larg4 {
   // that's an unrealistic small number, better setting
   // constexpr double tolerance = 0.0000001; // 1 nm
   double
-  OpFastScintillation::Disk_SolidAngle(const double d, const double h, const double b)
+  OpFastScintillation::Disk_SolidAngle(const double d, const double h, const double b) const
   {
     if (b <= 0. || d < 0. || h <= 0.) return 0.;
     const double leg2 = (b + d) * (b + d);
@@ -2073,7 +2073,7 @@ namespace larg4 {
 
   // solid angle of rectangular aperture
   double
-  OpFastScintillation::Rectangle_SolidAngle(const double a, const double b, const double d)
+  OpFastScintillation::Rectangle_SolidAngle(const double a, const double b, const double d) const
   {
     double aa = a / (2. * d);
     double bb = b / (2. * d);
@@ -2084,7 +2084,7 @@ namespace larg4 {
 
   // TODO: allow greater tolerance in comparisons, see note above on Disk_SolidAngle()
   double
-  OpFastScintillation::Rectangle_SolidAngle(Dims const& o, const std::array<double, 3> v)
+  OpFastScintillation::Rectangle_SolidAngle(Dims const& o, const std::array<double, 3> v) const
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -464,8 +464,8 @@ namespace larg4 {
   double model_far(double*, double*);
 
   static const size_t acos_bins = 2000000;
-  static std::array<double, acos_bins + 1>
-    acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
+  // static std::array<double, acos_bins + 1>
+  //   acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
   constexpr double acos_table(const double x);
   double fast_acos(const double x);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -259,6 +259,13 @@ namespace larg4 {
     void getVISTimes(std::vector<double>& arrivalTimes, const TVector3 &ScintPoint, const TVector3 &OpDetPoint);
     // Visible component timing parameterisation
 
+    void detectedDirectHits(std::map<size_t, int>& DetectedNum,
+                            const double Num,
+                            geo::Point_t const& ScintPoint);
+    void detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
+                            const double Num,
+                            geo::Point_t const& ScintPoint);
+
   protected:
     void BuildThePhysicsTable();
     // It builds either the fast or slow scintillation integral table;
@@ -295,13 +302,6 @@ namespace larg4 {
 
     /// Returns whether the semi-analytic visibility parametrization is being used.
     bool usesSemiAnalyticModel() const;
-
-    void detectedDirectHits(std::map<size_t, int>& DetectedNum,
-                            const double Num,
-                            geo::Point_t const& ScintPoint);
-    void detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
-                            const double Num,
-                            geo::Point_t const& ScintPoint);
 
     int VUVHits(const double Nphotons_created,
                 geo::Point_t const& ScintPoint,

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -347,8 +347,6 @@ namespace larg4 {
      double ftf1_sampling_factor;
      double ft0_max, ft0_break_point;*/
 
-    size_t NOpChannels;
-
     //For new VUV time parametrization
     double fstep_size, fmin_d, fmax_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance, fangle_bin_timing_vuv;
     std::vector<std::vector<double>> fparameters[7];

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -464,8 +464,6 @@ namespace larg4 {
   double model_far(double*, double*);
 
   static const size_t acos_bins = 2000000;
-  // static std::array<double, acos_bins + 1>
-  //   acos_arr; // to get minimum resolution of 0.0000005 in [0,1]
   constexpr double acos_table(const double x);
   double fast_acos(const double x);
 

--- a/larsim/LegacyLArG4/OpFastScintillation.hh
+++ b/larsim/LegacyLArG4/OpFastScintillation.hh
@@ -261,10 +261,10 @@ namespace larg4 {
 
     void detectedDirectHits(std::map<size_t, int>& DetectedNum,
                             const double Num,
-                            geo::Point_t const& ScintPoint);
+                            geo::Point_t const& ScintPoint) const;
     void detectedReflecHits(std::map<size_t, int>& ReflDetectedNum,
                             const double Num,
-                            geo::Point_t const& ScintPoint);
+                            geo::Point_t const& ScintPoint) const;
 
   protected:
     void BuildThePhysicsTable();
@@ -305,13 +305,13 @@ namespace larg4 {
 
     int VUVHits(const double Nphotons_created,
                 geo::Point_t const& ScintPoint,
-                OpticalDetector const& opDet);
+                OpticalDetector const& opDet) const;
     // Calculates semi-analytic model number of hits for vuv component
 
     int VISHits(geo::Point_t const& ScintPoint,
                 OpticalDetector const& opDet,
                 const double cathode_hits_rec,
-                const std::array<double, 3> hotspot);
+                const std::array<double, 3> hotspot) const;
     // Calculates semi-analytic model number of hits for visible component
 
     G4double single_exp(const G4double t, const G4double tau2) const;
@@ -370,16 +370,16 @@ namespace larg4 {
     };
 
     // solid angle of rectangular aperture calculation functions
-    double Rectangle_SolidAngle(const double a, const double b, const double d);
-    double Rectangle_SolidAngle(Dims const&  o, const std::array<double, 3> v);
+    double Rectangle_SolidAngle(const double a, const double b, const double d) const;
+    double Rectangle_SolidAngle(Dims const&  o, const std::array<double, 3> v) const;
     // solid angle of circular aperture calculation functions
-    double Disk_SolidAngle(const double d, const double h, const double b);
+    double Disk_SolidAngle(const double d, const double h, const double b) const;
     // solid angle of a dome aperture calculation functions
     double Omega_Dome_Model(const double distance, const double theta) const;
 
     // For VUV semi-analytic hits
     // Gaisser-Hillas correction parameters for VUV Nhits estimation
-    G4double Gaisser_Hillas(const double x, const double* par);
+    G4double Gaisser_Hillas(const double x, const double* par) const;
     double fdelta_angulo_vuv;
     // flat PDs
     bool fIsFlatPDCorr;
@@ -445,14 +445,14 @@ namespace larg4 {
                        const std::vector<double>& yData,
                        double x,
                        bool extrapolate,
-                       size_t i = 0);
+                       size_t i = 0) const;
     void interpolate3(std::array<double, 3>& inter,
                       const std::vector<double>& xData,
                       const std::vector<double>& yData1,
                       const std::vector<double>& yData2,
                       const std::vector<double>& yData3,
                       double x,
-                      bool extrapolate);
+                      bool extrapolate) const;
 
     static std::vector<geo::BoxBoundedGeo> extractActiveVolumes(geo::GeometryCore const& geom);
 
@@ -569,6 +569,17 @@ namespace larg4 {
     double d = 0.;
     for (unsigned int p = 0; p < dimension; ++p) {
       d += (*(x + p) - *(y + p)) * (*(x + p) - *(y + p));
+    }
+    return std::sqrt(d);
+  }
+
+  template <typename TVector3>
+  inline constexpr double
+  dist(const std::array<double, 3> x, const TVector3 y, const unsigned int dimension, const unsigned int start)
+  {
+    double d = 0.;
+    for (unsigned int p = start; p < dimension; ++p) {
+      d += (x[p] - y[p]) * (x[p] - y[p]);
     }
     return std::sqrt(d);
   }


### PR DESCRIPTION
SBN needs to access `OpFastScintillation::detectedDirectHits()` and `OpFastScintillation::detectedReflecHits()` in order to get an estimation of the photons that arrive to optical detectors using the semi-analytical approach instead of the photon library. Currently, those two methods are private. This PR changes them to public. 

`detectedDirectHits` and `detectedReflecHits` should be provided by a service (similarly to the `PhotonVisibilityService`) and this is planned to be done in the future when things will be moved to `larg4`. For now, we need to access them in this way.