### PR TITLE
Add DoFastComponent option to PDFastSimPAR

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -7,6 +7,7 @@ standard_pdfastsim_par_ar:
 {
   module_type:           "PDFastSimPAR"
   SimulationLabel:       "IonAndScint"
+  DoFastComponent:       true
   DoSlowComponent:       true
   DoReflectedLight:      false
   IncludePropTime:       true

--- a/larsim/PhotonPropagation/ScintTimeTools/scintillationtime_tool.fcl
+++ b/larsim/PhotonPropagation/ScintTimeTools/scintillationtime_tool.fcl
@@ -12,11 +12,4 @@ ScintTimeLAr:
     SlowDecayTime:    1600.0         // decay time of slow scintillation
 }
 
-ScintTimeXeDopedLAr:
-{
-    tool_type: ScintTimeXeDopedLAr
-    LogLevel:   1
-}
-
-
 END_PROLOG


### PR DESCRIPTION
Add a new fhicl option to turn on and off the Early (singlet) light component as well as the Late (triplet) light component. This is particularly helpful in the context of Xe doping simulation which often has only a late light component. The option has a default value of True for backwards compatibility, making this a non-breaking change. 