### PR TITLE
Volume name feature for RadioGen event generator.

### DIFF
--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -897,12 +897,21 @@ namespace evgen{
     auto const& detInfo
       = *(lar::providerFrom<detinfo::DetectorPropertiesService>());
     
-    TPCelectronics_tick const startTick { -int(detInfo.ReadOutWindowSize()) };
-    TPCelectronics_tick const endTick { detInfo.NumberTimeSamples() };
+    //
+    // we take a number of (TPC electronics) ticks before the trigger time,
+    // and we go to a number of ticks after the trigger time;
+    // that shift is one readout window size
+    //
+    
+    auto const trigTimeTick
+      = timings.toTick<electronics_tick>(timings.TriggerTime());
+    electronics_time_ticks const beforeTicks
+      { -int(detInfo.ReadOutWindowSize()) };
+    electronics_time_ticks const afterTicks { detInfo.NumberTimeSamples() };
     
     return {
-      double(timings.toTimeScale<simulation_time>(startTick)),
-      double(timings.toTimeScale<simulation_time>(endTick))
+      double(timings.toTimeScale<simulation_time>(trigTimeTick + beforeTicks)),
+      double(timings.toTimeScale<simulation_time>(trigTimeTick + afterTicks))
       };
   } // RadioGen::defaulttimewindow()
 

--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -953,7 +953,7 @@ namespace evgen{
     auto const& detInfo
       = *(lar::providerFrom<detinfo::DetectorPropertiesService>());
     
-    TPCelectronics_tick const startTick { -detInfo.ReadOutWindowSize() };
+    TPCelectronics_tick const startTick { -int(detInfo.ReadOutWindowSize()) };
     TPCelectronics_tick const endTick { detInfo.NumberTimeSamples() };
     
     return {

--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -192,62 +192,6 @@ namespace {
 }
 
 
-#ifndef LARCOREALG_GEOMETRY_ROOTGEOMETRYNAVIGATOR_H
-namespace geo { // FIXME this is going to be into larcorealg/Geometry/ROOTGeometryNavigator.h
-  
-  class ROOTGeometryNavigator {
-    
-    TGeoManager const* manager = nullptr;
-    
-      public:
-    ROOTGeometryNavigator(TGeoManager const& manager): manager(&manager) {}
-    
-    template <typename Op>
-    bool apply(geo::GeoNodePath& path, Op&& op) const;
-    
-    template <typename Op>
-    bool apply(Op&& op) const;
-    
-  }; // ROOTGeometryNavigator
-  
-  
-  template <typename Op>
-  bool ROOTGeometryNavigator::apply
-    (geo::GeoNodePath& path, Op&& op) const
-  {
-    if (!op(path)) return false;
-    
-    TGeoNode const& node = path.current();
-    TGeoVolume const* pVolume = node.GetVolume();
-    if (pVolume) { // is it even possible not to?
-      int const nDaughters = pVolume->GetNdaughters();
-      for (int iDaughter: util::counter<int>(nDaughters)) {
-        TGeoNode const* pDaughter = pVolume->GetNode(iDaughter);
-        if (!pDaughter) continue; // fishy...
-        
-        path.append(*pDaughter);
-        if (!apply(path, std::forward<Op>(op))) return false;
-        path.pop();
-      } // for
-    } // if we have a volume
-    
-    return true;
-    
-  } // ROOTGeometryNavigator::apply()
-  
-  
-  template <typename Op>
-  bool ROOTGeometryNavigator::apply(Op&& op) const {
-    assert(manager);
-    geo::GeoNodePath path { manager->GetTopNode() };
-    return apply(path, std::forward<Op>(op));
-    
-  } // ROOTGeometryNavigator::apply()
-  
-  
-} // namespace geo
-#endif // LARCOREALG_GEOMETRY_ROOTGEOMETRYNAVIGATOR_H
-
 namespace evgen{
 
   //____________________________________________________________________________

--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -301,10 +301,15 @@ namespace evgen{
     auto t1 = pset.get< std::vector<double> >("T1", {});
     
     if (fT0.empty() || fT1.empty()) { // better be both empty...
-      assert(fT0.empty() && fT1.empty());
-      auto const times = defaulttimewindow();
-      t0.push_back(times.first);
-      t1.push_back(times.second);
+      if (!fT0.empty() || !fT1.empty()) {
+        throw art::Exception(art::errors::Configuration)
+          << "RadioGen T0 and T1 need to be both non-empty, or both empty"
+          " (now T0 has " << fT0.size() << " entries and T1 has " << fT0.size()
+          << ")\n";
+      }
+      auto const [ defaultT0, defaultT1 ] = defaulttimewindow();
+      t0.push_back(defaultT0);
+      t1.push_back(defaultT1);
     }
     
     //

--- a/larsim/EventGenerator/RadioGen_module.cc
+++ b/larsim/EventGenerator/RadioGen_module.cc
@@ -69,6 +69,8 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardataalg/DetectorInfo/DetectorTimings.h"
 #include "lardataalg/DetectorInfo/DetectorProperties.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/ROOTGeometryNavigator.h"
 #include "larcorealg/Geometry/GeometryCore.h"
@@ -219,6 +221,7 @@ namespace evgen{
     auto t1 = pset.get< std::vector<double> >("T1", {});
     
     if (fT0.empty() || fT1.empty()) { // better be both empty...
+      assert(fT0.empty() && fT1.empty());
       auto const times = defaulttimewindow();
       t0.push_back(times.first);
       t1.push_back(times.second);
@@ -893,9 +896,9 @@ namespace evgen{
     using namespace detinfo::timescales;
     
     auto const& timings = detinfo::makeDetectorTimings
-      (lar::providerFrom<detinfo::DetectorClocksService>());
-    auto const& detInfo
-      = *(lar::providerFrom<detinfo::DetectorPropertiesService>());
+      (art::ServiceHandle<detinfo::DetectorClocksService>()->DataForJob());
+    detinfo::DetectorPropertiesData const& detInfo
+      = art::ServiceHandle<detinfo::DetectorPropertiesService>()->DataForJob();
     
     //
     // we take a number of (TPC electronics) ticks before the trigger time,
@@ -906,7 +909,7 @@ namespace evgen{
     auto const trigTimeTick
       = timings.toTick<electronics_tick>(timings.TriggerTime());
     electronics_time_ticks const beforeTicks
-      { -int(detInfo.ReadOutWindowSize()) };
+      { -static_cast<int>(detInfo.ReadOutWindowSize()) };
     electronics_time_ticks const afterTicks { detInfo.NumberTimeSamples() };
     
     return {


### PR DESCRIPTION
Features have been added to `RadioGen` event generator:
* volumes can be added by name instead of coordinates
* generation times can be specified nuclide by nuclide, or one for all (or there is a not-so-useful default)
* added Doxygen documentation

These and other features have been discussed long time ago with @tomjunk, but at this time I have to be realistic and accept I will not have the time to add them.
So I invite @tomjunk in particular to check this proposal, and I will fix anything related to the _currently proposed_ features.

Note that ICARUS is already using the new features (specifying `volCryostat` is way more convenient and maintainable than specifying in the configuration file the coordinates of two different volumes).