### PR TITLE
Update the larsim interface to MARLEY for compatbility with v1.2.0.

### DIFF
--- a/larsim/EventGenerator/MARLEY/CMakeLists.txt
+++ b/larsim/EventGenerator/MARLEY/CMakeLists.txt
@@ -14,6 +14,7 @@ art_make(LIB_LIBRARIES
            ROOT::Geom
            ROOT::Physics
            ${ART_UTILITIES}
+           ${FHICLCPP}
          MODULE_LIBRARIES
            larsim_EventGenerator_MARLEY
            larcoreobj_SummaryData

--- a/larsim/EventGenerator/MARLEY/MARLEYHelper.cxx
+++ b/larsim/EventGenerator/MARLEY/MARLEYHelper.cxx
@@ -12,6 +12,7 @@
 
 // LArSoft includes
 #include "larsim/EventGenerator/MARLEY/MARLEYHelper.h"
+#include "larsim/EventGenerator/MARLEY/MarleyParameterSetWalker.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 
 // ROOT includes
@@ -29,13 +30,12 @@ namespace {
 }
 
 //------------------------------------------------------------------------------
-evgen::MARLEYHelper::MARLEYHelper(
-  const fhicl::Table<evgen::MARLEYHelper::Config>& conf,
-  rndm::NuRandomService& rand_service, const std::string& helper_name)
-  : fHelperName(helper_name)
+evgen::MARLEYHelper::MARLEYHelper( const fhicl::ParameterSet& pset,
+  rndm::NuRandomService& rand_service, const std::string& helper_name )
+  : fHelperName( helper_name )
 {
   // Configure MARLEY using the FHiCL parameters
-  this->reconfigure(conf);
+  this->reconfigure( pset );
 
   // Register this MARLEY generator with the NuRandomService. For simplicity,
   // we use a lambda as the seeder function (see NuRandomService.h for
@@ -48,12 +48,12 @@ evgen::MARLEYHelper::MARLEYHelper(
     [this](rndm::NuRandomService::EngineId const& /* unused */,
       rndm::NuRandomService::seed_t lar_seed) -> void
     {
-      if (fMarleyGenerator && fMarleyGenerator.get()) {
-        auto seed = static_cast<uint_fast64_t>(lar_seed);
-        fMarleyGenerator.get()->reseed(seed);
+      if ( fMarleyGenerator && fMarleyGenerator.get() ) {
+        auto seed = static_cast<uint_fast64_t>( lar_seed );
+        fMarleyGenerator->reseed( seed );
       }
     },
-    fHelperName, conf.get_PSet(), { "seed" }
+    fHelperName, pset, { "seed" }
   );
 
   // Unless I'm mistaken, the call to registerEngine should seed the generator
@@ -64,13 +64,13 @@ evgen::MARLEYHelper::MARLEYHelper(
   // FHiCL file if one was given.
   // TODO: figure out what's going on here, and remove this workaround as
   // needed
-  uint_fast64_t marley_cast_seed = static_cast<uint_fast64_t>(marley_seed);
-  if (marley_cast_seed != fMarleyGenerator->get_seed()) {
-    fMarleyGenerator->reseed(marley_cast_seed);
+  uint_fast64_t marley_cast_seed = static_cast<uint_fast64_t>( marley_seed );
+  if ( marley_cast_seed != fMarleyGenerator->get_seed() ) {
+    fMarleyGenerator->reseed( marley_cast_seed );
   }
 
   // Log initialization information from the MARLEY generator
-  MF_LOG_INFO(fHelperName) << fMarleyLogStream.str();
+  MF_LOG_INFO( fHelperName ) << fMarleyLogStream.str();
   fMarleyLogStream = std::stringstream();
 
   // Do any needed setup of the MARLEY class dictionaries
@@ -78,16 +78,16 @@ evgen::MARLEYHelper::MARLEYHelper(
 }
 
 //------------------------------------------------------------------------------
-void evgen::MARLEYHelper::add_marley_particles(simb::MCTruth& truth,
+void evgen::MARLEYHelper::add_marley_particles( simb::MCTruth& truth,
   const std::vector<marley::Particle*>& particles,
-  const TLorentzVector& vtx_pos, bool track)
+  const TLorentzVector& vtx_pos, bool track )
 {
   // Loop over the vector of MARLEY particles and add simb::MCParticle
   // versions of each of them to the MCTruth object.
-  for (const marley::Particle* p : particles) {
+  for ( const marley::Particle* p : particles ) {
     // Treat all of these particles as primaries, which have negative
     // track IDs by convention
-    int trackID = -1*(truth.NParticles() + 1);
+    int trackID = -1 * ( truth.NParticles() + 1 );
 
     int pdg = p->pdg_code();
     double mass = p->mass() * MeV_to_GeV;
@@ -95,32 +95,32 @@ void evgen::MARLEYHelper::add_marley_particles(simb::MCTruth& truth,
     double py = p->py() * MeV_to_GeV;
     double pz = p->pz() * MeV_to_GeV;
     double E = p->total_energy() * MeV_to_GeV;
-    TLorentzVector mom(px, py, pz, E);
+    TLorentzVector mom( px, py, pz, E );
 
     int status = 0; // don't track the particles in LArG4 by default
-    if (track) status = 1;
+    if ( track ) status = 1;
 
-    simb::MCParticle part(trackID /* trackID to use in Geant4 */, pdg,
-      "MARLEY", -1 /* primary particle */, mass, status);
+    simb::MCParticle part( trackID /* trackID to use in Geant4 */, pdg,
+      "MARLEY", -1 /* primary particle */, mass, status );
 
-    part.AddTrajectoryPoint(vtx_pos, mom);
-    truth.Add(part);
+    part.AddTrajectoryPoint( vtx_pos, mom );
+    truth.Add( part );
   }
 }
 
 //------------------------------------------------------------------------------
 simb::MCTruth evgen::MARLEYHelper::create_MCTruth(
-  const TLorentzVector& vtx_pos, marley::Event* marley_event)
+  const TLorentzVector& vtx_pos, marley::Event* marley_event )
 {
   simb::MCTruth truth;
 
-  truth.SetOrigin(simb::kSuperNovaNeutrino);
+  truth.SetOrigin( simb::kSuperNovaNeutrino );
 
   marley::Event event = fMarleyGenerator->create_event();
 
   // Add the initial and final state particles to the MCTruth object.
-  add_marley_particles(truth, event.get_initial_particles(), vtx_pos, false);
-  add_marley_particles(truth, event.get_final_particles(), vtx_pos, true);
+  add_marley_particles( truth, event.get_initial_particles(), vtx_pos, false );
+  add_marley_particles( truth, event.get_final_particles(), vtx_pos, true );
 
   // calculate a few parameters for the call to SetNeutrino
   const marley::Particle& nu = event.projectile();
@@ -158,13 +158,13 @@ simb::MCTruth evgen::MARLEYHelper::create_MCTruth(
     Q2 * std::pow(MeV_to_GeV, 2)
   );
 
-  if (marley_event) *marley_event = event;
+  if ( marley_event ) *marley_event = event;
 
   // Process the MARLEY logging messages (if any) captured by our
   // stringstream and forward them to the messagefacility logger
   std::string line;
-  while(std::getline(fMarleyLogStream, line)) {
-    MF_LOG_INFO(fHelperName) << line;
+  while( std::getline(fMarleyLogStream, line) ) {
+    MF_LOG_INFO( fHelperName ) << line;
   }
 
   // Reset the MARLEY log stream
@@ -174,16 +174,16 @@ simb::MCTruth evgen::MARLEYHelper::create_MCTruth(
 }
 
 //------------------------------------------------------------------------------
-std::string evgen::MARLEYHelper::find_file(const std::string& fileName,
-  const std::string& fileType)
+std::string evgen::MARLEYHelper::find_file( const std::string& fileName,
+  const std::string& fileType )
 {
-  cet::search_path searchPath("FW_SEARCH_PATH");
+  cet::search_path searchPath( "FW_SEARCH_PATH" );
 
   std::string fullName;
-  searchPath.find_file(fileName, fullName);
+  searchPath.find_file( fileName, fullName );
 
-  if (fullName.empty())
-    throw cet::exception("MARLEYHelper")
+  if ( fullName.empty() )
+    throw cet::exception( "MARLEYHelper" )
       << "Cannot find MARLEY " << fileType << " data file '"
       << fileName << '\'';
 
@@ -192,7 +192,7 @@ std::string evgen::MARLEYHelper::find_file(const std::string& fileName,
 
 //------------------------------------------------------------------------------
 void evgen::MARLEYHelper::load_full_paths_into_json(
-  marley::JSON& json, const std::string& key)
+  marley::JSON& json, const std::string& key, bool missing_ok )
 {
   if ( json.has_key(key) ) {
 
@@ -201,73 +201,57 @@ void evgen::MARLEYHelper::load_full_paths_into_json(
     if ( value.is_array() ) {
       // Replace each file name (which may appear in the FHiCL configuration
       // without a full path) with the full path found using cetlib
-      for (auto& element : value.array_range()) {
-        element = find_file(element.to_string(), key);
+      for ( auto& element : value.array_range() ) {
+        element = find_file( element.to_string(), key );
       }
     }
 
     else value = find_file(value.to_string(), key);
   }
-  else throw cet::exception("MARLEYHelper") << "Missing \"" << key
-    << "\" key in the MARLEY parameters.";
+  else if ( !missing_ok ) throw cet::exception("MARLEYHelper")
+    << "Missing \"" << key << "\" key in the MARLEY parameters.";
 }
 
 //------------------------------------------------------------------------------
-void evgen::MARLEYHelper::reconfigure(
-  const fhicl::Table<evgen::MARLEYHelper::Config>& conf)
+void evgen::MARLEYHelper::reconfigure( const fhicl::ParameterSet& pset )
 {
   // Convert the FHiCL parameters into a JSON object that MARLEY can understand
-  marley::JSON json = fhicl_parameter_to_json(&conf);
+  evgen::MarleyParameterSetWalker mpsw;
+  pset.walk( mpsw );
+
+  marley::JSON& json = mpsw.get_json();
 
   // Update the reaction and structure data file names to the full paths
   // using cetlib to search for them
-  load_full_paths_into_json(json, "reactions");
-  load_full_paths_into_json(json, "structure");
+  load_full_paths_into_json( json, "reactions", false );
+  load_full_paths_into_json( json, "structure", true );
 
   // Also update the path for a neutrino source spectrum given in a ROOT
   // TFile
   if ( json.has_key("source") ) {
-    marley::JSON& source_object = json.at("source");
+    marley::JSON& source_object = json.at( "source" );
 
     if ( source_object.has_key("tfile") ) {
-      load_full_paths_into_json(source_object, "tfile");
+      load_full_paths_into_json( source_object, "tfile" );
     }
   }
 
-  // Convert the neutrino direction 3-vector into the JSON object expected by
-  // MARLEY
-  if ( json.has_key("direction") ) {
-    // Get the vector components from the length-3 array
-    marley::JSON& dir_object = json.at("direction");
-
-    double x = dir_object.at(0).to_double();
-    double y = dir_object.at(1).to_double();
-    double z = dir_object.at(2).to_double();
-
-    // Replace the array with an equivalent JSON object
-    dir_object = marley::JSON();
-    dir_object["x"] = x;
-    dir_object["y"] = y;
-    dir_object["z"] = z;
-  }
-
   // Create a new MARLEY configuration based on the JSON parameters
-  MF_LOG_INFO("MARLEYHelper " + fHelperName) << "MARLEY will now use"
+  MF_LOG_INFO( "MARLEYHelper " + fHelperName ) << "MARLEY will now use"
     " the JSON configuration\n" << json.dump_string() << '\n';
-  marley::RootJSONConfig config(json);
+  marley::RootJSONConfig config( json );
 
   // Create a new marley::Generator object based on the current configuration
   fMarleyGenerator = std::make_unique<marley::Generator>(
-    config.create_generator());
+    config.create_generator() );
 }
 
 //------------------------------------------------------------------------------
 void evgen::MARLEYHelper::load_marley_dictionaries()
 {
-
   static bool already_loaded_marley_dict = false;
 
-  if (already_loaded_marley_dict) return;
+  if ( already_loaded_marley_dict ) return;
 
   // Current (24 July 2016) versions of ROOT 6 require runtime
   // loading of headers for custom classes in order to use
@@ -278,19 +262,19 @@ void evgen::MARLEYHelper::load_marley_dictionaries()
   // This is the same technique used in the MARLEY source code
   // for the executable (src/marley.cc). If you change how this
   // code works, please sync changes with the executable as well.
-  if (gROOT->GetVersionInt() >= 60000) {
-    MF_LOG_INFO("MARLEYHelper " + fHelperName) << "ROOT 6 or greater"
+  if ( gROOT->GetVersionInt() >= 60000 ) {
+    MF_LOG_INFO( "MARLEYHelper " + fHelperName ) << "ROOT 6 or greater"
       << " detected. Loading class information\nfrom headers"
       << " \"marley/Particle.hh\" and \"marley/Event.hh\"";
     TInterpreter::EErrorCode* ec = new TInterpreter::EErrorCode();
-    gInterpreter->ProcessLine("#include \"marley/Particle.hh\"", ec);
-    if (*ec != 0) throw cet::exception("MARLEYHelper " + fHelperName)
+    gInterpreter->ProcessLine( "#include \"marley/Particle.hh\"", ec );
+    if ( *ec != 0 ) throw cet::exception( "MARLEYHelper " + fHelperName )
       << "Error loading MARLEY header Particle.hh. For MARLEY headers stored"
       << " in /path/to/include/marley/, please add /path/to/include"
       << " to your ROOT_INCLUDE_PATH environment variable and"
       << " try again.";
-    gInterpreter->ProcessLine("#include \"marley/Event.hh\"");
-    if (*ec != 0) throw cet::exception("MARLEYHelper") << "Error loading"
+    gInterpreter->ProcessLine( "#include \"marley/Event.hh\"" );
+    if ( *ec != 0 ) throw cet::exception( "MARLEYHelper" ) << "Error loading"
       << " MARLEY header Event.hh. For MARLEY headers stored in"
       << " /path/to/include/marley/, please add /path/to/include"
       << " to your ROOT_INCLUDE_PATH environment variable and"
@@ -301,115 +285,4 @@ void evgen::MARLEYHelper::load_marley_dictionaries()
   // dictionaries (which are linked to this algorithm) contain all of
   // the needed information
   already_loaded_marley_dict = true;
-}
-
-//------------------------------------------------------------------------------
-marley::JSON evgen::MARLEYHelper::fhicl_parameter_to_json(
-  const fhicl::detail::ParameterBase* par)
-{
-  // Don't bother with the rest of the analysis if we've been handed a
-  // nullptr or if the parameter is disabled in the current configuration
-  if (par && par->should_use()) {
-
-    auto type = par->parameter_type();
-    if (fhicl::is_atom(type)) {
-
-      // This is an ugly hack to load FHiCL atoms into JSON objects. We have
-      // to do it type-by-type using the current (12/2016) implementation of
-      // the fhicl::Atom and fhicl::OptionalAtom template classes.
-      if ( !par->is_optional() ) {
-        if (auto atm = dynamic_cast<const fhicl::Atom<double>* >(par))
-          return fhicl_atom_to_json<>(atm);
-        else if (auto atm = dynamic_cast<const fhicl::Atom<std::string>* >(par))
-        {
-          return fhicl_atom_to_json<>(atm);
-        }
-        else if (auto atm = dynamic_cast<const fhicl::Atom<bool>* >(par))
-        {
-          return fhicl_atom_to_json<>(atm);
-        }
-        else if (auto atm = dynamic_cast<const fhicl::Atom<int>* >(par))
-        {
-          return fhicl_atom_to_json<>(atm);
-        }
-        else throw cet::exception("MarleyGen") << "Failed to deduce"
-          << " the type of the FHiCL atom " << par->key();
-      }
-      else { // optional atoms
-        if (auto opt_atom = dynamic_cast<const fhicl::OptionalAtom<double>* >(par))
-        {
-          return fhicl_optional_atom_to_json<>(opt_atom);
-        }
-        else if (auto opt_atom = dynamic_cast<const fhicl::OptionalAtom<std::string>* >(par))
-        {
-          return fhicl_optional_atom_to_json<>(opt_atom);
-        }
-        else if (auto opt_atom = dynamic_cast<const fhicl::OptionalAtom<bool>* >(par))
-        {
-          return fhicl_optional_atom_to_json<>(opt_atom);
-        }
-        else if (auto opt_atom = dynamic_cast<const fhicl::OptionalAtom<int>* >(par))
-        {
-          return fhicl_optional_atom_to_json<>(opt_atom);
-        }
-        else throw cet::exception("MarleyGen") << "Failed to deduce"
-          << " the type of the FHiCL optional atom " << par->key();
-      }
-    }
-    else if (fhicl::is_sequence(type)) {
-
-      // This is another ugly hack to allow us to fill the JSON array. We
-      // have to do it type-by-type using the current (12/2016)
-      // implementation of the fhicl::Sequence template class.
-      if (auto seq = dynamic_cast<const fhicl::Sequence<double>* >(par))
-        return fhicl_sequence_to_json<>(seq);
-      else if (auto seq = dynamic_cast<const fhicl::Sequence<double, 3>* >(par))
-      {
-        return fhicl_sequence_to_json<>(seq);
-      }
-      else if (auto seq = dynamic_cast<const fhicl::Sequence<std::string>* >(par))
-      {
-        return fhicl_sequence_to_json<>(seq);
-      }
-      else if (auto seq = dynamic_cast<const fhicl::Sequence<int>* >(par))
-      {
-        return fhicl_sequence_to_json<>(seq);
-      }
-      else if (auto seq = dynamic_cast<const fhicl::Sequence<bool>* >(par))
-      {
-        return fhicl_sequence_to_json<>(seq);
-      }
-      else throw cet::exception("MarleyGen") << "Failed to deduce"
-        << " the type of the FHiCL sequence " << par->key();
-
-      return marley::JSON();
-    }
-    else if (fhicl::is_table(type)) {
-
-      // Downcast the parameter pointer into a TableBase pointer so that we
-      // can iterate over its members
-      auto table = dynamic_cast<const fhicl::detail::TableBase*>(par);
-      if (!table) throw cet::exception("MarleyGen") << "Failed dynamic_cast"
-        << " of fhicl::detail::ParameterBase* to fhicl::detail::TableBase*"
-        << " when fhicl_is_table() was true";
-
-      // Create an empty JSON object
-      marley::JSON object = marley::JSON::make(
-        marley::JSON::DataType::Object);
-
-      // Load it with the members of the table recursively
-      for (const auto& m : table->members()) {
-        if (m && m->should_use()) {
-          marley::JSON temp = fhicl_parameter_to_json(m.get());
-          // Skip members that are null (typically unused optional FHiCL
-          // parameters)
-          if (!temp.is_null()) object[ m->name() ] = temp;
-        }
-      }
-      return object;
-    }
-  }
-
-  // Return a null JSON object if something strange happened.
-  return marley::JSON();
 }

--- a/larsim/EventGenerator/MARLEY/MARLEYHelper.h
+++ b/larsim/EventGenerator/MARLEY/MARLEYHelper.h
@@ -18,15 +18,6 @@
 
 // framework includes
 #include "fhiclcpp/ParameterSet.h"
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/OptionalAtom.h"
-#include "fhiclcpp/types/OptionalSequence.h"
-#include "fhiclcpp/types/OptionalTable.h"
-#include "fhiclcpp/types/Sequence.h"
-#include "fhiclcpp/types/Table.h"
-#include "fhiclcpp/types/detail/ParameterArgumentTypes.h"
-#include "fhiclcpp/types/detail/ParameterBase.h"
-#include "fhiclcpp/types/detail/TableBase.h"
 
 // art extensions
 namespace rndm { class NuRandomService; }
@@ -41,6 +32,7 @@ namespace rndm { class NuRandomService; }
 // MARLEY includes
 #include "marley/Generator.hh"
 #include "marley/JSON.hh"
+
 namespace marley {
   class Event;
   class Particle;
@@ -52,267 +44,35 @@ namespace evgen {
 
     public:
 
-      using Name = fhicl::Name;
-      using Comment = fhicl::Comment;
-
-      /// Collection of configuration parameters that will be
-      /// forwarded to MARLEY and used to define the neutrino
-      /// source
-      struct Source_Config {
-        fhicl::Atom<std::string> type_ {
-          Name("type"),
-          Comment("Type of neutrino source for MARLEY to use")
-        };
-
-        fhicl::Atom<std::string> neutrino_ {
-          Name("neutrino"),
-          Comment("Kind of neutrino (flavor, matter/antimatter) that the"
-            " neutrino source produces")
-        };
-
-        fhicl::Atom<double> Emin_ {
-          Name("Emin"),
-          Comment("Minimum energy (MeV) of the neutrinos produced by this"
-            " source"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "fermi-dirac") || (type == "beta-fit" );
-          }
-        };
-
-        fhicl::Atom<double> Emax_ {
-          Name("Emax"),
-          Comment("Maximum energy (MeV) of the neutrinos produced by this"
-            " source"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "fermi-dirac") || (type == "beta-fit" )
-              || (type == "histogram");
-          }
-        };
-
-        fhicl::Atom<double> temperature_ {
-          Name("temperature"),
-          Comment("Effective temperature for the Fermi-Dirac distribution"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "fermi-dirac");
-          }
-        };
-
-        fhicl::OptionalAtom<double> eta_ {
-          Name("eta"),
-          Comment("Pinching parameter for the Fermi-Dirac distribution"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "fermi-dirac");
-          }
-        };
-
-        fhicl::Atom<double> energy_ {
-          Name("energy"),
-          Comment("Energy (MeV) of the neutrinos produced by a monoenergetic"
-            " source"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "monoenergetic");
-          }
-        };
-
-        fhicl::Atom<double> Emean_ {
-          Name("Emean"),
-          Comment("Mean energy (MeV) of the neutrinos produced by a beta-fit"
-            " source"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "beta-fit");
-          }
-        };
-
-        fhicl::OptionalAtom<double> beta_ {
-          Name("beta"),
-          Comment("Pinching parameter for a beta-fit source"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "beta-fit");
-          }
-        };
-
-        fhicl::Sequence<double> E_bin_lefts_ {
-          Name("E_bin_lefts"),
-          Comment("Left edges for each energy bin in the histogram"),
-          [this]() -> bool {
-            auto type = type_();
-            return type == "histogram";
-          }
-        };
-
-        fhicl::Sequence<double> weights_ {
-          Name("weights"),
-          Comment("Weights for each energy bin in the histogram"),
-          [this]() -> bool {
-            auto type = type_();
-            return type == "histogram";
-          }
-        };
-
-        fhicl::Sequence<double> energies_ {
-          Name("energies"),
-          Comment("Energies (MeV) for each grid point"),
-          [this]() -> bool {
-            auto type = type_();
-            return type == "grid";
-          }
-        };
-
-        fhicl::Sequence<double> prob_densities_ {
-          Name("prob_densities"),
-          Comment("Probability densities for each grid point"),
-          [this]() -> bool {
-            auto type = type_();
-            return type == "grid";
-          }
-        };
-
-        fhicl::Atom<std::string> rule_ {
-          Name("rule"),
-          Comment("Interpolation rule for computing probability densities"
-            " between grid points. Allowed values include \"linlin\","
-            " \"linlog\", \"loglin\", \"loglog\", and \"constant\""),
-          [this]() -> bool {
-            auto type = type_();
-            return type == "grid";
-          }
-        };
-
-        fhicl::Atom<std::string> tfile_ {
-          Name("tfile"),
-          Comment("Name of the ROOT file that contains a TH1 or TGraph neutrino"
-            " source spectrum"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "th1") || (type == "tgraph");
-          }
-        };
-
-        fhicl::Atom<std::string> namecycle_ {
-          Name("namecycle"),
-          Comment("Namecycle of the ROOT TH1 or TGraph to use"),
-          [this]() -> bool {
-            auto type = type_();
-            return (type == "th1") || (type == "tgraph");
-          }
-        };
-
-        fhicl::Atom<bool> weight_flux_ {
-          Name("weight_flux"),
-          Comment("Whether to weight the input flux by the reaction cross section(s)"),
-          true
-        };
-
-      }; // struct Source_Config
-
-      /// Collection of configuration parameters that will be
-      /// forwarded to MARLEY
-      struct Config {
-
-        fhicl::OptionalAtom<std::string> seed_ {
-          Name("seed"),
-          Comment("Seed used for the MARLEY generator")
-        };
-
-        fhicl::Sequence<double, 3> direction_ {
-          Name("direction"),
-          Comment("3-vector that points in the direction of motion of the"
-            " incident neutrinos"),
-	  // for c2: need double braces
-          std::array<double, 3> {{ 0., 0., 1. }} // default value
-        };
-
-        fhicl::Sequence<std::string> reactions_ {
-          Name("reactions"),
-          Comment("List of matrix element data files to use to define reactions"
-            " in MARLEY")
-        };
-
-        fhicl::Sequence<std::string> structure_ {
-          Name("structure"),
-          Comment("List of TALYS format nuclear structure data files to use"
-            " in MARLEY")
-        };
-
-        fhicl::Table<Source_Config> source_ {
-          Name("source"),
-          Comment("Neutrino source configuration")
-        };
-
-      }; // struct Config
-
-      // Configuration-checking constructors
-      MARLEYHelper(const fhicl::Table<Config>& conf,
+      MARLEYHelper( const fhicl::ParameterSet& pset,
         rndm::NuRandomService& rand_service,
-        const std::string& generator_name);
+        const std::string& generator_name );
 
-      MARLEYHelper(const fhicl::ParameterSet& pset,
-        rndm::NuRandomService& rand_service, const std::string& generator_name)
-        : MARLEYHelper(fhicl::Table<Config>(pset, {}),
-        rand_service, generator_name) {}
-
-      void reconfigure(const fhicl::Table<Config>& conf);
+      void reconfigure( const fhicl::ParameterSet& pset );
 
       // If a non-null marley::Event* is supplied, the marley::Event
       // object corresponding to the generated MCTruth object is loaded
       // into the target of the pointer.
-      simb::MCTruth create_MCTruth(const TLorentzVector& vtx_pos,
-        marley::Event* marley_event = nullptr);
+      simb::MCTruth create_MCTruth( const TLorentzVector& vtx_pos,
+        marley::Event* marley_event = nullptr );
 
       marley::Generator& get_generator() { return *fMarleyGenerator; }
       const marley::Generator& get_generator() const
         { return *fMarleyGenerator; }
 
-      std::string find_file(const std::string& fileName,
-        const std::string& fileType);
+      std::string find_file( const std::string& fileName,
+        const std::string& fileType );
 
     protected:
 
-      template <typename T> marley::JSON fhicl_atom_to_json(
-        const fhicl::Atom<T>* atom)
-      {
-        return marley::JSON(atom->operator()());
-      }
-
-      template <typename T> marley::JSON fhicl_optional_atom_to_json(
-        const fhicl::OptionalAtom<T>* opt_atom)
-      {
-        T value;
-        if (opt_atom->operator()(value)) return marley::JSON(value);
-        // Return a null JSON object if the fhicl::OptionalAtom wasn't used
-        else return marley::JSON();
-      }
-
-      template <typename S> marley::JSON fhicl_sequence_to_json(
-        const S* sequence)
-      {
-        marley::JSON array = marley::JSON::make(
-          marley::JSON::DataType::Array);
-
-        for (size_t i = 0; i < sequence->size(); ++i) {
-          array.append(sequence->operator()(i));
-        }
-        return array;
-      }
-
-      marley::JSON fhicl_parameter_to_json(
-        const fhicl::detail::ParameterBase* par);
-
-      void add_marley_particles(simb::MCTruth& truth,
+      void add_marley_particles( simb::MCTruth& truth,
         const std::vector<marley::Particle*>& particles,
-        const TLorentzVector& vtx_pos, bool track);
+        const TLorentzVector& vtx_pos, bool track );
 
-      void load_full_paths_into_json(marley::JSON& json,
-        const std::string& array_name);
+      void load_full_paths_into_json( marley::JSON& json,
+        const std::string& array_name, bool missing_ok = false );
 
-      std::unique_ptr<marley::Generator> fMarleyGenerator;
+      std::unique_ptr< marley::Generator > fMarleyGenerator;
 
       // name to use for this instance of MARLEYHelper
       std::string fHelperName;

--- a/larsim/EventGenerator/MARLEY/MarleyParameterSetWalker.h
+++ b/larsim/EventGenerator/MARLEY/MarleyParameterSetWalker.h
@@ -1,0 +1,91 @@
+//////////////////////////////////////////////////////////////////////////////
+/// \file MarleyParameterSetWalker.h
+/// \brief Concrete fhicl::ParameterSetWalker that converts a
+/// fhicl::ParameterSet into a marley::JSON object
+///
+/// \author Steven Gardiner <gardiner@fnal.gov>
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef LARSIM_MARLEY_PARAMETERSET_WALKER_H
+#define LARSIM_MARLEY_PARAMETERSET_WALKER_H
+
+// standard library includes
+#include <string>
+#include <vector>
+
+// framework includes
+#include "fhiclcpp/ParameterSetWalker.h"
+#include "fhiclcpp/detail/printing_helpers.h"
+
+// MARLEY includes
+#include "marley/JSON.hh"
+
+namespace evgen {
+
+  class MarleyParameterSetWalker : public fhicl::ParameterSetWalker {
+
+    public:
+
+      inline const marley::JSON& get_json() const { return full_json_; }
+      inline marley::JSON& get_json() { return full_json_; }
+
+    private:
+
+      inline void enter_table( const key_t& key, const any_t& ) override {
+        auto& json = json_refs_.back().get();
+        json_refs_.emplace_back( json[ key ]
+          = marley::JSON::make(marley::JSON::DataType::Object) );
+      }
+
+      inline void enter_sequence( const key_t& key, const any_t& ) override {
+        auto& json = json_refs_.back().get();
+        in_seq_ = true;
+        seq_index_ = 0u;
+        json_refs_.emplace_back( json[ key ]
+          = marley::JSON::make(marley::JSON::DataType::Array) );
+      }
+
+      inline void atom( const key_t& key, const any_t& any ) override {
+        auto& json = json_refs_.back().get();
+        // Convert the atom to a string. Add an extra space to keep some
+        // of MARLEY's JSON parsing routines (which rely on looking ahead
+        // in some cases) happy
+        std::string atom_val = fhicl::detail::atom::value( any ) + ' ';
+        marley::JSON json_atom;
+        // Hard-coded value taken from fhiclcpp/detail/printing_helpers.cc
+        if ( atom_val != "@nil" ) {
+          std::istringstream iss( atom_val );
+          // Utility function defined in marley/JSON.hh
+          json_atom = marley::parse_next( iss );
+        }
+        if ( in_seq_ ) {
+          json[ seq_index_++ ] = json_atom;
+        }
+        else {
+          json[ key ] = json_atom;
+        }
+      }
+
+      inline void exit_table( const key_t&, const any_t& ) override {
+        json_refs_.pop_back();
+      }
+
+      inline void exit_sequence( const key_t&, const any_t& ) override {
+        json_refs_.pop_back();
+        in_seq_ = false;
+      }
+
+      /// Owned JSON object used to store the converted FHiCL parameters
+      marley::JSON full_json_;
+
+      /// References to the owned JSON object or a sub-object thereof
+      std::vector< std::reference_wrapper<marley::JSON> >
+        json_refs_ = { full_json_ };
+
+      unsigned seq_index_ = 0u;
+      bool in_seq_ = false;
+  };
+
+}
+
+#endif // LARSIM_MARLEY_PARAMETERSET_WALKER_H

--- a/larsim/EventGenerator/MARLEY/marley.fcl
+++ b/larsim/EventGenerator/MARLEY/marley.fcl
@@ -52,26 +52,19 @@ standard_marley:
     #seed: 12345
 
     # Incident neutrino direction 3-vector [ x, y, z ]
-    direction: [ 0., 0., 1. ]
+    direction: {
+      x: 0.0
+      y: 0.0
+      z: 1.0
+    }
 
     # The user must define at least one reaction
     # by passing MARLEY the name of a matrix element
-    # data file. Two are currently available, both
+    # data file. Three are currently available
     # for the reaction ve + 40Ar --> e- + 40K*.
-    # The 2009 version uses an (p,n) scattering
-    # measurement for the experimental matrix elements,
-    # while the 1998 version uses a 40Ti beta decay
-    # measurement.
     reactions: [ "ve40ArCC_Bhattacharya2009.react" ]
     #reactions: [ "ve40ArCC_Bhattacharya1998.react" ]
     #reactions: [ "ve40ArCC_Liu1998.react" ]
-
-    # Nuclear structure (discrete levels and gamma-ray
-    # branching ratios) data files in the TALYS format
-    # may be specified here. The recommended data
-    # files are z019, z018, and z017 from TALYS-1.6,
-    # which are included with MARLEY v0.9.5.
-    structure: [ "z019", "z018", "z017" ]
 
     # Examples of all currently-allowed MARLEY neutrino
     # sources are given below. Only one of these FHiCL tables

--- a/larsim/EventGenerator/MARLEY/prodmarley.fcl
+++ b/larsim/EventGenerator/MARLEY/prodmarley.fcl
@@ -1,10 +1,6 @@
-# Generates events in the DUNE 10kt workspace geometry (4 APAs)
-
+#include "geometry.fcl"
 #include "marley.fcl"
-#include "services_dune.fcl"
-#include "largeantmodules_dune.fcl"
-#include "detsimmodules_dune.fcl"
-#include "caldata_dune.fcl"
+#include "seedservice.fcl"
 
 process_name: MarleyGen
 
@@ -13,8 +9,11 @@ services:
   # Load the service that manages root files for histograms.
   TFileService: { fileName: "marley_hist.root" }
   TimeTracker:  {}
+
   RandomNumberGenerator: {} #ART native random number generator
-                @table::dunefd_simulation_services
+  NuRandomService: @local::random_NuRandomService
+
+  @table::standard_geometry_services # from geometry.fcl
 }
 
 
@@ -38,21 +37,13 @@ physics:
  {
    # Generate events using MARLEY
    generator: @local::standard_marley
-   # Track particles in the detector using Geant4
-   largeant:  @local::dunefd_largeant
-   # Simulate TPC wire responses
-   daq:       @local::dunefd_simwire       
-   # Convert raw::RawDigit objects to recob:wire objects
-   caldata:   @local::dunefd_calwire
-   # Use cheated reconstruction to produce recob:Hit objects
-   #hitcheat:  @local::dunefd_hitcheater
    # Save the state of the LArSoft random number generators
    rns:       { module_type: "RandomNumberSaver" }
  }
 
  # define the producer and filter modules for this path, order matters, filters
  # reject all following items.  see lines starting physics.producers below
- simulate: [ generator, largeant, daq, caldata, rns ]
+ simulate: [ generator, rns ]
  
  # define the output stream, there could be more than one if using filters 
  stream1:  [ out1 ]
@@ -79,21 +70,3 @@ outputs:
    fileName:    "marley_gen.root"
  }
 }
-
-# Make sure that the geometry is what we think it is
-services.Geometry: @local::dune10kt_workspace_geo
-
-# Adjustments to the standard LArG4 parameters
-services.LArG4Parameters.ParticleKineticEnergyCut: 1.0e-5 # GeV
-services.LArG4Parameters.StoreTrajectories: true
-services.LArG4Parameters.KeepEMShowerDaughters: true
-# Use NeutronHP data (very important for neutrino-induced neutron emission!)
-# which is not enabled by default in LArSoft.
-services.LArG4Parameters.UseCustomPhysics: true
-services.LArG4Parameters.EnabledPhysics: [ "LowEnergyEm",
-                                           "SynchrotronAndGN",
-                                           "Ion",
-                                           "NeutronHP",
-                                           "Decay",
-                                           "HadronElastic",
-                                           "Stopping" ]

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -12,7 +12,7 @@ larg4           v09_03_03
 nugen           v1_11_03
 nurandom        v1_05_02
 nutools         v3_09_02
-marley          v1_1_1g
+marley          v1_2_0
 larsoft_data    v1_02_01
 cetbuildtools   v7_17_01    -   only_for_build
 end_product_list


### PR DESCRIPTION
NOTE: These changes require upgrading to the marley v1_2_0 ups product. I've made a draft of the necessary changes to the build-framework scripts (`build-framework-marley-ssi-build`) using the same branch name (`feature/gardiner-marley-v120`).

Eliminate the ugly hacks used to convert FHiCL into MARLEY's native JSON format. Instead, use a new class derived from `fhicl::ParameterSetWalker` to manage the conversion. Forego FHiCL validation of the generator settings in favor of letting MARLEY handle that itself. Adjust prodmarley.fcl so that it is experiment-agnostic.