### PR TITLE
Make cheat::BackTracker::ChannelToTrackIDEs() quiet

### DIFF
--- a/larsim/MCCheater/BackTracker.h
+++ b/larsim/MCCheater/BackTracker.h
@@ -130,6 +130,22 @@ namespace cheat {
     std::vector<const sim::IDE*> TrackIdToSimIDEs_Ps(int const& id) const;
     std::vector<const sim::IDE*> TrackIdToSimIDEs_Ps(int const& id, const geo::View_t view) const;
 
+    /**
+     * @brief Returns the cached `sim::SimChannel` on the specified `channel`.
+     * @param channel ID of the TPC channel to find
+     * @return _art_ pointer to `sim::SimChannel`, or an null pointer if none
+     * @see FindSimChannel()
+     */
+    art::Ptr<sim::SimChannel> FindSimChannelPtr(raw::ChannelID_t channel) const;
+    
+    /**
+     * @brief Returns the cached `sim::SimChannel` on the specified `channel`.
+     * @param channel ID of the TPC channel to find
+     * @return _art_ pointer to `sim::SimChannel`
+     * @throw cet::exception (category: `"BackTracker"`) if no `sim::SimChannel`
+     *                       for the requested  `channel` found
+     * @see FindSimChannelPtr()
+     */
     art::Ptr<sim::SimChannel> FindSimChannel(raw::ChannelID_t channel) const;
 
     std::vector<sim::TrackIDE> ChannelToTrackIDEs(detinfo::DetectorClocksData const& clockData,


### PR DESCRIPTION
This is a proposed solution to [Redmine issue #26010](https://cdcvs.fnal.gov/redmine/issues/26010).

The method `cheat::BackTracker::ChannelToTrackIDEs()` uses a new method `cheat::BackTracker::FindSimChannelPtr()` which is quiet and reports errors by a special return value (null `art::Ptr`).

This was tested with LArSoft and `sbncode` `v09_24_02_00`.
