### PR TITLE
Fix misleading message in PhotonVisibilityService

### DIFF
--- a/larsim/PhotonPropagation/PhotonVisibilityService_service.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService_service.cc
@@ -204,9 +204,11 @@ namespace phot {
 
         size_t NOpDets = geom->NOpDets();
         size_t NVoxels = GetVoxelDef().GetNVoxels();
-        mf::LogInfo("PhotonVisibilityService")
-          << " Vis service running library build job.  Please ensure "
-          << " job contains LightSource, LArG4, SimPhotonCounter" << std::endl;
+        if (fLibraryBuildJob) {
+          mf::LogInfo("PhotonVisibilityService")
+            << " Vis service running library build job.  Please ensure "
+            << " job contains LightSource, LArG4, SimPhotonCounter";
+        }
 
         art::TFileDirectory* pDir = nullptr;
         try {


### PR DESCRIPTION
A message about photon library build mode appeared even in some cases when library build mode was not active.
This simple fix (to an issue that I suspect _I_ may have introduced long ago) prevents that.

Now, this is a very bad thing that I am doing, by creating a fix using GitHub editor (meaning, I did not even compile the proposed fix and I am relying on the C.I. test). I might be using too much Python...

Also: this change can be aggregated to others before being scheduled for merge, since it is not urgent.