### PR TITLE
Reconfigure PDFastSimPAR to remove the PhotonVisibilityService 

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -1,0 +1,25 @@
+#include "opticalsimparameterisations.fcl"
+#include "scintillationtime_tool.fcl"
+
+BEGIN_PROLOG
+
+standard_pdfastsim_par_ar:
+{
+  module_type:           "PDFastSimPAR"
+  SimulationLabel:       "IonAndScint"
+  DoSlowComponent:       true
+  DoReflectedLight:      false
+  IncludePropTime:       true
+  UseLitePhotons:        true
+  OpaqueCathode:         true
+  OnlyOneCryostat:       false
+  ScintTimeTool:         @local::ScintTimeLAr
+
+  VUVTiming: @local::common_vuv_timing_parameterization
+  #VISTiming: 
+  #VUVHits:    # This is detector-specific, and without a real configuration this module won't work
+  #VISHits:   
+}
+
+
+END_PROLOG

--- a/larsim/PhotonPropagation/PDFastSimPVS.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPVS.fcl
@@ -1,0 +1,14 @@
+#include "scintillationtime_tool.fcl"
+
+BEGIN_PROLOG
+
+standard_pdfastsim_pvs:
+{
+  module_type:            "PDFastSimPVS"
+  SimulationLabel:        "IonAndScint"
+  DoSlowComponent:        true
+  ScintTimeTool:          @local::ScintTimeLAr
+}
+
+
+END_PROLOG


### PR DESCRIPTION
and LArG4Parameters services. Allows multiple instances with different optical property configurations to run in the same job. As a bonus, this moves us one step closer to eliminating the PVS entirely and to enabling multi-threading. Remaining services in this module are geometry, NuRandom, and LArProperties. The latter is only used to get the attenuation of the LAr, and could also potentially be moved to a fhicl parameter of this module.