### PR TITLE
Add checks for large SCE shifts as a signal to drop charge

### DIFF
--- a/larsim/ElectronDrift/CMakeLists.txt
+++ b/larsim/ElectronDrift/CMakeLists.txt
@@ -8,6 +8,7 @@ art_make(LIB_LIBRARIES
          MODULE_LIBRARIES
            larsim_ElectronDrift
            larsim_Simulation
+	   larsim_Utils
            larsim_IonizationScintillation
            larcorealg_Geometry
            nurandom_RandomUtils_NuRandomService_service

--- a/larsim/ElectronDrift/DriftElectronstoPlane_module.cc
+++ b/larsim/ElectronDrift/DriftElectronstoPlane_module.cc
@@ -294,6 +294,11 @@ namespace detsim {
         posOffsetxyz[0] = posOffsets.X();
         posOffsetxyz[1] = posOffsets.Y();
         posOffsetxyz[2] = posOffsets.Z();
+	if (posOffsetxyz[0] < -1E9 || posOffsetxyz[0] > 1E9 ||
+	    posOffsetxyz[1] < -1E9 || posOffsetxyz[1] > 1E9 ||
+	    posOffsetxyz[2] < -1E9 || posOffsetxyz[2] > 1E9) {
+	  continue;
+	}
       }
 
       double avegagetransversePos1 = 0.;

--- a/larsim/ElectronDrift/DriftElectronstoPlane_module.cc
+++ b/larsim/ElectronDrift/DriftElectronstoPlane_module.cc
@@ -59,6 +59,7 @@
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"
 #include "larsim/ElectronDrift/ISCalculationSeparate.h"
+#include "larsim/Utils/SCEOffsetBounds.h"
 
 // Framework includes
 #include "art/Framework/Core/EDProducer.h"
@@ -291,14 +292,10 @@ namespace detsim {
       auto const* SCE = lar::providerFrom<spacecharge::SpaceChargeService>();
       if (SCE->EnableSimSpatialSCE() == true) {
         posOffsets = SCE->GetPosOffsets(mp);
+	if (larsim::Utils::SCE::out_of_bounds(posOffsets)) continue;
         posOffsetxyz[0] = posOffsets.X();
         posOffsetxyz[1] = posOffsets.Y();
         posOffsetxyz[2] = posOffsets.Z();
-	if (posOffsetxyz[0] < -1E9 || posOffsetxyz[0] > 1E9 ||
-	    posOffsetxyz[1] < -1E9 || posOffsetxyz[1] > 1E9 ||
-	    posOffsetxyz[2] < -1E9 || posOffsetxyz[2] > 1E9) {
-	  continue;
-	}
       }
 
       double avegagetransversePos1 = 0.;

--- a/larsim/ElectronDrift/ShiftEdepSCE_module.cc
+++ b/larsim/ElectronDrift/ShiftEdepSCE_module.cc
@@ -24,6 +24,7 @@
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"
 #include "larsim/IonizationScintillation/ISCalcSeparate.h"
+#include "larsim/Utils/SCEOffsetBounds.h"
 
 namespace spacecharge {
   class ShiftEdepSCE;
@@ -93,14 +94,10 @@ spacecharge::ShiftEdepSCE::produce(art::Event& e)
     if (sce->EnableSimSpatialSCE()) {
       posOffsetsStart = sce->GetPosOffsets({edep.StartX(), edep.StartY(), edep.StartZ()});
       posOffsetsEnd = sce->GetPosOffsets({edep.EndX(), edep.EndY(), edep.EndZ()});
-      if (posOffsetsStart.X() < -1E9 || posOffsetsStart.X() > 1E9 ||
-          posOffsetsStart.Y() < -1E9 || posOffsetsStart.Y() > 1E9 ||
-          posOffsetsStart.Z() < -1E9 || posOffsetsStart.Z() > 1E9 ||
-          posOffsetsEnd.X() < -1E9 || posOffsetsEnd.X() > 1E9 ||
-          posOffsetsEnd.Y() < -1E9 || posOffsetsEnd.Y() > 1E9 ||
-          posOffsetsEnd.Z() < -1E9 || posOffsetsEnd.Z() > 1E9) {
-        continue;
-      }
+      if (larsim::Utils::SCE::out_of_bounds(posOffsetsStart) ||
+          larsim::Utils::SCE::out_of_bounds(posOffsetsEnd) ) { 
+          continue; 
+        }
     }
     auto const isData = fISAlg.CalcIonAndScint(detProp, edep);
     outEdepVec.emplace_back(

--- a/larsim/ElectronDrift/ShiftEdepSCE_module.cc
+++ b/larsim/ElectronDrift/ShiftEdepSCE_module.cc
@@ -93,6 +93,14 @@ spacecharge::ShiftEdepSCE::produce(art::Event& e)
     if (sce->EnableSimSpatialSCE()) {
       posOffsetsStart = sce->GetPosOffsets({edep.StartX(), edep.StartY(), edep.StartZ()});
       posOffsetsEnd = sce->GetPosOffsets({edep.EndX(), edep.EndY(), edep.EndZ()});
+      if (posOffsetsStart.X() < -1E9 || posOffsetsStart.X() > 1E9 ||
+          posOffsetsStart.Y() < -1E9 || posOffsetsStart.Y() > 1E9 ||
+          posOffsetsStart.Z() < -1E9 || posOffsetsStart.Z() > 1E9 ||
+          posOffsetsEnd.X() < -1E9 || posOffsetsEnd.X() > 1E9 ||
+          posOffsetsEnd.Y() < -1E9 || posOffsetsEnd.Y() > 1E9 ||
+          posOffsetsEnd.Z() < -1E9 || posOffsetsEnd.Z() > 1E9) {
+        continue;
+      }
     }
     auto const isData = fISAlg.CalcIonAndScint(detProp, edep);
     outEdepVec.emplace_back(

--- a/larsim/ElectronDrift/SimDriftElectrons_module.cc
+++ b/larsim/ElectronDrift/SimDriftElectrons_module.cc
@@ -359,6 +359,11 @@ namespace detsim {
         posOffsetxyz[0] = posOffsets.X();
         posOffsetxyz[1] = posOffsets.Y();
         posOffsetxyz[2] = posOffsets.Z();
+        if (posOffsetxyz[0] < -1E9 || posOffsetxyz[0] > 1E9 ||
+            posOffsetxyz[1] < -1E9 || posOffsetxyz[1] > 1E9 ||
+            posOffsetxyz[2] < -1E9 || posOffsetxyz[2] > 1E9) {
+          continue;
+        }
       }
 
       double avegagetransversePos1 = 0.;

--- a/larsim/ElectronDrift/SimDriftElectrons_module.cc
+++ b/larsim/ElectronDrift/SimDriftElectrons_module.cc
@@ -58,6 +58,7 @@
 #include "lardataobj/Simulation/SimDriftedElectronCluster.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "larsim/Simulation/LArG4Parameters.h"
+#include "larsim/Utils/SCEOffsetBounds.h"
 
 #include "larcoreobj/SimpleTypesAndConstants/RawTypes.h" // raw::ChannelID_t
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
@@ -356,14 +357,12 @@ namespace detsim {
       auto const* SCE = lar::providerFrom<spacecharge::SpaceChargeService>();
       if (SCE->EnableSimSpatialSCE() == true) {
         posOffsets = SCE->GetPosOffsets(mp);
+	if (larsim::Utils::SCE::out_of_bounds(posOffsets)) {
+          continue;
+	}
         posOffsetxyz[0] = posOffsets.X();
         posOffsetxyz[1] = posOffsets.Y();
         posOffsetxyz[2] = posOffsets.Z();
-        if (posOffsetxyz[0] < -1E9 || posOffsetxyz[0] > 1E9 ||
-            posOffsetxyz[1] < -1E9 || posOffsetxyz[1] > 1E9 ||
-            posOffsetxyz[2] < -1E9 || posOffsetxyz[2] > 1E9) {
-          continue;
-        }
       }
 
       double avegagetransversePos1 = 0.;

--- a/larsim/LegacyLArG4/CMakeLists.txt
+++ b/larsim/LegacyLArG4/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories($ENV{XERCES_C_INC})
 
 art_make(LIB_LIBRARIES
            larsim_PhotonPropagation_PhotonVisibilityService_service
+	   larsim_Utils
            lardataobj_Simulation
            larcorealg_Geometry
            nug4_G4Base

--- a/larsim/LegacyLArG4/LArVoxelReadout.cxx
+++ b/larsim/LegacyLArG4/LArVoxelReadout.cxx
@@ -35,6 +35,7 @@
 #include "larsim/LegacyLArG4/IonizationAndScintillation.h"
 #include "larsim/LegacyLArG4/LArVoxelReadout.h"
 #include "larsim/LegacyLArG4/ParticleListAction.h"
+#include "larsim/Utils/SCEOffsetBounds.h"
 
 // CLHEP
 #include "CLHEP/Random/RandGauss.h"
@@ -398,9 +399,7 @@ namespace larg4 {
       auto const* SCE = lar::providerFrom<spacecharge::SpaceChargeService>();
       if (SCE->EnableSimSpatialSCE() == true) {
         posOffsets = SCE->GetPosOffsets({xyz[0], xyz[1], xyz[2]});
-        if (posOffsets.X() < -1E9 || posOffsets.X() > 1E9 ||
-            posOffsets.Y() < -1E9 || posOffsets.Y() > 1E9 ||
-            posOffsets.Z() < -1E9 || posOffsets.Z() > 1E9) {
+	if (larsim::Utils::SCE::out_of_bounds(posOffsets)) {
           return;
         }
       }

--- a/larsim/LegacyLArG4/LArVoxelReadout.cxx
+++ b/larsim/LegacyLArG4/LArVoxelReadout.cxx
@@ -398,6 +398,11 @@ namespace larg4 {
       auto const* SCE = lar::providerFrom<spacecharge::SpaceChargeService>();
       if (SCE->EnableSimSpatialSCE() == true) {
         posOffsets = SCE->GetPosOffsets({xyz[0], xyz[1], xyz[2]});
+        if (posOffsets.X() < -1E9 || posOffsets.X() > 1E9 ||
+            posOffsets.Y() < -1E9 || posOffsets.Y() > 1E9 ||
+            posOffsets.Z() < -1E9 || posOffsets.Z() > 1E9) {
+          return;
+        }
       }
       posOffsets.SetX(-posOffsets.X());
 

--- a/larsim/Utils/SCEOffsetBounds.cxx
+++ b/larsim/Utils/SCEOffsetBounds.cxx
@@ -1,0 +1,20 @@
+/**
+ * @file larsim/Utils/SCEOffsetBounds.cxx
+ *
+ * @brief Implementation of SCE Offset Bounds Checking method(s)
+ *
+ * @author Tom Junk (trj@fnal.gov)
+ *
+ * $Log: $
+ */
+
+// LArSoft
+#include "larsim/Utils/SCEOffsetBounds.h"
+
+bool larsim::Utils::SCE::out_of_bounds(geo::Vector_t const &offset)
+{
+  constexpr double limit{1.e9};
+  return (std::abs(offset.X()) > limit ||
+          std::abs(offset.Y()) > limit ||
+          std::abs(offset.Z()) > limit);
+}

--- a/larsim/Utils/SCEOffsetBounds.h
+++ b/larsim/Utils/SCEOffsetBounds.h
@@ -1,0 +1,28 @@
+/**
+ * @file larsim/Utils/SCEOffsetBounds.h
+ *
+ * @brief Utility function for testing if Space Charge offsets are out of bounds
+ *
+ * @author Tom Junk (trj@fnal.gov)
+ *
+ * $log: $
+ */
+#ifndef LARSIMSCEOFFSETBOUNDS_H_SEEN
+#define LARSIMSCEOFFSETBOUNDS_H_SEEN
+
+//LArSoft
+#include "larcore/Geometry/Geometry.h"
+
+namespace larsim
+{
+  namespace Utils
+  {
+    namespace SCE
+    {
+      bool out_of_bounds(geo::Vector_t const &offset);
+    }
+  }
+}
+
+#endif  // #ifndef LARSIMSCEOFFSETBOUNDS_H_SEEN
+


### PR DESCRIPTION
Some charge in ProtoDUNE-SP collects on the electron diverters which poke out into the drift volume.  These changes allow the space charge service in dunetpc to signal to the simulation to drop this charge from the simulation by putting in very large (>1E9 cm) offsets without generating error messages.   It's a bit of a hack -- one might add a flag from the space charge model to say that the charge disappears instead of just being moved, but that would be a much bigger redesign.