### PR TITLE
Add Option to Merge AuxDetHits in MergeSimSources Module

### DIFF
--- a/larsim/MergeSimSources/MergeSimSources.cxx
+++ b/larsim/MergeSimSources/MergeSimSources.cxx
@@ -177,10 +177,26 @@ void sim::MergeSimSourcesUtility::MergeSimEnergyDeposits(
 
   int const offset = fG4TrackIDOffsets.at(source_index);
   auto const offsetEDepID = [offset](sim::SimEnergyDeposit const& edep)
-    { return sim::MergeSimSourcesUtility::offsetTrackID(edep, offset); };
+    { return sim::MergeSimSourcesUtility::offsetSimEnergyDepositTrackID(edep, offset); };
   
   dest.reserve(dest.size() + src.size());
   std::transform(begin(src), end(src), back_inserter(dest), offsetEDepID);
+
+}
+
+
+void sim::MergeSimSourcesUtility::MergeAuxDetHits(
+  std::vector<sim::AuxDetHit>& dest,
+  const std::vector<sim::AuxDetHit>& src,
+  std::size_t source_index
+) const {
+
+  int const offset = fG4TrackIDOffsets.at(source_index);
+  auto const offsetAuxDetHitID = [offset](sim::AuxDetHit const& adh)
+    { return sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID(adh, offset); };
+
+  dest.reserve(dest.size() + src.size());
+  std::transform(begin(src), end(src), back_inserter(dest), offsetAuxDetHitID);
 
 }
 
@@ -217,7 +233,7 @@ void sim::MergeSimSourcesUtility::UpdateG4TrackIDRange(std::pair<int,int> newran
 }
 
 
-sim::SimEnergyDeposit sim::MergeSimSourcesUtility::offsetTrackID
+sim::SimEnergyDeposit sim::MergeSimSourcesUtility::offsetSimEnergyDepositTrackID
   (sim::SimEnergyDeposit const& edep, int offset)
 {
 
@@ -236,5 +252,30 @@ sim::SimEnergyDeposit sim::MergeSimSourcesUtility::offsetTrackID
     edep.PdgCode()           // pdg
     };
 } // sim::MergeSimSourcesUtility::offsetTrackID()
+
+
+sim::AuxDetHit sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID
+  (sim::AuxDetHit const& adh, int offset)
+{
+
+  auto tid = (adh.GetTrackID()>=0) ? (adh.GetTrackID() + offset) : (adh.GetTrackID() - offset);
+
+  return sim::AuxDetHit{
+      adh.GetID(),              // copy number
+      tid,                      // g4 track id
+      adh.GetEnergyDeposited(),
+      adh.GetEntryX(),
+      adh.GetEntryY(),
+      adh.GetEntryZ(),
+      adh.GetEntryT(),
+      adh.GetExitX(),
+      adh.GetExitY(),
+      adh.GetExitZ(),
+      adh.GetExitT(),
+      adh.GetExitMomentumX(),
+      adh.GetExitMomentumY(),
+      adh.GetExitMomentumZ(),
+    };
+} // sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID()
 
 

--- a/larsim/MergeSimSources/MergeSimSources.h
+++ b/larsim/MergeSimSources/MergeSimSources.h
@@ -18,6 +18,7 @@
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
+#include "lardataobj/Simulation/AuxDetHit.h"
 
 namespace sim{
 
@@ -50,6 +51,9 @@ namespace sim{
     void MergeSimEnergyDeposits( std::vector<sim::SimEnergyDeposit>&,
 			      const std::vector<sim::SimEnergyDeposit>&, size_t) const;
 
+    void MergeAuxDetHits( std::vector<sim::AuxDetHit>&,
+            const std::vector<sim::AuxDetHit>&, size_t) const;
+
     const std::vector< std::vector<size_t> >& GetMCParticleListMap() { return fMCParticleListMap; }
 
   private:
@@ -61,8 +65,11 @@ namespace sim{
 
     void UpdateG4TrackIDRange(std::pair<int,int>,size_t);
 
-    static sim::SimEnergyDeposit offsetTrackID
-      (sim::SimEnergyDeposit const& edep, int offset);
+    static sim::SimEnergyDeposit offsetSimEnergyDepositTrackID
+      (sim::SimEnergyDeposit const&, int);
+
+    static sim::AuxDetHit offsetAuxDetHitTrackID
+      (sim::AuxDetHit const&, int);
 
   }; //end MergeSimSourcesUtility class
 


### PR DESCRIPTION
This PR adds the option to merge `sim::AuxDetHits` from different streams in the `MergeSimSources` modules. This is needed when we run more than one instance of LArG4 and we then want to merge the output.

The default behavior of `MergeSimSources` is unchanged, this PR only adds an additional option that right now we need in SBND.