### PR TITLE
Fix for GenericCRT

### DIFF
--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -90,9 +90,16 @@ sim::AuxDetSimChannel sim::GenericCRTUtility::GetAuxDetSimChannelByNumber(const 
     double ycoordinate = (auxDetHit.GetEntryY() + auxDetHit.GetExitY())/2.0;
     double zcoordinate = (auxDetHit.GetEntryZ() + auxDetHit.GetExitZ())/2.0;
     double worldPos[3] = {xcoordinate,ycoordinate,zcoordinate};
-    fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
+
     if(auxDetHit.GetID() == inputchannel)   // this is the channel we want.
     {
+      // Find the IDs given the hit position
+      fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
+
+      mf::LogDebug("GenericCRTUtility") << "Found an AuxDetHit with ID " << auxDetHit.GetID()
+                                        << " for AuxDet ID " << ad_id_no
+                                        << " Sens ID " << ad_sen_id_no << std::endl;
+
       auto tempIDE = toAuxDetIDE(auxDetHit);
 
       std::vector<sim::AuxDetIDE>::iterator IDEitr
@@ -113,10 +120,15 @@ sim::AuxDetSimChannel sim::GenericCRTUtility::GetAuxDetSimChannelByNumber(const 
         IDEvector.push_back(std::move(tempIDE));
       }//else
 
-      break;
+      // break;
     } // end if the AuxDetHit channel checks out.
 
   } // end main loop on AuxDetHit
+
+
+  mf::LogDebug("GenericCRTUtility") << "Returning AuxDetSimChannel for ID "
+                                    << ad_id_no << " " << ad_sen_id_no
+                                    << ", with " << IDEvector.size() << " IDEs." << std::endl;
 
   //push back the AuxDetSimChannel Vector.
   //TODO check the last parameter values.

--- a/larsim/GenericCRT/GenericCRT.cxx
+++ b/larsim/GenericCRT/GenericCRT.cxx
@@ -18,10 +18,10 @@ sim::GenericCRTUtility::GenericCRTUtility(const std::string energyUnitsScale)
   HepTool::Evaluator eval;
   eval.setStdMath();
   eval.setSystemOfUnits();
-  
+
   const std::string scaleExpression = "MeV / " + energyUnitsScale;
   fEnergyUnitsScale = eval.evaluate(scaleExpression.c_str());
-  
+
   if(eval.status() != 0) fEnergyUnitsScale = 1.;
 }
 
@@ -29,16 +29,16 @@ sim::AuxDetIDE sim::GenericCRTUtility::toAuxDetIDE(const sim::AuxDetHit &InputHi
 {
   sim::AuxDetIDE outputIDE;
 
-  outputIDE.trackID		    = InputHit.GetTrackID();
+  outputIDE.trackID = InputHit.GetTrackID();
   outputIDE.energyDeposited	= InputHit.GetEnergyDeposited() * fEnergyUnitsScale;
-  outputIDE.entryX		= InputHit.GetEntryX();
-  outputIDE.entryY		= InputHit.GetEntryY();
-  outputIDE.entryZ		= InputHit.GetEntryZ();
-  outputIDE.entryT		= InputHit.GetEntryT();
-  outputIDE.exitX		= InputHit.GetExitX();
-  outputIDE.exitY		= InputHit.GetExitY();
-  outputIDE.exitZ		= InputHit.GetExitZ();
-  outputIDE.exitT		= InputHit.GetExitT();
+  outputIDE.entryX = InputHit.GetEntryX();
+  outputIDE.entryY = InputHit.GetEntryY();
+  outputIDE.entryZ = InputHit.GetEntryZ();
+  outputIDE.entryT = InputHit.GetEntryT();
+  outputIDE.exitX = InputHit.GetExitX();
+  outputIDE.exitY = InputHit.GetExitY();
+  outputIDE.exitZ	= InputHit.GetExitZ();
+  outputIDE.exitT	= InputHit.GetExitT();
   outputIDE.exitMomentumX	= InputHit.GetExitMomentumX();
   outputIDE.exitMomentumY	= InputHit.GetExitMomentumY();
   outputIDE.exitMomentumZ	= InputHit.GetExitMomentumZ();
@@ -60,11 +60,11 @@ std::vector<unsigned int> sim::GenericCRTUtility::GetAuxDetChannels(const std::v
     {
 
       std::vector<unsigned int>::iterator Chanitr
-	= std::find(AuxDetChanNumber.begin(), AuxDetChanNumber.end(), hit.GetID());
+        = std::find(AuxDetChanNumber.begin(), AuxDetChanNumber.end(), hit.GetID());
 
       if(Chanitr == AuxDetChanNumber.end()){ //If trackID is already in the map, update it
-	//if channel ID is not in the set yet, add it
-	AuxDetChanNumber.push_back(hit.GetID());
+        //if channel ID is not in the set yet, add it
+        AuxDetChanNumber.push_back(hit.GetID());
       }//
 
     }
@@ -84,39 +84,39 @@ sim::AuxDetSimChannel sim::GenericCRTUtility::GetAuxDetSimChannelByNumber(const 
   size_t ad_sen_id_no = 9999;
 
   for (auto const& auxDetHit : InputHitVector)
+  {
+
+    double xcoordinate = (auxDetHit.GetEntryX() + auxDetHit.GetExitX())/2.0;
+    double ycoordinate = (auxDetHit.GetEntryY() + auxDetHit.GetExitY())/2.0;
+    double zcoordinate = (auxDetHit.GetEntryZ() + auxDetHit.GetExitZ())/2.0;
+    double worldPos[3] = {xcoordinate,ycoordinate,zcoordinate};
+    fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
+    if(auxDetHit.GetID() == inputchannel)   // this is the channel we want.
     {
+      auto tempIDE = toAuxDetIDE(auxDetHit);
 
-      double xcoordinate = (auxDetHit.GetEntryX() + auxDetHit.GetExitX())/2.0;
-      double ycoordinate = (auxDetHit.GetEntryY() + auxDetHit.GetExitY())/2.0;
-      double zcoordinate = (auxDetHit.GetEntryZ() + auxDetHit.GetExitZ())/2.0;
-      double worldPos[3] = {xcoordinate,ycoordinate,zcoordinate};
-      fGeo->FindAuxDetSensitiveAtPosition(worldPos, ad_id_no, ad_sen_id_no, 0.0001);
-      if(auxDetHit.GetID() == inputchannel)   // this is the channel we want.
-	{
-	  auto tempIDE = toAuxDetIDE(auxDetHit);
+      std::vector<sim::AuxDetIDE>::iterator IDEitr
+        = std::find(IDEvector.begin(), IDEvector.end(), tempIDE);
 
-	  std::vector<sim::AuxDetIDE>::iterator IDEitr
-	    = std::find(IDEvector.begin(), IDEvector.end(), tempIDE);
+      if(IDEitr != IDEvector.end()){ //If trackID is already in the map, update it
+        //Andrzej's note - following logic from AuxDetReadout in Legacy, but why are the other paremeters getting overwritten like that?
+        IDEitr->energyDeposited += tempIDE.energyDeposited;
+        IDEitr->exitX            = tempIDE.exitX;
+        IDEitr->exitY            = tempIDE.exitY;
+        IDEitr->exitZ            = tempIDE.exitZ;
+        IDEitr->exitT            = tempIDE.exitT;
+        IDEitr->exitMomentumX    = tempIDE.exitMomentumX;
+        IDEitr->exitMomentumY    = tempIDE.exitMomentumY;
+        IDEitr->exitMomentumZ    = tempIDE.exitMomentumZ;
+      }
+      else{  //if trackID is not in the set yet, add it
+        IDEvector.push_back(std::move(tempIDE));
+      }//else
 
-	  if(IDEitr != IDEvector.end()){ //If trackID is already in the map, update it
-	    //Andrzej's note - following logic from AuxDetReadout in Legacy, but why are the other paremeters getting overwritten like that?
-	    IDEitr->energyDeposited += tempIDE.energyDeposited;
-	    IDEitr->exitX            = tempIDE.exitX;
-	    IDEitr->exitY            = tempIDE.exitY;
-	    IDEitr->exitZ            = tempIDE.exitZ;
-	    IDEitr->exitT            = tempIDE.exitT;
-	    IDEitr->exitMomentumX    = tempIDE.exitMomentumX;
-	    IDEitr->exitMomentumY    = tempIDE.exitMomentumY;
-	    IDEitr->exitMomentumZ    = tempIDE.exitMomentumZ;
-	  }
-	  else{  //if trackID is not in the set yet, add it
-	    IDEvector.push_back(std::move(tempIDE));
-	  }//else
+      break;
+    } // end if the AuxDetHit channel checks out.
 
-	  break;
-	} // end if the AuxDetHit channel checks out.
-
-    } // end main loop on AuxDetHit
+  } // end main loop on AuxDetHit
 
   //push back the AuxDetSimChannel Vector.
   //TODO check the last parameter values.

--- a/larsim/GenericCRT/GenericCRT.h
+++ b/larsim/GenericCRT/GenericCRT.h
@@ -19,6 +19,7 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "larcore/Geometry/Geometry.h"
 #include "CLHEP/Evaluator/Evaluator.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include <memory>
 


### PR DESCRIPTION
This PR fixes a problem with the GenericCRT code. The GenericCRT module makes `AuxDetSimChannels` from the LArG4 `AuxDetHits`. In doing so, it was only saving the first IDE happening on a SimChannel, subsequent IDEs were not saved. This fix allows saving all IDEs, and it has been tested to work as expected using the SBND workflow.