### PR TITLE
Light simulation updates for DUNE vertical drift

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -12,6 +12,7 @@ standard_pdfastsim_par_ar:
   DoReflectedLight:      false
   IncludeAnodeReflections: false
   IncludePropTime:       true
+  GeoPropTimeOnly:       false
   UseLitePhotons:        true
   OpaqueCathode:         true
   OnlyOneCryostat:       false

--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -15,6 +15,7 @@ standard_pdfastsim_par_ar:
   GeoPropTimeOnly:       false
   UseLitePhotons:        true
   OpaqueCathode:         true
+  OnlyActiveVolume:     true
   OnlyOneCryostat:       false
   ScintTimeTool:         @local::ScintTimeLAr
 

--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -10,6 +10,7 @@ standard_pdfastsim_par_ar:
   DoFastComponent:       true
   DoSlowComponent:       true
   DoReflectedLight:      false
+  IncludeAnodeReflections: false
   IncludePropTime:       true
   UseLitePhotons:        true
   OpaqueCathode:         true

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -384,6 +384,7 @@ namespace phot {
     TVector3 fcathode_centre;
     TVector3 fanode_centre;
     std::vector<geo::BoxBoundedGeo> fActiveVolumes;
+    int fNTPC;
     // Optical detector properties for semi-analytic hits
     double fradius;
     Dims fcathode_plane;
@@ -810,6 +811,7 @@ namespace phot {
     // Store info from the Geometry service
     nOpDets = geom.NOpDets();
     fActiveVolumes = fISTPC.extractActiveLArVolume(geom);
+    fNTPC = geom.NTPC();
 
     {
       auto log = mf::LogTrace("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
@@ -1428,7 +1430,7 @@ namespace phot {
     // temporary method working for SBND, uBooNE, DUNE 1x2x6; to be replaced to work in full DUNE geometry
     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
     if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10. && fActiveVolumes.size() > 1) { // TODO: unhardcode
+        std::abs(OpDetPoint.X()) > 10. && fNTPC == 2) { // TODO: unhardcode
       return false;
     }
     return true;

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -267,6 +267,7 @@ namespace phot {
       fhicl::Atom<bool>          DoFastComponent  { Name("DoFastComponent"),  Comment("Simulate slow scintillation light, default true"), true };
       fhicl::Atom<bool>          DoSlowComponent  { Name("DoSlowComponent"),  Comment("Simulate slow scintillation light") };
       fhicl::Atom<bool>          DoReflectedLight { Name("DoReflectedLight"), Comment("Simulate reflected visible light") };
+      fhicl::Atom<bool>          IncludeAnodeReflections { Name("IncludeAnodeReflections"), Comment("Simulate anode reflections, default false"), false };
       fhicl::Atom<bool>          IncludePropTime  { Name("IncludePropTime"),  Comment("Simulate light propagation time") };
       fhicl::Atom<bool>          UseLitePhotons   { Name("UseLitePhotons"),   Comment("Store SimPhotonsLite/OpDetBTRs instead of SimPhotons") };
       fhicl::Atom<bool>          OpaqueCathode    { Name("OpaqueCathode"),    Comment("Photons cannot cross the cathode") };
@@ -276,6 +277,8 @@ namespace phot {
       ODP                        VISTiming        { Name("VISTiming"),        Comment("Configuration for visible timing parameterization")}; 
       DP                         VUVHits          { Name("VUVHits"),          Comment("Configuration for UV visibility parameterization")}; 
       ODP                        VISHits          { Name("VISHits"),          Comment("Configuration for visibile visibility parameterization")}; 
+
+      
 
     };
     using Parameters = art::EDProducer::Table<Config>;
@@ -295,6 +298,7 @@ namespace phot {
       double w; // width
       geo::Point_t OpDetPoint;
       int type;
+      int orientation;
     };
 
     void Initialization();
@@ -317,8 +321,9 @@ namespace phot {
                             std::map<size_t, int>& ReflDetectedNumSlow,
                             const double NumFast,
                             const double NumSlow,
-                            geo::Point_t const& ScintPoint);
-
+                            geo::Point_t const& ScintPoint,
+                            bool AnodeMode = false);
+    
     void VUVHits(const double NumFast,
                 const double NumSlow,
                 geo::Point_t const& ScintPoint,
@@ -330,7 +335,8 @@ namespace phot {
                 const double cathode_hits_rec_fast,
                 const double cathode_hits_rec_slow,
                 geo::Point_t const& hotspot,
-                std::vector<int> &ReflDetThis);
+                std::vector<int> &ReflDetThis,
+                bool AnodeMode = false);
 
     void propagationTime(std::vector<double>& arrival_time_dist,
                          geo::Point_t const& x0,
@@ -352,7 +358,7 @@ namespace phot {
 
     // solid angle of rectangular aperture calculation functions
     double Rectangle_SolidAngle(const double a, const double b, const double d);
-    double Rectangle_SolidAngle(Dims const& o, geo::Vector_t const& v);
+    double Rectangle_SolidAngle(Dims const& o, geo::Vector_t const& v, double OpDetOrientation);
     // solid angle of circular aperture calculation functions
     double Disk_SolidAngle(const double d, const double h, const double b);
      // solid angle of a dome aperture calculation functions
@@ -371,14 +377,18 @@ namespace phot {
 
     // geometry properties
     double fplane_depth, fcathode_zdimension, fcathode_ydimension;
+    double fanode_plane_depth, fanode_ydimension, fanode_zdimension;
     TVector3 fcathode_centre;
+    TVector3 fanode_centre;
     std::vector<geo::BoxBoundedGeo> fActiveVolumes;
     // Optical detector properties for semi-analytic hits
     double fradius;
     Dims fcathode_plane;
+    Dims fanode_plane;
     int fL_abs_vuv;
     std::vector<geo::Point_t> fOpDetCenter;
     std::vector<int> fOpDetType;
+    std::vector<int> fOpDetOrientation;
     std::vector<double> fOpDetLength;
     std::vector<double> fOpDetHeight;
 
@@ -395,6 +405,7 @@ namespace phot {
     bool fDoFastComponent;
     bool fDoSlowComponent;
     bool fDoReflectedLight;
+    bool fIncludeAnodeReflections;
     bool fIncludePropTime;
     bool fUseLitePhotons;
     bool fOpaqueCathode;
@@ -433,6 +444,11 @@ namespace phot {
     std::vector<std::vector<double>> fGHvuvpars_flat;
     std::vector<double> fborder_corr_angulo_flat;
     std::vector<std::vector<double>> fborder_corr_flat;
+    // lateral PDs
+    bool fIsFlatPDCorrLat;
+    double fFieldCageTransparency;
+    std::vector<double> fGH_distances_anode;
+    std::vector<std::vector<std::vector<double>>> fGHvuvpars_flat_lateral;    
     // dome PDs
     bool fIsDomePDCorr;
     std::vector<std::vector<double>> fGHvuvpars_dome;
@@ -442,14 +458,20 @@ namespace phot {
     // For VIS semi-analytic hits
     // correction parameters for VIS Nhits estimation
     double fdelta_angulo_vis;
+    double fAnodeReflectivity;
     // flat PDs
     std::vector<double> fvis_distances_x_flat;
     std::vector<double> fvis_distances_r_flat;
     std::vector<std::vector<std::vector<double>>> fvispars_flat;
+    // lateral PDs
+    std::vector<double> fvis_distances_x_flat_lateral;
+    std::vector<double> fvis_distances_r_flat_lateral;
+    std::vector<std::vector<std::vector<double>>> fvispars_flat_lateral;
     // dome PDs
     std::vector<double> fvis_distances_x_dome;
     std::vector<double> fvis_distances_r_dome;
     std::vector<std::vector<std::vector<double>>> fvispars_dome;
+    
 
   };
 
@@ -471,6 +493,7 @@ namespace phot {
     , fDoFastComponent(config().DoFastComponent())
     , fDoSlowComponent(config().DoSlowComponent())
     , fDoReflectedLight(config().DoReflectedLight())
+    , fIncludeAnodeReflections(config().IncludeAnodeReflections())
     , fIncludePropTime(config().IncludePropTime())
     , fUseLitePhotons(config().UseLitePhotons())
     , fOpaqueCathode(config().OpaqueCathode())
@@ -494,7 +517,11 @@ namespace phot {
       throw art::Exception(art::errors::Configuration)
           << "Reflected light propagation time simulation requested, but VISTiming not specified." << "\n";
     }
-    
+
+    if(fIncludeAnodeReflections && !config().VISHits.get_if_present<fhicl::ParameterSet>(fVISHitsParams)) {
+      throw art::Exception(art::errors::Configuration)
+          << "Anode reflections light simulation requested, but VisHits not specified." << "\n";
+    }   
 
 
     Initialization();
@@ -590,8 +617,19 @@ namespace phot {
       std::map<size_t, int> DetectedNumSlow;
 
       bool needHits = (nphot_fast > 0 && fDoFastComponent) || (nphot_slow > 0 && fDoSlowComponent);
-      if ( needHits ) 
+      if ( needHits ) {
         detectedDirectHits(DetectedNumFast, DetectedNumSlow, nphot_fast, nphot_slow, ScintPoint);
+        if ( fIncludeAnodeReflections ) {
+          std::map<size_t, int> AnodeDetectedNumFast;
+          std::map<size_t, int> AnodeDetectedNumSlow;
+          detectedReflecHits(AnodeDetectedNumFast, AnodeDetectedNumSlow, nphot_fast, nphot_slow, ScintPoint, true);
+          // add to exiting count
+          for (size_t const OpDet : util::counter(nOpDets)){
+            DetectedNumFast[OpDet] += AnodeDetectedNumFast[OpDet];
+            DetectedNumSlow[OpDet] += AnodeDetectedNumSlow[OpDet];
+          }
+        }
+      }
 
       // reflected light, if enabled
       std::map<size_t, int> ReflDetectedNumFast;
@@ -796,25 +834,40 @@ namespace phot {
                        fActiveVolumes[0].CenterY(),
                        fActiveVolumes[0].CenterZ()};
 
+    fanode_centre = {geom.TPC(0, 0).FirstPlane().GetCenter().X(),
+                      fActiveVolumes[0].CenterY(),
+                      fActiveVolumes[0].CenterZ() };
+
     for (size_t const i : util::counter(nOpDets)) {
       geo::OpDetGeo const& opDet = geom.OpDetGeoFromOpDet(i);
       fOpDetCenter.push_back(opDet.GetCenter());
 
       if (opDet.isSphere()) {  // dome PMTs
         fOpDetType.push_back(1); // dome
+        fOpDetOrientation.push_back(0); // anode/cathode (default)
         fOpDetLength.push_back(-1);
         fOpDetHeight.push_back(-1);
       }
       else if (opDet.isBar()) {
         fOpDetType.push_back(0); // (X)Arapucas/Bars
+        // determine orientation to get correction OpDet dimensions
         fOpDetLength.push_back(opDet.Length());
-        fOpDetHeight.push_back(opDet.Height());
+        if (opDet.Width() > opDet.Height()) { // laterals, Y dimension smallest
+          fOpDetOrientation.push_back(1);          
+          fOpDetHeight.push_back(opDet.Width());  
+        }
+        else {  // anode/cathode (default), X dimension smallest
+          fOpDetOrientation.push_back(0);
+          fOpDetHeight.push_back(opDet.Height());
+        }        
       }
       else {
         fOpDetType.push_back(2); // disk PMTs
+        fOpDetOrientation.push_back(0); // anode/cathode (default)
         fOpDetLength.push_back(-1);
         fOpDetHeight.push_back(-1);
       }
+
     }
 
     if (fIncludePropTime) {
@@ -877,18 +930,24 @@ namespace phot {
     mf::LogInfo("PDFastSimPAR") << "Using VUV visibility parameterization";
     
     fIsFlatPDCorr     = fVUVHitsParams.get<bool>("FlatPDCorr", false);
+    fIsFlatPDCorrLat  = fVUVHitsParams.get<bool>("FlatPDCorrLat", false);
     fIsDomePDCorr     = fVUVHitsParams.get<bool>("DomePDCorr", false);
-    fdelta_angulo_vuv = fVUVHitsParams.get<double>("delta_angulo_vuv");
+    fdelta_angulo_vuv = fVUVHitsParams.get<double>("delta_angulo_vuv", 10);
     fradius           = fVUVHitsParams.get<double>("PMT_radius", 10.16);
+    fFieldCageTransparency = fVUVHitsParams.get<double>("FieldCageTransparency", 1.0);
 
-    if (!fIsFlatPDCorr && !fIsDomePDCorr) {
+    if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
       throw cet::exception("PDFastSimPAR")
-          << "Both isFlatPDCorr and isDomePDCorr parameters are false, at least one type of parameterisation is required for the semi-analytic light simulation." << "\n";
+          << "Both isFlatPDCorr/isFlatPDCorrLat and isDomePDCorr parameters are false, at least one type of parameterisation is required for the semi-analytic light simulation." << "\n";
     }
     if (fIsFlatPDCorr) {
         fGHvuvpars_flat          = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_flat");
         fborder_corr_angulo_flat = fVUVHitsParams.get<std::vector<double>>("GH_border_angulo_flat");
         fborder_corr_flat        = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_flat");
+    }
+    if (fIsFlatPDCorrLat) {
+        fGHvuvpars_flat_lateral  = fVUVHitsParams.get<std::vector<std::vector<std::vector<double>>>>("GH_PARS_flat_lateral");
+        fGH_distances_anode      = fVUVHitsParams.get<std::vector<double>>("GH_distances_anode");
     }
     if (fIsDomePDCorr) {
         fGHvuvpars_dome          = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_dome");
@@ -921,6 +980,34 @@ namespace phot {
       fcathode_plane.w = fcathode_zdimension;
       fplane_depth = std::abs(fcathode_centre[0]);
     }
+
+    // Load corrections for Anode reflections configuration
+    if (fIncludeAnodeReflections) {
+      mf::LogInfo("PDFastSimPAR") << "Using anode reflections parameterization";
+      fdelta_angulo_vis = fVISHitsParams.get<double>("delta_angulo_vis");
+      fAnodeReflectivity = fVISHitsParams.get<double>("AnodeReflectivity");
+
+      if (fIsFlatPDCorr) {
+        fvis_distances_x_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_x_flat");
+        fvis_distances_r_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_r_flat");
+        fvispars_flat         = fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat");
+      }
+
+      if (fIsFlatPDCorrLat) {
+        fvis_distances_x_flat_lateral = fVISHitsParams.get<std::vector<double>>("VIS_distances_x_flat_lateral");
+        fvis_distances_r_flat_lateral = fVISHitsParams.get<std::vector<double>>("VIS_distances_r_flat_lateral");
+        fvispars_flat_lateral         = fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat_lateral");
+      }
+
+      // anode dimensions
+      fanode_ydimension = fActiveVolumes[0].SizeY();
+      fanode_zdimension = fActiveVolumes[0].SizeZ();
+
+      // set anode plane struct for solid angle function
+      fanode_plane.h = fanode_ydimension;
+      fanode_plane.w = fanode_zdimension;
+      fanode_plane_depth = fanode_centre[0];
+    }
   }
 
   //......................................................................
@@ -938,7 +1025,7 @@ namespace phot {
       // set detector struct for solid angle function
       const PDFastSimPAR::OpticalDetector op{
         fOpDetHeight[OpDet], fOpDetLength[OpDet],
-        fOpDetCenter[OpDet], fOpDetType[OpDet]};
+        fOpDetCenter[OpDet], fOpDetType[OpDet], fOpDetOrientation[OpDet]};
 
       std::vector<int> DetThis(2, 0);
       VUVHits(NumFast, NumSlow, ScintPoint, op, DetThis);
@@ -972,7 +1059,7 @@ namespace phot {
       // get scintillation point coordinates relative to arapuca window centre
       geo::Vector_t const abs_relative{
         std::abs(relative.X()), std::abs(relative.Y()), std::abs(relative.Z())};
-      solid_angle = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_relative);
+      solid_angle = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_relative, opDet.orientation);
     }
     // PMTs (dome)
     else if (opDet.type == 1) {
@@ -1006,14 +1093,39 @@ namespace phot {
     double pars_ini[4] = {0, 0, 0, 0};
     double s1 = 0; double s2 = 0; double s3 = 0;
     // flat PDs
-    if ((opDet.type == 0 || opDet.type == 2) && fIsFlatPDCorr){
-      pars_ini[0] = fGHvuvpars_flat[0][j];
-      pars_ini[1] = fGHvuvpars_flat[1][j];
-      pars_ini[2] = fGHvuvpars_flat[2][j];
-      pars_ini[3] = fGHvuvpars_flat[3][j];
-      s1 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[0], theta, true);
-      s2 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[1], theta, true);
-      s3 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[2], theta, true);
+    if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)){
+      if (opDet.orientation == 1 && fIsFlatPDCorrLat) { // laterals, alternate parameterisation method
+        // distance to anode plane
+        double d_anode = std::abs(fanode_centre[0] - ScintPoint.X()); 
+        
+        // build arrays for interpolation
+        int n_distances = fGH_distances_anode.size();
+        std::vector<double> p1, p2, p3, p4;
+        p1.reserve(n_distances); p2.reserve(n_distances); p3.reserve(n_distances); p4.reserve(n_distances);
+        for (int i = 0; i < n_distances; i++) {
+          p1.push_back(fGHvuvpars_flat_lateral[0][i][j]);
+          p2.push_back(fGHvuvpars_flat_lateral[1][i][j]);
+          p3.push_back(fGHvuvpars_flat_lateral[2][i][j]);
+          p4.push_back(fGHvuvpars_flat_lateral[3][i][j]);
+        }
+
+        // interpolate in distance to anode
+        pars_ini[0] = interpolate(fGH_distances_anode, p1, d_anode, false);
+        pars_ini[1] = interpolate(fGH_distances_anode, p2, d_anode, false);
+        pars_ini[2] = interpolate(fGH_distances_anode, p3, d_anode, false);
+        pars_ini[3] = interpolate(fGH_distances_anode, p4, d_anode, false);
+      
+      }
+      else if (opDet.orientation == 0 && fIsFlatPDCorr) { // cathode/anode, default parameterisation method
+        pars_ini[0] = fGHvuvpars_flat[0][j];
+        pars_ini[1] = fGHvuvpars_flat[1][j];
+        pars_ini[2] = fGHvuvpars_flat[2][j];
+        pars_ini[3] = fGHvuvpars_flat[3][j];
+        s1 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[0], theta, true);
+        s2 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[1], theta, true);
+        s3 = interpolate( fborder_corr_angulo_flat, fborder_corr_flat[2], theta, true);
+      }
+      else std::cout << "Error: corrections for chosen optical detector type missing." << std::endl;
     }
     // dome PDs
     else if (opDet.type == 1 && fIsDomePDCorr) {
@@ -1036,6 +1148,9 @@ namespace phot {
     // calculate correction
     double GH_correction = Gaisser_Hillas(distance, pars_ini);
 
+    // apply field cage transparency factor to laterals
+    if (opDet.orientation == 1) GH_correction = GH_correction * fFieldCageTransparency;
+
     // calculate number photons for fast and slow componenets
     DetThis[0] = fRandPoissPhot->fire(GH_correction * hits_geo_fast / cosine);
     DetThis[1] = fRandPoissPhot->fire(GH_correction * hits_geo_slow / cosine);
@@ -1049,21 +1164,30 @@ namespace phot {
                                    std::map<size_t, int>& ReflDetectedNumSlow,
                                    const double NumFast,
                                    const double NumSlow,
-                                   geo::Point_t const& ScintPoint)
+                                   geo::Point_t const& ScintPoint,
+                                   bool AnodeMode)
   {
     // 1). calculate total number of hits of VUV photons on
     // reflective foils via solid angle + Gaisser-Hillas
-    // corrections:
+    // corrections:  
 
-    // set plane_depth for correct TPC:
-    double const plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
+    // get scintpoint coords relative to centre of cathode plane and set plane dimensions
+    geo::Vector_t ScintPoint_relative;
+    Dims plane_dimensions;
+    double plane_depth;
+    if (AnodeMode) {
+      plane_dimensions = fanode_plane;
+      plane_depth = fanode_plane_depth;
+      ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - fanode_plane_depth), std::abs(ScintPoint.Y() - fanode_centre[1]), std::abs(ScintPoint.Z() - fanode_centre[2]));
+    }
+    else {
+      plane_dimensions = fcathode_plane;
+      plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
+      ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - plane_depth), std::abs(ScintPoint.Y() - fcathode_centre[1]), std::abs(ScintPoint.Z() - fcathode_centre[2]));
+    }
 
-    // get scintpoint coords relative to centre of cathode plane
-    geo::Vector_t const ScintPoint_relative = {std::abs(ScintPoint.X() - plane_depth),
-                                                 std::abs(ScintPoint.Y() - fcathode_centre[1]),
-                                                 std::abs(ScintPoint.Z() - fcathode_centre[2])};
-    // calculate solid angle of cathode from the scintillation point
-    double solid_angle_cathode = Rectangle_SolidAngle(Dims{fcathode_plane.h, fcathode_plane.w}, ScintPoint_relative);
+    // calculate solid angle of cathode from the scintillation point, orientation always = 0 (cathode)
+    double solid_angle_cathode = Rectangle_SolidAngle(plane_dimensions, ScintPoint_relative, 0);
 
     // calculate distance and angle between ScintPoint and hotspot
     // vast majority of hits in hotspot region directly infront of scintpoint,
@@ -1111,10 +1235,10 @@ namespace phot {
       // set detector struct for solid angle function
       const  PDFastSimPAR::OpticalDetector op{
         fOpDetHeight[OpDet], fOpDetLength[OpDet],
-        fOpDetCenter[OpDet], fOpDetType[OpDet]};
+        fOpDetCenter[OpDet], fOpDetType[OpDet], fOpDetOrientation[OpDet]};
 
       std::vector<int> ReflDetThis(2, 0);
-      VISHits(ScintPoint, op, cathode_hits_rec_fast, cathode_hits_rec_slow, hotspot, ReflDetThis);
+      VISHits(ScintPoint, op, cathode_hits_rec_fast, cathode_hits_rec_slow, hotspot, ReflDetThis, AnodeMode);
 
       ReflDetectedNumFast[OpDet] = ReflDetThis[0];
       ReflDetectedNumSlow[OpDet] = ReflDetThis[1];
@@ -1127,11 +1251,14 @@ namespace phot {
                         const double cathode_hits_rec_fast,
                         const double cathode_hits_rec_slow,
                         geo::Point_t const& hotspot,
-                        std::vector<int> &ReflDetThis)
+                        std::vector<int> &ReflDetThis,
+                        bool AnodeMode)
   {
 
-    // set plane_depth for correct TPC:
-    double const plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
+    // set correct plane_depth
+    double plane_depth;
+    if (AnodeMode) plane_depth = fanode_plane_depth;
+    else plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
 
     // calculate number of these hits which reach the optical
     // detector from the hotspot using solid angle:
@@ -1142,7 +1269,13 @@ namespace phot {
     // distance from hotspot to optical detector
     const double distance_vis = emission_relative.R();
     //  angle between hotspot and optical detector
-    const double cosine_vis = std::abs(emission_relative.X()) / distance_vis;
+    double cosine_vis;
+    if (opDet.orientation == 1) { // lateral
+      cosine_vis = std::abs(emission_relative.Y()) / distance_vis;
+    }
+    else { // anode/cathode (default)
+      cosine_vis = std::abs(emission_relative.X()) / distance_vis;
+    }
     // const double theta_vis = std::acos(cosine_vis) * 180. / CLHEP::pi;
     const double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
 
@@ -1154,7 +1287,7 @@ namespace phot {
       geo::Vector_t const abs_emission_relative{std::abs(emission_relative.X()),
                                                 std::abs(emission_relative.Y()),
                                                 std::abs(emission_relative.Z())};
-      solid_angle_detector = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_emission_relative);
+      solid_angle_detector = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_emission_relative, opDet.orientation);
     }
     // PMTS (dome)
     else if (opDet.type == 1) {
@@ -1183,29 +1316,46 @@ namespace phot {
     double d_c = std::abs(ScintPoint.X() - plane_depth);       // distance to cathode
     double border_correction = 0;
     // flat PDs
-    if ((opDet.type == 0 || opDet.type == 2) && fIsFlatPDCorr){
+    if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)){
+
+      // select correct parameter set depending on PD orientation
+      std::vector<double> vis_distances_x;
+      std::vector<double> vis_distances_r;
+      std::vector<std::vector<std::vector<double>>> vispars;
+      if (opDet.orientation == 1 && fIsFlatPDCorrLat) { // laterals
+        vis_distances_x = fvis_distances_x_flat_lateral;
+        vis_distances_r = fvis_distances_r_flat_lateral;
+        vispars = fvispars_flat_lateral;
+      }
+      else if (opDet.orientation == 0 && fIsFlatPDCorr) { // cathode/anode
+        vis_distances_x = fvis_distances_x_flat;
+        vis_distances_r = fvis_distances_r_flat;
+        vispars = fvispars_flat;
+      }
+      else std::cout << "Error: corrections for chosen optical detector type missing." << std::endl;
+      
       // interpolate in d_c for each r bin
-      const size_t nbins_r = fvispars_flat[k].size();
+      const size_t nbins_r = vispars[k].size();
       std::vector<double> interp_vals(nbins_r, 0.0);
       {
         size_t idx = 0;
-        size_t size = fvis_distances_x_flat.size();
-        if (d_c >= fvis_distances_x_flat[size - 2])
+        size_t size = vis_distances_x.size();
+        if (d_c >= vis_distances_x[size - 2])
           idx = size - 2;
         else {
-          while (d_c > fvis_distances_x_flat[idx + 1])
+          while (d_c > vis_distances_x[idx + 1])
             idx++;
         }
         for (size_t i = 0; i < nbins_r; ++i) {
-          interp_vals[i] = interpolate(fvis_distances_x_flat,
-                                       fvispars_flat[k][i],
+          interp_vals[i] = interpolate(vis_distances_x,
+                                       vispars[k][i],
                                        d_c,
                                        false,
                                        idx);
         }
       }
       // interpolate in r
-      border_correction = interpolate(fvis_distances_r_flat, interp_vals, r, false);
+      border_correction = interpolate(vis_distances_r, interp_vals, r, false); 
     }
     // dome PDs
     else if (opDet.type == 1 && fIsDomePDCorr) {
@@ -1231,6 +1381,9 @@ namespace phot {
       }
       // interpolate in r
       border_correction = interpolate(fvis_distances_r_dome, interp_vals, r, false);
+
+      // apply anode reflectivity factor
+      if (AnodeMode) border_correction = border_correction * fAnodeReflectivity;
     }
     else {
      std::cout << "Error: Invalid optical detector type. 0 = rectangular, 1 = dome, 2 = disk. Or corrections for chosen optical detector type missing." << std::endl;
@@ -1240,6 +1393,7 @@ namespace phot {
     ReflDetThis[1] = fRandPoissPhot->fire(border_correction * hits_geo_slow / cosine_vis);
   }
 
+
   bool
   PDFastSimPAR::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
                                  geo::Point_t const& OpDetPoint) const
@@ -1248,7 +1402,7 @@ namespace phot {
     // temporary method working for SBND, uBooNE, DUNE 1x2x6; to be replaced to work in full DUNE geometry
     // check x coordinate has same sign or is close to zero, otherwise return 0 hits
     if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10.) { // TODO: unhardcode
+        std::abs(OpDetPoint.X()) > 10. && fActiveVolumes.size() > 1) { // TODO: unhardcode
       return false;
     }
     return true;
@@ -1684,52 +1838,65 @@ namespace phot {
   }
 
   double
-  PDFastSimPAR::Rectangle_SolidAngle(Dims const& o, geo::Vector_t const& v)
+  PDFastSimPAR::Rectangle_SolidAngle(Dims const& o, geo::Vector_t const& v, double OpDetOrientation)
   {
     // v is the position of the track segment with respect to
     // the center position of the arapuca window
 
+    // solid angle calculation depends on orientation of PD, set correct distances to use
+    double d1;
+    double d2; 
+    if (OpDetOrientation == 1) {
+      // lateral PD, arapuca plane fixed in y direction
+      d1 = v.X();
+      d2 = v.Y(); 
+    }
+    else {
+      // anode/cathode PD, arapuca plane fixed in x direction [default]
+      d1 = v.Y();
+      d2 = v.X();
+    }
     // arapuca plane fixed in x direction
-    if (isApproximatelyZero(v.Y()) && isApproximatelyZero(v.Z())) {
-      return Rectangle_SolidAngle(o.h, o.w, v.X());
+    if (isApproximatelyZero(d1) && isApproximatelyZero(v.Z())) {
+      return Rectangle_SolidAngle(o.h, o.w, d2);
     }
-    if (isDefinitelyGreaterThan(v.Y(), o.h * .5) && isDefinitelyGreaterThan(v.Z(), o.w * .5)) {
-      double A = v.Y() - o.h * .5;
+    if (isDefinitelyGreaterThan(d1, o.h * .5) && isDefinitelyGreaterThan(v.Z(), o.w * .5)) {
+      double A = d1 - o.h * .5;
       double B = v.Z() - o.w * .5;
-      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), v.X()) -
-                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v.X()) -
-                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v.X()) +
-                          Rectangle_SolidAngle(2. * A, 2. * B, v.X())) *
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
                          .25;
       return to_return;
     }
-    if ((v.Y() <= o.h * .5) && (v.Z() <= o.w * .5)) {
-      double A = -v.Y() + o.h * .5;
+    if ((d1 <= o.h * .5) && (v.Z() <= o.w * .5)) {
+      double A = -d1 + o.h * .5;
       double B = -v.Z() + o.w * .5;
-      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), v.X()) +
-                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v.X()) +
-                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v.X()) +
-                          Rectangle_SolidAngle(2. * A, 2. * B, v.X())) *
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
                          .25;
       return to_return;
     }
-    if (isDefinitelyGreaterThan(v.Y(), o.h * .5) && (v.Z() <= o.w * .5)) {
-      double A = v.Y() - o.h * .5;
+    if (isDefinitelyGreaterThan(d1, o.h * .5) && (v.Z() <= o.w * .5)) {
+      double A = d1 - o.h * .5;
       double B = -v.Z() + o.w * .5;
-      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), v.X()) -
-                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), v.X()) +
-                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, v.X()) -
-                          Rectangle_SolidAngle(2. * A, 2. * B, v.X())) *
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
                          .25;
       return to_return;
     }
-    if ((v.Y() <= o.h * .5) && isDefinitelyGreaterThan(v.Z(), o.w * .5)) {
-      double A = -v.Y() + o.h * .5;
+    if ((d1 <= o.h * .5) && isDefinitelyGreaterThan(v.Z(), o.w * .5)) {
+      double A = -d1 + o.h * .5;
       double B = v.Z() - o.w * .5;
-      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), v.X()) -
-                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, v.X()) +
-                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), v.X()) -
-                          Rectangle_SolidAngle(2. * A, 2. * B, v.X())) *
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
                          .25;
       return to_return;
     }


### PR DESCRIPTION
This PR adds the requires modifications/extensions to the semi-analytic fast optical simulation in PDFastSimPAR for simulating the DUNE vertical drift geometry:
- adds geometry calculations required for lateral detectors
- adds alternate parameterisation approach developed for lateral detectors
- adds option to use reflected light model to simulate light reflected from anode (for use at Xenon wavelength)
- adds options to simulate light external to the active volume and to account for field cage shadowing via scaling factors, used to allow modelling of lateral detectors located outside of the field cage
- adds geometric only transport time model (for use at Xenon wavelength)

More details about the changes can be found here: https://indico.fnal.gov/event/46504/contributions/223984/attachments/147571/189111/DUNE_collaboration_meeting_21.09.23_dunevd.pdf

These changes should not impact the light simulation in DUNE horizontal drift or SBND.