### PR TITLE
Correct IDE energy units

### DIFF
--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -19,7 +19,7 @@ sim::AuxDetIDE sim::GenericCRTUtility::toAuxDetIDE(const sim::AuxDetHit &InputHi
     sim::AuxDetIDE outputIDE;
 
    outputIDE.trackID		    = InputHit.GetTrackID();
-   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited();
+   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() / CLHEP::GeV;
    outputIDE.entryX		= InputHit.GetEntryX();
    outputIDE.entryY		= InputHit.GetEntryY();
    outputIDE.entryZ		= InputHit.GetEntryZ();

--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -5,7 +5,7 @@
  * Description:
  * Class with Algorithms to convert sim::AuxDetHits to sim::AuxDetSimChannels
  *
-*/
+ */
 
 
 #include "GenericCRT.h"
@@ -26,25 +26,25 @@ sim::GenericCRTUtility::GenericCRTUtility(const std::string energyUnitsScale)
 }
 
 sim::AuxDetIDE sim::GenericCRTUtility::toAuxDetIDE(const sim::AuxDetHit &InputHit) const
-  {
-    sim::AuxDetIDE outputIDE;
+{
+  sim::AuxDetIDE outputIDE;
 
-   outputIDE.trackID		    = InputHit.GetTrackID();
-   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() * fEnergyUnitsScale;
-   outputIDE.entryX		= InputHit.GetEntryX();
-   outputIDE.entryY		= InputHit.GetEntryY();
-   outputIDE.entryZ		= InputHit.GetEntryZ();
-   outputIDE.entryT		= InputHit.GetEntryT();
-   outputIDE.exitX		= InputHit.GetExitX();
-   outputIDE.exitY		= InputHit.GetExitY();
-   outputIDE.exitZ		= InputHit.GetExitZ();
-   outputIDE.exitT		= InputHit.GetExitT();
-   outputIDE.exitMomentumX	= InputHit.GetExitMomentumX();
-   outputIDE.exitMomentumY	= InputHit.GetExitMomentumY();
-   outputIDE.exitMomentumZ	= InputHit.GetExitMomentumZ();
+  outputIDE.trackID		    = InputHit.GetTrackID();
+  outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() * fEnergyUnitsScale;
+  outputIDE.entryX		= InputHit.GetEntryX();
+  outputIDE.entryY		= InputHit.GetEntryY();
+  outputIDE.entryZ		= InputHit.GetEntryZ();
+  outputIDE.entryT		= InputHit.GetEntryT();
+  outputIDE.exitX		= InputHit.GetExitX();
+  outputIDE.exitY		= InputHit.GetExitY();
+  outputIDE.exitZ		= InputHit.GetExitZ();
+  outputIDE.exitT		= InputHit.GetExitT();
+  outputIDE.exitMomentumX	= InputHit.GetExitMomentumX();
+  outputIDE.exitMomentumY	= InputHit.GetExitMomentumY();
+  outputIDE.exitMomentumZ	= InputHit.GetExitMomentumZ();
 
 
-   return outputIDE;
+  return outputIDE;
 }
 
 
@@ -57,19 +57,19 @@ std::vector<unsigned int> sim::GenericCRTUtility::GetAuxDetChannels(const std::v
 
 
   for(auto const& hit : InputHitVector)
-  {
+    {
 
-  std::vector<unsigned int>::iterator Chanitr
-      = std::find(AuxDetChanNumber.begin(), AuxDetChanNumber.end(), hit.GetID());
+      std::vector<unsigned int>::iterator Chanitr
+	= std::find(AuxDetChanNumber.begin(), AuxDetChanNumber.end(), hit.GetID());
 
-   if(Chanitr == AuxDetChanNumber.end()){ //If trackID is already in the map, update it
-         //if channel ID is not in the set yet, add it
-      AuxDetChanNumber.push_back(hit.GetID());
-        }//
+      if(Chanitr == AuxDetChanNumber.end()){ //If trackID is already in the map, update it
+	//if channel ID is not in the set yet, add it
+	AuxDetChanNumber.push_back(hit.GetID());
+      }//
 
-  }
+    }
 
-return AuxDetChanNumber;
+  return AuxDetChanNumber;
 
 }
 
@@ -77,50 +77,50 @@ return AuxDetChanNumber;
 
 sim::AuxDetSimChannel sim::GenericCRTUtility::GetAuxDetSimChannelByNumber(const std::vector<sim::AuxDetHit>& InputHitVector, unsigned int inputchannel) const
 {
-        std::vector<sim::AuxDetIDE> IDEvector;
-        //loop over sim::AuxDetHits and assign them to AuxDetSimChannels.
+  std::vector<sim::AuxDetIDE> IDEvector;
+  //loop over sim::AuxDetHits and assign them to AuxDetSimChannels.
 
-        size_t ad_id_no = 9999;
-        size_t ad_sen_id_no = 9999;
+  size_t ad_id_no = 9999;
+  size_t ad_sen_id_no = 9999;
 
-        for (auto const& auxDetHit : InputHitVector)
-        {
+  for (auto const& auxDetHit : InputHitVector)
+    {
 
-            double xcoordinate = (auxDetHit.GetEntryX() + auxDetHit.GetExitX())/2.0;
-            double ycoordinate = (auxDetHit.GetEntryY() + auxDetHit.GetExitY())/2.0;
-            double zcoordinate = (auxDetHit.GetEntryZ() + auxDetHit.GetExitZ())/2.0;
-            double worldPos[3] = {xcoordinate,ycoordinate,zcoordinate};
-            fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
-            if(auxDetHit.GetID() == inputchannel)   // this is the channel we want.
-            {
-                auto tempIDE = toAuxDetIDE(auxDetHit);
+      double xcoordinate = (auxDetHit.GetEntryX() + auxDetHit.GetExitX())/2.0;
+      double ycoordinate = (auxDetHit.GetEntryY() + auxDetHit.GetExitY())/2.0;
+      double zcoordinate = (auxDetHit.GetEntryZ() + auxDetHit.GetExitZ())/2.0;
+      double worldPos[3] = {xcoordinate,ycoordinate,zcoordinate};
+      fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
+      if(auxDetHit.GetID() == inputchannel)   // this is the channel we want.
+	{
+	  auto tempIDE = toAuxDetIDE(auxDetHit);
 
-                std::vector<sim::AuxDetIDE>::iterator IDEitr
-                = std::find(IDEvector.begin(), IDEvector.end(), tempIDE);
+	  std::vector<sim::AuxDetIDE>::iterator IDEitr
+	    = std::find(IDEvector.begin(), IDEvector.end(), tempIDE);
 
-                if(IDEitr != IDEvector.end()){ //If trackID is already in the map, update it
-                    //Andrzej's note - following logic from AuxDetReadout in Legacy, but why are the other paremeters getting overwritten like that?
-                    IDEitr->energyDeposited += tempIDE.energyDeposited;
-                    IDEitr->exitX            = tempIDE.exitX;
-                    IDEitr->exitY            = tempIDE.exitY;
-                    IDEitr->exitZ            = tempIDE.exitZ;
-                    IDEitr->exitT            = tempIDE.exitT;
-                    IDEitr->exitMomentumX    = tempIDE.exitMomentumX;
-                    IDEitr->exitMomentumY    = tempIDE.exitMomentumY;
-                    IDEitr->exitMomentumZ    = tempIDE.exitMomentumZ;
-                    }
-                    else{  //if trackID is not in the set yet, add it
-                        IDEvector.push_back(std::move(tempIDE));
-                    }//else
+	  if(IDEitr != IDEvector.end()){ //If trackID is already in the map, update it
+	    //Andrzej's note - following logic from AuxDetReadout in Legacy, but why are the other paremeters getting overwritten like that?
+	    IDEitr->energyDeposited += tempIDE.energyDeposited;
+	    IDEitr->exitX            = tempIDE.exitX;
+	    IDEitr->exitY            = tempIDE.exitY;
+	    IDEitr->exitZ            = tempIDE.exitZ;
+	    IDEitr->exitT            = tempIDE.exitT;
+	    IDEitr->exitMomentumX    = tempIDE.exitMomentumX;
+	    IDEitr->exitMomentumY    = tempIDE.exitMomentumY;
+	    IDEitr->exitMomentumZ    = tempIDE.exitMomentumZ;
+	  }
+	  else{  //if trackID is not in the set yet, add it
+	    IDEvector.push_back(std::move(tempIDE));
+	  }//else
 
-                    break;
-            } // end if the AuxDetHit channel checks out.
+	  break;
+	} // end if the AuxDetHit channel checks out.
 
-        } // end main loop on AuxDetHit
+    } // end main loop on AuxDetHit
 
-        //push back the AuxDetSimChannel Vector.
-        //TODO check the last parameter values.
-        return sim::AuxDetSimChannel(ad_id_no, std::move(IDEvector), ad_sen_id_no);
+  //push back the AuxDetSimChannel Vector.
+  //TODO check the last parameter values.
+  return sim::AuxDetSimChannel(ad_id_no, std::move(IDEvector), ad_sen_id_no);
 }
 
 

--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -13,9 +13,16 @@
 #include <utility> // std::move()
 #include <algorithm> // std::find()
 
-sim::GenericCRTUtility::GenericCRTUtility(const double energyUnitsScale)
+sim::GenericCRTUtility::GenericCRTUtility(const std::string energyUnitsScale)
 {
-  fEnergyUnitsScale = energyUnitsScale;
+  HepTool::Evaluator eval;
+  eval.setStdMath();
+  eval.setSystemOfUnits();
+  
+  const std::string scaleExpression = "MeV / " + energyUnitsScale;
+  fEnergyUnitsScale = eval.evaluate(scaleExpression.c_str());
+  
+  if(eval.status() != 0) fEnergyUnitsScale = 1.;
 }
 
 sim::AuxDetIDE sim::GenericCRTUtility::toAuxDetIDE(const sim::AuxDetHit &InputHit) const

--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -13,13 +13,17 @@
 #include <utility> // std::move()
 #include <algorithm> // std::find()
 
+sim::GenericCRTUtility::GenericCRTUtility(const double energyUnitsScale)
+{
+  fEnergyUnitsScale = energyUnitsScale;
+}
 
 sim::AuxDetIDE sim::GenericCRTUtility::toAuxDetIDE(const sim::AuxDetHit &InputHit) const
   {
     sim::AuxDetIDE outputIDE;
 
    outputIDE.trackID		    = InputHit.GetTrackID();
-   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() / CLHEP::GeV;
+   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() * fEnergyUnitsScale;
    outputIDE.entryX		= InputHit.GetEntryX();
    outputIDE.entryY		= InputHit.GetEntryY();
    outputIDE.entryZ		= InputHit.GetEntryZ();

--- a/larsim/GenericCRT/GenericCRT.h
+++ b/larsim/GenericCRT/GenericCRT.h
@@ -9,7 +9,7 @@
  * Description:
  * Class with Algorithms to convert sim::AuxDetHits to sim::AuxDetSimChannels
  *
-*/
+ */
 
 
 #include "lardataobj/Simulation/SimChannel.h"
@@ -24,9 +24,9 @@
 
 namespace sim{
 
-    class GenericCRTUtility{
+  class GenericCRTUtility{
 
-    public:
+  public:
 
     GenericCRTUtility(const std::string energyUnitsScale);
 
@@ -38,13 +38,13 @@ namespace sim{
 
     sim::AuxDetSimChannel GetAuxDetSimChannelByNumber(const std::vector<sim::AuxDetHit>& InputHitVector, unsigned int inputchannel) const;
 
-    private:
+  private:
 
-      art::ServiceHandle<geo::Geometry const> fGeo;
+    art::ServiceHandle<geo::Geometry const> fGeo;
 
-      double fEnergyUnitsScale;
+    double fEnergyUnitsScale;
 
-    };
+  };
 
 }
 

--- a/larsim/GenericCRT/GenericCRT.h
+++ b/larsim/GenericCRT/GenericCRT.h
@@ -27,6 +27,8 @@ namespace sim{
 
     public:
 
+    GenericCRTUtility(double energyUnitsScale);
+
     sim::AuxDetIDE toAuxDetIDE(sim::AuxDetHit const& InputHit) const;
 
     std::vector<unsigned int> GetAuxDetChannels(const std::vector<sim::AuxDetHit>& InputHitVector) const;
@@ -38,6 +40,8 @@ namespace sim{
     private:
 
       art::ServiceHandle<geo::Geometry const> fGeo;
+
+      double fEnergyUnitsScale;
 
     };
 

--- a/larsim/GenericCRT/GenericCRT.h
+++ b/larsim/GenericCRT/GenericCRT.h
@@ -18,6 +18,7 @@
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larcore/Geometry/Geometry.h"
+#include "CLHEP/Evaluator/Evaluator.h"
 
 #include <memory>
 
@@ -27,7 +28,7 @@ namespace sim{
 
     public:
 
-    GenericCRTUtility(double energyUnitsScale);
+    GenericCRTUtility(const std::string energyUnitsScale);
 
     sim::AuxDetIDE toAuxDetIDE(sim::AuxDetHit const& InputHit) const;
 

--- a/larsim/GenericCRT/GenericCRT_module.cc
+++ b/larsim/GenericCRT/GenericCRT_module.cc
@@ -45,6 +45,7 @@ public:
 
 private:
 
+  double fEnergyUnitsScale;
   sim::GenericCRTUtility fCRTConvertUtil;
 
   // Declare member data here.
@@ -54,7 +55,8 @@ private:
 
 sim::GenericCRT::GenericCRT(fhicl::ParameterSet const& p)
   : EDProducer{p}  //
-  ,fCRTConvertUtil()
+  ,fEnergyUnitsScale (p.get<double>("EnergyUnitsScale",1.))
+  ,fCRTConvertUtil(fEnergyUnitsScale)
   // More initializers here.
 {
 

--- a/larsim/GenericCRT/GenericCRT_module.cc
+++ b/larsim/GenericCRT/GenericCRT_module.cc
@@ -45,7 +45,7 @@ public:
 
 private:
 
-  double fEnergyUnitsScale;
+  std::string fEnergyUnitsScale;
   sim::GenericCRTUtility fCRTConvertUtil;
 
   // Declare member data here.
@@ -55,7 +55,7 @@ private:
 
 sim::GenericCRT::GenericCRT(fhicl::ParameterSet const& p)
   : EDProducer{p}  //
-  ,fEnergyUnitsScale (p.get<double>("EnergyUnitsScale",1.))
+  ,fEnergyUnitsScale (p.get<std::string>("EnergyUnitsScale","MeV"))
   ,fCRTConvertUtil(fEnergyUnitsScale)
   // More initializers here.
 {

--- a/larsim/GenericCRT/GenericCRT_module.cc
+++ b/larsim/GenericCRT/GenericCRT_module.cc
@@ -58,10 +58,10 @@ sim::GenericCRT::GenericCRT(fhicl::ParameterSet const& p)
   ,fEnergyUnitsScale (p.get<std::string>("EnergyUnitsScale","MeV"))
   ,fCRTConvertUtil(fEnergyUnitsScale)
   // More initializers here.
-{
+  {
 
-  produces< std::vector<sim::AuxDetSimChannel> >();
-}
+    produces< std::vector<sim::AuxDetSimChannel> >();
+  }
 
 void sim::GenericCRT::produce(art::Event& e)
 {

--- a/larsim/GenericCRT/config_genericCRT.fcl
+++ b/larsim/GenericCRT/config_genericCRT.fcl
@@ -4,7 +4,7 @@ sbnd_genericCRT:
 {
   module_type: "GenericCRT"
   LArG4Label: "largeant"
-
+  EnergyUnitsScale: 1e-3
 }
 
 END_PROLOG

--- a/larsim/GenericCRT/config_genericCRT.fcl
+++ b/larsim/GenericCRT/config_genericCRT.fcl
@@ -4,7 +4,7 @@ sbnd_genericCRT:
 {
   module_type: "GenericCRT"
   LArG4Label: "largeant"
-  EnergyUnitsScale: 1e-3
+  EnergyUnitsScale: "GeV"
 }
 
 END_PROLOG


### PR DESCRIPTION
As requested by @hanswenzel in LArSoft/larg4#34 I am moving the conversion of IDE energy from MeV to GeV further downstream. @ilepetic has confirmed SBND are currently the only users of GenericCRT, so this should only effect our use case.