### PR TITLE
Fix MCShower's Ancestor Start and End

### DIFF
--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -123,12 +123,12 @@ namespace sim {
       shower_prof.AncestorTrackID ( ancestor_part._track_id );
       shower_prof.AncestorProcess ( ancestor_part._process  );
 
-      shower_prof.Start         ( MCStep ( shower_part._start_vtx, shower_part._start_mom ) );
-      shower_prof.End           ( MCStep ( shower_part._end_vtx,   shower_part._end_mom   ) );
-      shower_prof.MotherStart   ( MCStep ( mother_part._start_vtx, mother_part._start_mom ) );
-      shower_prof.MotherEnd     ( MCStep ( mother_part._end_vtx,   mother_part._end_mom   ) );
-      shower_prof.AncestorStart ( MCStep ( mother_part._start_vtx, mother_part._start_mom ) );
-      shower_prof.AncestorEnd   ( MCStep ( mother_part._end_vtx,   mother_part._end_mom   ) );
+      shower_prof.Start         ( MCStep ( shower_part._start_vtx,   shower_part._start_mom   ) );
+      shower_prof.End           ( MCStep ( shower_part._end_vtx,     shower_part._end_mom     ) );
+      shower_prof.MotherStart   ( MCStep ( mother_part._start_vtx,   mother_part._start_mom   ) );
+      shower_prof.MotherEnd     ( MCStep ( mother_part._end_vtx,     mother_part._end_mom     ) );
+      shower_prof.AncestorStart ( MCStep ( ancestor_part._start_vtx, ancestor_part._start_mom ) );
+      shower_prof.AncestorEnd   ( MCStep ( ancestor_part._end_vtx,   ancestor_part._end_mom   ) );
 
       // Daughter list
       std::vector<unsigned int> daughter_track_id;


### PR DESCRIPTION
It looks like there is a typo where the MCShower's ancestor particle Start and End MCSteps are filled. They are filled with the MCShower's mother, instead of the ancestor. This PR fixes this.
