### PR TITLE
Removed spurious configuration parameter

### DIFF
--- a/larsim/LegacyLArG4/largeantmodules.fcl
+++ b/larsim/LegacyLArG4/largeantmodules.fcl
@@ -18,7 +18,6 @@ standard_largeant:
 # not be included here.
 # DisableWireplanes:      false
 # UseModBoxRecomb:        false   # use Modified Box recombination model
- UseModLarqlRecomb:        false   # use LArQL recombination corrections (dependence on EF)
 }
 argoneut_largeant:   @local::standard_largeant
 # The following line is already in largeantmodules_microboone.fcl


### PR DESCRIPTION
Parameter `UseModLarqlRecomb` does not belong to `LegacyLArG4`, so it should not be in its configuration.
It is, in fact, supported by `LArG4Parameters` "service".