### PR TITLE
[FEAT] Add photon fast simulation module based on GAN graph

### DIFF
--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -1,3 +1,9 @@
+include_directories ( ${CMAKE_CURRENT_SOURCE_DIR} )
+include_directories ( $ENV{PROTOBUF_INC} )
+include_directories ( $ENV{TENSORFLOW_INC} )
+include_directories ( $ENV{TENSORFLOW_INC}/eigen )
+include_directories ( $ENV{TENSORFLOW_INC}/absl )
+
 art_make(LIB_LIBRARIES larevt_Filters
                        lardataobj_RawData
                        larcorealg_Geometry
@@ -62,3 +68,4 @@ install_scripts()
 add_subdirectory(LibraryBuildTools)
 add_subdirectory(LibraryMappingTools)
 add_subdirectory(ScintTimeTools)
+add_subdirectory(TFLoaderTools)

--- a/larsim/PhotonPropagation/PDFastSimGAN_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimGAN_module.cc
@@ -1,0 +1,319 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       PDFastSimGAN
+// Plugin Type: producer
+// File:        PDFastSimGAN_module.cc
+// Description:
+// - acts on sim::SimEnergyDeposit from LArG4Main, 
+// - simulate the OpDet response to optical photons
+// Input: 'sim::SimEnergyDeposit'
+// Output: 'sim::OpDetBacktrackerRecord'
+//Fast simulation of propagating the photons created from SimEnergyDeposits.
+
+//This module does a fast simulation of propagating the photons created from SimEnergyDeposits,
+//This simulation is done using the graph trained by GAN, which gives the visibilities of each optical channel
+//with respect to scinitllation vertex in the TPC volume, to avoid propagating single photons using Geant4.
+//At the end of this module a collection of the propagated photons either as
+//'sim::OpDetBacktrackerRecord' are placed into the art event.
+
+//The steps this module takes are:
+//  - to take number of photon and the vertex information from 'sim::SimEnergyDeposits',
+//  - use the visibilities to determine the amount of visible photons at each optical channel,
+//  - visible photons: the number of photons times the visibility at the middle of the Geant4 step for a given optical channel.
+//  - other photon information is got from 'sim::SimEnergyDeposits'
+//  - add 'sim::OpDetBacktrackerRecord' to event
+// Oct. 20, 2020 by Mu Wei
+////////////////////////////////////////////////////////////////////////
+
+// Art libraries
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Utilities/make_tool.h"
+#include "canvas/Utilities/Exception.h"
+#include "canvas/Utilities/InputTag.h"
+#include "nurandom/RandomUtils/NuRandomService.h"
+#include "fhiclcpp/ParameterSet.h"
+
+// LArSoft libraries
+#include "larcore/Geometry/Geometry.h"
+#include "larsim/Simulation/LArG4Parameters.h"
+#include "lardataobj/Simulation/SimEnergyDeposit.h"
+#include "lardataobj/Simulation/SimPhotons.h"
+#include "lardataobj/Simulation/OpDetBacktrackerRecord.h"
+#include "lardata/DetectorInfoServices/LArPropertiesService.h"
+#include "larsim/PhotonPropagation/ScintTimeTools/ScintTime.h"
+#include "larsim/PhotonPropagation/TFLoaderTools/TFLoader.h"
+
+// Random number engine
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandPoissonQ.h"
+
+namespace phot
+{
+    class PDFastSimGAN : public art::EDProducer
+    {
+    public:
+        explicit PDFastSimGAN(fhicl::ParameterSet const&);
+        void beginJob()    override;
+        void endJob()    override;
+        
+        void produce(art::Event&) override;
+        void AddOpDetBTR(std::vector< sim::OpDetBacktrackerRecord > & opbtr,
+                             std::map<int, int> & ChannelMap,
+                             sim::OpDetBacktrackerRecord btr);
+    private:
+        bool                          fDoSlowComponent;
+        art::InputTag                 simTag;
+        std::unique_ptr<ScintTime>    fScintTime;        //Tool to retrive timinig of scintillation 
+        std::unique_ptr<TFLoader>     fTFGenerator;      //Tool to predict the hit pattern based on TensorFlow network 
+        CLHEP::HepRandomEngine&       fPhotonEngine;
+        CLHEP::HepRandomEngine&       fScintTimeEngine;
+        std::map<int, int>            PDChannelToSOCMap; //Where each OpChan is.
+        int                           nOpChannels;       //Number of optical detector
+    };
+    
+    //......................................................................    
+    PDFastSimGAN::PDFastSimGAN(fhicl::ParameterSet const& pset)
+    : art::EDProducer{pset}
+    , fDoSlowComponent{pset.get<bool>("DoSlowComponent")}
+    , simTag{pset.get<art::InputTag>("SimulationLabel")}
+    , fScintTime{art::make_tool<ScintTime>(pset.get<fhicl::ParameterSet>("ScintTimeTool"))}
+    , fTFGenerator{art::make_tool<TFLoader>(pset.get<fhicl::ParameterSet>("TFLoaderTool"))}
+    , fPhotonEngine(art::ServiceHandle<rndm::NuRandomService>{}->createEngine(*this, "HepJamesRandom", "photon", pset, "SeedPhoton"))
+    , fScintTimeEngine(art::ServiceHandle<rndm::NuRandomService>()->createEngine(*this, "HepJamesRandom", "scinttime", pset, "SeedScintTime"))
+    {
+        std::cout << "PDFastSimGAN Module Construct" << std::endl;
+
+        art::ServiceHandle<sim::LArG4Parameters const> lgp;
+        
+        if (lgp->UseLitePhotons())
+        {
+            std::cout << "Use Lite Photon." << std::endl;
+            produces< std::vector<sim::SimPhotonsLite> >();
+            produces< std::vector<sim::OpDetBacktrackerRecord> >();
+        }
+        else
+        {
+            std::cout << "Use Sim Photon." << std::endl;
+            produces< std::vector<sim::SimPhotons> >();
+        }
+    }
+    
+    //......................................................................
+    void PDFastSimGAN::beginJob()
+    {
+        std::cout << "PDFastSimGAN beginJob." << std::endl;
+        
+        fTFGenerator->Initialization();
+        
+        art::ServiceHandle<geo::Geometry const> geo;                        
+        nOpChannels = int(geo->Cryostat(0).NOpDet());
+        std::cout << "Number of optical detectors: " << nOpChannels << std::endl;
+        
+        return;
+    }
+    
+    //......................................................................
+    void PDFastSimGAN::endJob()
+    {
+        std::cout << "PDFastSimGAN endJob." << std::endl;
+        fTFGenerator->CloseSession();
+        
+        return;
+    }
+    
+    //......................................................................    
+    void PDFastSimGAN::produce(art::Event& event)
+    {
+        std::cout << "PDFastSimGAN Module Producer" << std::endl;
+                
+        art::ServiceHandle<sim::LArG4Parameters const> lgp;        
+        
+        CLHEP::RandPoissonQ randpoisphot{fPhotonEngine};
+        
+        std::unique_ptr< std::vector< sim::SimPhotons > >             phot   (new std::vector<sim::SimPhotons>);
+        std::unique_ptr< std::vector< sim::SimPhotonsLite > >         phlit  (new std::vector<sim::SimPhotonsLite>);
+        std::unique_ptr< std::vector< sim::OpDetBacktrackerRecord > > opbtr  (new std::vector<sim::OpDetBacktrackerRecord>);
+        
+        auto& photonCollection (*phot);
+        auto& photonLiteCollection (*phlit);
+        
+        photonCollection.resize(nOpChannels);
+        photonLiteCollection.resize(nOpChannels);
+        
+        for (int i = 0; i < nOpChannels; i ++)
+        {
+            photonCollection[i].fOpChannel    = i;
+            photonLiteCollection[i].OpChannel = i;
+        }
+        
+        art::Handle< std::vector<sim::SimEnergyDeposit> > edepHandle;
+        if (!event.getByLabel(simTag, edepHandle))
+        {
+            std::cout << "PDFastSimGAN Module Cannot getByLabel: " << simTag << std::endl;
+            return;
+        }
+                
+        art::ServiceHandle<geo::Geometry> geom;
+        auto const& edeps = edepHandle;
+        
+        int num_points    = 0;
+        
+        float vis_scale   = 1.0; // to scale the visibility fraction, for test only;
+        
+        for (auto const& edepi: *edeps)
+        {
+            num_points ++;
+            
+            int trackID       = edepi.TrackID();
+            int nphot         = edepi.NumPhotons();
+            int nion          = edepi.NumElectrons();
+            double edeposit   = edepi.Energy()/nphot;
+            double pos[3]     = {edepi.MidPointX(), edepi.MidPointY(), edepi.MidPointZ()};
+            
+            int nphot_fast    = edepi.NumFPhotons();
+            int nphot_slow    = edepi.NumSPhotons();
+            
+            std::vector<double> pars;
+            pars.push_back(pos[0]);
+            pars.push_back(pos[1]);
+            pars.push_back(pos[2]);
+            fTFGenerator->Predict(pars);
+            std::vector<double> Visibilities = fTFGenerator->GetPrediction();
+            if(int(Visibilities.size()) != nOpChannels)
+            {
+                std::cout << "PDFastSimGAN get channels from graph " << Visibilities.size() << " is not the same as from geometry: " <<  nOpChannels << std::endl;
+                break;
+            }
+            
+            for (int channel = 0; channel < nOpChannels; ++ channel)
+            {
+                auto visibleFraction = Visibilities[channel] * vis_scale;  // to scale the visibility fraction;
+                
+                if (visibleFraction == 0.0)
+                {
+                    continue; //vertex is not visible at this optical channel.
+                }
+
+                if (lgp->UseLitePhotons())
+                {
+                    sim::OpDetBacktrackerRecord tmpbtr(channel);
+                    if (nphot_fast > 0)
+                    {
+                        //random number, poisson distribution, mean: the amount of photons visible at this channel
+                        auto n = static_cast<int>(randpoisphot.fire(nphot_fast * visibleFraction));
+                        for (long i = 0; i < n; ++i) 
+                        {
+                            //calculates the time at which the photon was produced
+                            fScintTime->GenScintTime(true, fScintTimeEngine);
+                            auto time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                            ++ photonLiteCollection[channel].DetectedPhotons[time];
+                            tmpbtr.AddScintillationPhotons(trackID, time, 1, pos, edeposit);                        
+                        }
+                    }
+                    
+                    if ((nphot_slow > 0) && fDoSlowComponent) 
+                    {
+                        auto n = static_cast<int>(randpoisphot.fire(nphot_slow * visibleFraction));
+                        for (long i = 0; i < n; ++i) 
+                        {
+                            fScintTime->GenScintTime(false, fScintTimeEngine);
+                            auto time = static_cast<int>(edepi.StartT()+ fScintTime->GetScintTime());
+                            ++ photonLiteCollection[channel].DetectedPhotons[time];
+                            tmpbtr.AddScintillationPhotons(trackID, time, 1, pos, edeposit); 
+                        }
+                    }
+                    
+                    AddOpDetBTR(*opbtr, PDChannelToSOCMap, tmpbtr);
+                }
+                else
+                {
+                    sim::OnePhoton photon;
+                    photon.SetInSD         = false;
+                    photon.InitialPosition = edepi.End();
+                    photon.Energy          = 9.7e-6;
+
+                    if (nphot_fast > 0)
+                    {
+                        //random number, poisson distribution, mean: the amount of photons visible at this channel
+                        auto n = static_cast<int>(randpoisphot.fire(nphot_fast * visibleFraction));
+                        if (n > 0)
+                        {
+                            fScintTime->GenScintTime(true, fScintTimeEngine);
+                            auto time   = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                            photon.Time = time;
+                            // add n copies of sim::OnePhoton photon to the photon collection for a given OpChannel
+                            photonCollection[channel].insert(photonCollection[channel].end(), n, photon);
+                        }
+                    }
+                    if ((nphot_slow > 0) && fDoSlowComponent)
+                    {
+                        //random number, poisson distribution, mean: the amount of photons visible at this channel
+                        auto n = static_cast<int>(randpoisphot.fire(nphot_slow * visibleFraction));
+                        if (n > 0)
+                        {
+                            fScintTime->GenScintTime(false, fScintTimeEngine);
+                            auto time   = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                            photon.Time = time;
+                            // add n copies of sim::OnePhoton photon to the photon collection for a given OpChannel
+                            photonCollection[channel].insert(photonCollection[channel].end(), n, photon);
+                        }
+                    }
+                }
+            }
+        }
+        
+        PDChannelToSOCMap.clear();
+        
+        if (lgp->UseLitePhotons())
+        {
+            event.put(move(phlit));
+            event.put(move(opbtr));
+        }
+        else
+        {
+            event.put(move(phot));
+        }
+        
+        return;
+    }
+    
+    //......................................................................    
+    void PDFastSimGAN::AddOpDetBTR(std::vector< sim::OpDetBacktrackerRecord > & opbtr,
+                                         std::map<int, int> & ChannelMap,
+                                         sim::OpDetBacktrackerRecord btr) 
+    {
+        int iChan = btr.OpDetNum();
+        std::map<int, int>::iterator channelPosition = ChannelMap.find(iChan);
+        
+        if (channelPosition == ChannelMap.end() )
+        {
+            ChannelMap[iChan] = opbtr.size();
+            opbtr.emplace_back(std::move(btr));
+        }
+        else
+        {
+            unsigned int idtest = channelPosition->second;
+            auto const& timePDclockSDPsMap = btr.timePDclockSDPsMap();
+            
+            for(auto const& timePDclockSDP : timePDclockSDPsMap)
+            {
+                for(auto const& sdp : timePDclockSDP.second)
+                {
+                    double xyz[3] = {sdp.x, sdp.y, sdp.z};
+                    opbtr.at(idtest).AddScintillationPhotons(sdp.trackID,
+                                                             timePDclockSDP.first,
+                                                             sdp.numPhotons,
+                                                             xyz,
+                                                             sdp.energy);
+                }
+            }
+        }
+
+        return;
+    }  
+} // namespace
+
+DEFINE_ART_MODULE(phot::PDFastSimGAN)

--- a/larsim/PhotonPropagation/TFLoaderTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/TFLoaderTools/CMakeLists.txt
@@ -1,0 +1,34 @@
+art_make(NO_PLUGINS
+  EXCLUDE
+    TFLoaderGAN_tool.cc
+  LIB_LIBRARIES
+    ${ART_FRAMEWORK_SERVICES_REGISTRY}
+    cetlib
+    cetlib_except
+    fhiclcpp
+    ${CLHEP}
+    ${ART_UTILITIES}
+    ${PROTOBUF}
+    ${TENSORFLOW}
+    ${FOR_TENSORFLOW}
+  )
+
+simple_plugin(TFLoaderGAN "tool"
+              larsim_PhotonPropagation_TFLoaderTools
+              )
+
+install_headers()
+install_fhicl()
+install_source()
+
+if( DEFINED ENV{TENSORFLOW_DIR} )
+  if ( "${OSTYPE}" MATCHES "slf6" )
+    set(FOR_TENSORFLOW "-lrt")
+  endif ()
+endif ()
+
+include_directories ( ${CMAKE_CURRENT_SOURCE_DIR} )
+include_directories ( $ENV{PROTOBUF_INC} )
+include_directories ( $ENV{TENSORFLOW_INC} )
+include_directories ( $ENV{TENSORFLOW_INC}/eigen )
+include_directories ( $ENV{TENSORFLOW_INC}/absl )

--- a/larsim/PhotonPropagation/TFLoaderTools/TFLoader.cc
+++ b/larsim/PhotonPropagation/TFLoaderTools/TFLoader.cc
@@ -1,0 +1,16 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       TFLoader
+// Plugin Type: tool
+// File:        TFLoader_tool.cc TFLoader.h
+// Oct. 21, 2020 by Mu Wei (wmu@fnal.gov)
+////////////////////////////////////////////////////////////////////////
+
+#include "larsim/PhotonPropagation/TFLoaderTools/TFLoader.h"
+
+namespace phot 
+{
+    //----------------------------------------------------------------------
+    TFLoader::TFLoader()
+    {
+    }
+}

--- a/larsim/PhotonPropagation/TFLoaderTools/TFLoader.h
+++ b/larsim/PhotonPropagation/TFLoaderTools/TFLoader.h
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       TFLoader
+// Plugin Type: tool
+// File:        TFLoader_tool.cc TFLoader.h
+// Oct. 21, 2020 by Mu Wei (wmu@fnal.gov)
+////////////////////////////////////////////////////////////////////////
+#ifndef TFLoader_H
+#define TFLoader_H
+
+#include <memory>
+#include <vector>
+#include <string>
+
+#include "tensorflow/core/public/session.h"
+#include "tensorflow/core/platform/env.h"
+
+namespace phot
+{
+    class TFLoader
+    {
+    public:
+        TFLoader();
+        virtual ~TFLoader() = default;
+
+        virtual void Initialization()       = 0;
+        virtual void CloseSession()      = 0;
+        virtual void Predict(std::vector<double> pars)    = 0;
+        std::vector<double> GetPrediction() const   {return prediction;}
+        
+    protected:
+        std::vector<double>   prediction;
+    };
+}
+#endif

--- a/larsim/PhotonPropagation/TFLoaderTools/TFLoaderGAN.h
+++ b/larsim/PhotonPropagation/TFLoaderTools/TFLoaderGAN.h
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       TFLoaderGAN
+// Plugin Type: tool
+// File:        TFLoaderGAN_tool.cc TFLoaderGAN.h
+// Oct. 21, 2020 by Mu Wei (wmu@fnal.gov)
+////////////////////////////////////////////////////////////////////////
+#ifndef TFLoaderGAN_H
+#define TFLoaderGAN_H
+
+#include "art/Utilities/ToolMacros.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "larsim/PhotonPropagation/TFLoaderTools/TFLoader.h"
+
+
+namespace phot
+{
+    class TFLoaderGAN : public TFLoader
+    {
+    public:
+        explicit TFLoaderGAN(fhicl::ParameterSet const& pset);
+        void Initialization();
+        void CloseSession();
+        void Predict(std::vector<double> pars)  ;
+        
+    private:
+        std::string           ModelName;    //Full path to the model (.pb) file;
+        std::string           InputsName;   //Name of the input layer;
+        std::string           OutputName;   //Name of the output layer;
+        
+        tensorflow::Session*  session;
+        tensorflow::Status    status;
+    };
+}
+#endif

--- a/larsim/PhotonPropagation/TFLoaderTools/TFLoaderGAN_tool.cc
+++ b/larsim/PhotonPropagation/TFLoaderTools/TFLoaderGAN_tool.cc
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       TFLoaderGAN
+// Plugin Type: tool
+// File:        TFLoaderGAN_tool.cc TFLoaderGAN.h
+// Oct. 21, 2020 by Mu Wei (wmu@fnal.gov)
+////////////////////////////////////////////////////////////////////////
+#include "larsim/PhotonPropagation/TFLoaderTools/TFLoaderGAN.h"
+
+namespace phot
+{
+    //......................................................................    
+    TFLoaderGAN::TFLoaderGAN(fhicl::ParameterSet const& pset)
+    : ModelName{pset.get<std::string>("ModelName")}
+    , InputsName{pset.get<std::string>("InputsName")}
+    , OutputName{pset.get<std::string>("OutputName")}
+    {
+    }
+    
+    //......................................................................    
+    void TFLoaderGAN::Initialization()
+    {
+        std::cout << "Load TF Model: " << ModelName << ", Input Layer: " << InputsName << ", Output Layer: " << OutputName << "\n";
+        
+        //Initialize a tensorflow session
+        status = tensorflow::NewSession(tensorflow::SessionOptions(), &session);
+        if (!status.ok())
+        {
+            std::cout << status.ToString() << std::endl;
+            return;
+        }
+        
+        //Read in the protobuf graph
+        tensorflow::GraphDef graph_def;
+        status = tensorflow::ReadBinaryProto(tensorflow::Env::Default(), ModelName, &graph_def);
+        if (!status.ok())
+        {
+            std::cout << status.ToString() << std::endl;
+            return;
+        }
+        
+        //Add the graph to the session
+        status = session->Create(graph_def);
+        if (!status.ok())
+        {
+            std::cout << status.ToString() << std::endl;
+            return;
+        }
+        
+        std::cout << "TFLoader tool loaded successfully" << std::endl;
+        return;
+    }
+    
+    //......................................................................    
+    void TFLoaderGAN::CloseSession()
+    {
+        if (status.ok())
+        {
+            std::cout << "Close TF session" << std::endl;
+            session->Close();
+        }
+        
+        delete session;
+        return;
+    }
+    
+    //......................................................................    
+    void TFLoaderGAN::Predict(std::vector<double> pars)
+    {
+        //Clean prediction
+        std::vector<double>().swap(prediction);
+        
+        //Define inputs
+        tensorflow::Tensor input(tensorflow::DT_FLOAT, tensorflow::TensorShape({1, 3}));
+        auto dst = input.flat<float>().data();
+        copy_n(pars.begin(), 3, dst);        
+        std::vector<std::pair<std::string, tensorflow::Tensor>> inputs = {{ InputsName, input}};
+        
+        //Define outps
+        std::vector<tensorflow::Tensor> outputs;
+        
+        //Run the session
+        status = session->Run(inputs, {OutputName}, {}, &outputs);
+        if (!status.ok())
+        {
+            std::cout << status.ToString() << std::endl;
+            return;
+        }
+        
+        //Grab the outputs        
+        unsigned int img_num = outputs[0].shape().dim_size(0);
+        unsigned int img_row = outputs[0].shape().dim_size(1);
+        unsigned int img_col = outputs[0].shape().dim_size(2);
+        unsigned int img_cha = outputs[0].shape().dim_size(3);
+        
+        if(img_num !=1 || img_cha != 1)
+        {
+            std::cout << "Num of image or channel error!" << std::endl;
+        }
+        
+        for (unsigned int row_i = 0; row_i < img_row; row_i++)
+        {
+            for (unsigned int col_i = 0; col_i < img_col; col_i++)
+            {
+                // Get vaule through .flat()
+                unsigned int offset = row_i*img_col + col_i;
+                double value = outputs[0].flat<float>()(offset);
+//                // Get value through .tensor()
+//                double value = outputs[0].tensor<float, 4>()(0, row_i, col_i, 0);
+//                std::cout << "output[0](0, " << row_i << ", " << col_i << ", 0) = " << value << std::endl;
+                prediction.push_back(value);
+            }
+        }        
+        return;
+    }
+}
+DEFINE_ART_CLASS_TOOL(phot::TFLoaderGAN)

--- a/larsim/PhotonPropagation/TFLoaderTools/tfloader_gan_tool.fcl
+++ b/larsim/PhotonPropagation/TFLoaderTools/tfloader_gan_tool.fcl
@@ -1,0 +1,14 @@
+// tfloader_gan_tool.fcl
+// Oct. 10 2019 Wei Mu
+BEGIN_PROLOG
+
+TFLoaderToolGAN:
+{
+    tool_type: TFLoaderGAN
+    ModelName:   "./models/graph.pb"
+    InputsName:  "dense_1_input"
+    OutputName:  "activation_5/Sigmoid"
+}
+
+
+END_PROLOG


### PR DESCRIPTION
1. Introduce  a new photon fast simulation module based on the graph produced from GAN network.
2. In order to load the graph in larsfot, a tool has been introduced: TFLoader.
3. This tool need the tensorflow header file.
4. To compile the module/tool, the top level CMakeLists.txt should be also be updated.
5. I have tested the compiling, but I prefer the expert to update the top level CMakeLists.