### PR TITLE
Fix to allow PhotonBacktrackerService to use multiple scintillation labels

### DIFF
--- a/larsim/MCCheater/PhotonBackTracker.cc
+++ b/larsim/MCCheater/PhotonBackTracker.cc
@@ -42,6 +42,7 @@ namespace cheat{
 //    fDetClocks (detClock),
     fDelay     (config.Delay()),
     fG4ModuleLabel(config.G4ModuleLabel()),
+    fG4ModuleLabels(config.G4ModuleLabels()),
     fOpHitLabel(config.OpHitLabel()),
     fOpFlashLabel(config.OpFlashLabel()),
     //fWavLabel(config.WavLabel()),
@@ -58,6 +59,7 @@ namespace cheat{
 //    fDetClocks(detClock),
     fDelay(pSet.get<double>("Delay")),
     fG4ModuleLabel(pSet.get<art::InputTag>("G4ModuleLabel", "largeant")),
+    fG4ModuleLabels(pSet.get<std::vector<art::InputTag>>("G4ModuleLabels", {})),
     fOpHitLabel(pSet.get<art::InputTag>("OpHitLabel", "ophit")),
     fOpFlashLabel(pSet.get<art::InputTag>("OpFlashLabel", "opflash")),
     fMinOpHitEnergyFraction(pSet.get<double>("MinimumOpHitEnergyFraction", 0.1))
@@ -167,36 +169,23 @@ namespace cheat{
   //----------------------------------------------------------------
   const std::vector< sim::TrackSDP> PhotonBackTracker::OpHitToTrackSDPs(art::Ptr<recob::OpHit> const& opHit_P)  const
   {
-    //auto opHit = *opHit_P;
     auto OpDetNum =  fGeom->OpDetFromOpChannel(opHit_P->OpChannel()) ;
-    std::vector<sim::TrackSDP> trackSDPs;
     const double pTime = opHit_P->PeakTime();
     const double pWidth= opHit_P->Width();
     const double start = (pTime-pWidth)*1000-fDelay;
     const double end = (pTime+pWidth)*1000-fDelay;
-
-    //this->OpDetToTrackSDPs(trackSDPs, opHit_P->OpChannel(), start, end);
-
-
-    //return trackSDPs;
-    //return this->OpDetToTrackSDPs( opHit_P->OpChannel(), start, end);
     return this->OpDetToTrackSDPs( OpDetNum, start, end);
-
   }
 
   //----------------------------------------------------------------
   const std::vector<sim::TrackSDP> PhotonBackTracker::OpHitToTrackSDPs(recob::OpHit const& opHit) const
   {
     auto OpDetNum =  fGeom->OpDetFromOpChannel(opHit.OpChannel()) ;
-    std::vector<sim::TrackSDP> trackSDPs;
     const double pTime = opHit.PeakTime();
     const double pWidth= opHit.Width();
     const double start = (pTime-pWidth)*1000-fDelay;
     const double end = (pTime+pWidth)*1000-fDelay;
-
-
     return this->OpDetToTrackSDPs( OpDetNum, start, end);
-
   }
 
   //----------------------------------------------------------------

--- a/larsim/MCCheater/PhotonBackTracker.h
+++ b/larsim/MCCheater/PhotonBackTracker.h
@@ -23,6 +23,7 @@
 #include "canvas/Persistency/Common/Ptr.h"
 #include "canvas/Utilities/InputTag.h"
 #include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
 
 //LArSoft
 #include "lardataobj/RecoBase/OpHit.h"
@@ -46,6 +47,7 @@ namespace cheat{
       struct fhiclConfig{
         fhicl::Atom<double> Delay{fhicl::Name("Delay"), fhicl::Comment("The delay time needed to correctly account for the optical simulation and optical systems simulation. (The time between when a g4partcile was made, and when the simulation write out says a signal was recorded)."), 0};
         fhicl::Atom<art::InputTag> G4ModuleLabel{fhicl::Name("G4ModuleLabel"), fhicl::Comment("The label of the LArG4 module used to produce the art file we will be using."), "largeant"};
+        fhicl::Sequence<art::InputTag> G4ModuleLabels{fhicl::Name("G4ModuleLabels"), fhicl::Comment("The labels of the LArG4 modules used to produce the art file we will be using."), fhicl::Sequence<art::InputTag>::default_type{}};
         fhicl::Atom<art::InputTag> OpHitLabel{fhicl::Name("OpHitLabel"), fhicl::Comment("The default label for the module to use when grabbing OpHits"), "ophit"}; //This should be removed and replaced with some way to access the OpHitLabel given by the user in their own analysis module to avoid differing definitions.
         fhicl::Atom<art::InputTag> OpFlashLabel{fhicl::Name("OpFlashLabel"), fhicl::Comment("The default label for the module to use when grabbing OpFlash"), "opflash"}; //This should be removed and replaced with some way to access the OpFlashLabel given by the user in their own analysis module to avoid differing definitions.
         fhicl::Atom<double> MinOpHitEnergyFraction{fhicl::Name("MinOpHitEnergyFraction"), fhicl::Comment("The minimum contribution an energy deposit must make to a Hit to be considered part of that hit."),0.010};
@@ -244,6 +246,7 @@ namespace cheat{
       //      const detinfo::DetectorClocks* fDetClocks;
       const double fDelay;
       const art::InputTag fG4ModuleLabel;
+      const std::vector<art::InputTag> fG4ModuleLabels;
       const art::InputTag fOpHitLabel;
       const art::InputTag fOpFlashLabel;
       const double fMinOpHitEnergyFraction;

--- a/larsim/MCCheater/PhotonBackTracker.tcc
+++ b/larsim/MCCheater/PhotonBackTracker.tcc
@@ -17,45 +17,52 @@ namespace cheat{
     void PhotonBackTracker::PrepOpDetBTRs(Evt const& evt)
     {
       if(this->BTRsReady()){ return;}
-      auto const& btrHandle = evt.template getValidHandle < std::vector < sim::OpDetBacktrackerRecord > > (fG4ModuleLabel);
-      //      if(btrHandle.failedToGet()){
-      /*  mf::LogWarning("PhotonBackTracker") << "failed to get handle to     simb::MCParticle from "
-       *              << fG4ModuleLabel
-       *                          << ", return";*/ //This is now silent as it is expected to    happen every generation run. It is also temporary while we wait for
-      /*if( 0 ){ return;} //Insert check for DivRecs here, or don't use validHandle below.
-        auto const& divrecHandle = evt.template getValidHandle <std::vector<sim::OpDetDivRec>>(fWavLabel);
-        if(divrecHandle.failedToGet()){
-        return;
-        }*/
+      const std::vector<art::InputTag> G4ModuleLabels = (fG4ModuleLabels.empty()) ?
+        std::vector{fG4ModuleLabel} : fG4ModuleLabels;
 
-      art::fill_ptr_vector(priv_OpDetBTRs, btrHandle);
-      //art::fill_ptr_vector(priv_DivRecs, divrecHandle);
+      auto compareBTRlambda = [](art::Ptr<sim::OpDetBacktrackerRecord> a,
+                                 art::Ptr<sim::OpDetBacktrackerRecord> b)
+                                {return(a->OpDetNum()<b->OpDetNum());};
 
-      auto compareBTRlambda = [](art::Ptr<sim::OpDetBacktrackerRecord> a, art::Ptr<sim::OpDetBacktrackerRecord> b) {return(a->OpDetNum()<b->OpDetNum());};
-      if (!std::is_sorted(priv_OpDetBTRs.begin(),priv_OpDetBTRs.end(),compareBTRlambda)) 
-        std::sort(priv_OpDetBTRs.begin(),priv_OpDetBTRs.end(),compareBTRlambda);
-      //auto compareDivReclambda = [](art::Ptr<sim::OpDetDivRec> a, art::Ptr<sim::OpDetDivRec> b) {return(a->OpDetNum() < b->OpDetNum());};
-      /*if (!std::is_sorted(priv_DivRecs.begin(), priv_DivRecs.end(), compareDivReclambda)) 
-        std::sort(priv_DivRecs.begin(), priv_DivRecs.end(), compareDivReclambda);*/
-      //art::FindManyP<raw::OpDetWaveform, sim::OpDetDivRec> fp(priv_OpDetBTRs, evt, fWavLabel);// fp;
-      //art::FindOneP<raw::OpDetWaveform, sim::OpDetDivRec> fp(priv_OpDetBTRs, evt, fWavLabel);// fp;
-      //They come in sorted by BTR. Now make an index matched vector of data_t sorted by BTR. No. I need easy, not efficient. Map of DetNum to data_t. data_t is then channel mapped.
-      /*
-         if (fp.isValid()){
-         for( size_t btr_iter=0; btr_iter<priv_OpDetBTRs.size(); ++btr_iter){
-         auto btr=priv_OpDetBTRs.at(btr_iter);
-         auto od = btr->OpDetNum();
-         auto const& dr = fp.data(btr_iter);
-         for(auto& d : dr)
-         {
-         if(!d) continue;
-         priv_od_to_DivRec[od]=*d;//->ref();
-         }
+      for (auto& G4ModuleLabel : G4ModuleLabels) {
+        auto const& btrHandle = evt.template getValidHandle < std::vector < sim::OpDetBacktrackerRecord > > (G4ModuleLabel);
+        //      if(btrHandle.failedToGet()){
+        /*  mf::LogWarning("PhotonBackTracker") << "failed to get handle to     simb::MCParticle from "
+         *              << fG4ModuleLabel
+         *                          << ", return";*/ //This is now silent as it is expected to    happen every generation run. It is also temporary while we wait for
+        /*if( 0 ){ return;} //Insert check for DivRecs here, or don't use validHandle below.
+          auto const& divrecHandle = evt.template getValidHandle <std::vector<sim::OpDetDivRec>>(fWavLabel);
+          if(divrecHandle.failedToGet()){
+          return;
+          }*/
 
-         }
-         }else{throw cet::exception("PhotonBackTracker")<<"find Waveforms and DivRecs from BTRs failed.";}
-         */
+        art::fill_ptr_vector(priv_OpDetBTRs, btrHandle);
+        if (!std::is_sorted(priv_OpDetBTRs.begin(), priv_OpDetBTRs.end(), compareBTRlambda))
+          std::sort(priv_OpDetBTRs.begin(),priv_OpDetBTRs.end(),compareBTRlambda);
 
+        //art::fill_ptr_vector(priv_DivRecs, divrecHandle);
+        //auto compareDivReclambda = [](art::Ptr<sim::OpDetDivRec> a, art::Ptr<sim::OpDetDivRec> b) {return(a->OpDetNum() < b->OpDetNum());};
+        /*if (!std::is_sorted(priv_DivRecs.begin(), priv_DivRecs.end(), compareDivReclambda))
+          std::sort(priv_DivRecs.begin(), priv_DivRecs.end(), compareDivReclambda);*/
+        //art::FindManyP<raw::OpDetWaveform, sim::OpDetDivRec> fp(priv_OpDetBTRs, evt, fWavLabel);// fp;
+        //art::FindOneP<raw::OpDetWaveform, sim::OpDetDivRec> fp(priv_OpDetBTRs, evt, fWavLabel);// fp;
+        //They come in sorted by BTR. Now make an index matched vector of data_t sorted by BTR. No. I need easy, not efficient. Map of DetNum to data_t. data_t is then channel mapped.
+        /*
+          if (fp.isValid()){
+          for( size_t btr_iter=0; btr_iter<priv_OpDetBTRs.size(); ++btr_iter){
+          auto btr=priv_OpDetBTRs.at(btr_iter);
+          auto od = btr->OpDetNum();
+          auto const& dr = fp.data(btr_iter);
+          for(auto& d : dr)
+          {
+          if(!d) continue;
+          priv_od_to_DivRec[od]=*d;//->ref();
+          }
+
+          }
+          }else{throw cet::exception("PhotonBackTracker")<<"find Waveforms and DivRecs from BTRs failed.";}
+        */
+      }
       return;
     }
 
@@ -110,5 +117,5 @@ namespace cheat{
         priv_OpDetBTRs.clear();
         this->PrepOpDetBTRs(evt);
         this->PrepOpFlashToOpHits(evt);
-      } 
+      }
     }

--- a/larsim/MCCheater/PhotonBackTracker.tcc
+++ b/larsim/MCCheater/PhotonBackTracker.tcc
@@ -26,20 +26,13 @@ namespace cheat{
 
       for (auto& G4ModuleLabel : G4ModuleLabels) {
         auto const& btrHandle = evt.template getValidHandle < std::vector < sim::OpDetBacktrackerRecord > > (G4ModuleLabel);
-        //      if(btrHandle.failedToGet()){
-        /*  mf::LogWarning("PhotonBackTracker") << "failed to get handle to     simb::MCParticle from "
-         *              << fG4ModuleLabel
-         *                          << ", return";*/ //This is now silent as it is expected to    happen every generation run. It is also temporary while we wait for
-        /*if( 0 ){ return;} //Insert check for DivRecs here, or don't use validHandle below.
-          auto const& divrecHandle = evt.template getValidHandle <std::vector<sim::OpDetDivRec>>(fWavLabel);
-          if(divrecHandle.failedToGet()){
-          return;
-          }*/
-
         art::fill_ptr_vector(priv_OpDetBTRs, btrHandle);
         if (!std::is_sorted(priv_OpDetBTRs.begin(), priv_OpDetBTRs.end(), compareBTRlambda))
           std::sort(priv_OpDetBTRs.begin(),priv_OpDetBTRs.end(),compareBTRlambda);
 
+        // // // // // // // // // // // // // // // // // // // // // // // //
+        // DUNE-specific code which hasn't been migrated anywhere better yet //
+        // // // // // // // // // // // // // // // // // // // // // // // //
         //art::fill_ptr_vector(priv_DivRecs, divrecHandle);
         //auto compareDivReclambda = [](art::Ptr<sim::OpDetDivRec> a, art::Ptr<sim::OpDetDivRec> b) {return(a->OpDetNum() < b->OpDetNum());};
         /*if (!std::is_sorted(priv_DivRecs.begin(), priv_DivRecs.end(), compareDivReclambda))
@@ -62,6 +55,9 @@ namespace cheat{
           }
           }else{throw cet::exception("PhotonBackTracker")<<"find Waveforms and DivRecs from BTRs failed.";}
         */
+        // // // // // // // // // // // // // // // // // // // // // // // //
+        // DUNE-specific code which hasn't been migrated anywhere better yet //
+        // // // // // // // // // // // // // // // // // // // // // // // //
       }
       return;
     }

--- a/larsim/MCCheater/photonbacktrackerservice.fcl
+++ b/larsim/MCCheater/photonbacktrackerservice.fcl
@@ -3,9 +3,10 @@ BEGIN_PROLOG
 
 providerPBKConf:{
  G4ModuleLabel:            "largeant" # module that produced the sim::Particle and sim::SimChannel objects
+ G4ModuleLabels:         ["largeant"] # list of modules that produced the sim::Particle and sim::SimChannel objects
  MinimumHitEnergyFraction: 0.1        # minimum fraction of energy a G4 trackID contributes to a hit to be 
                                       # counted in hit based efficiency and purity calculations
- Delay:                    0          #This number is the difference between when light arrives at the detector, and the time recorded in OpHits. This number is experiment specific and should be set by each experiment. 
+ Delay:                    0          # difference between when light arrives at the detector, and the time recorded in OpHits. This number is experiment specific and should be set by each experiment. 
 }
 
 standard_photonbacktrackerservice:


### PR DESCRIPTION
This became necessary since the G4 refactoring, where multiple instances of light scintillation are started to handle the various aspects of light simulation.

Care has been taken to ensure backwards compatibility, and I believe that it shouldn't break anything.

I cleaned the code a bit, there are some remaining comments that I haven't removed but I'm happy to chuck them if someone more knowledgable is sure they're not needed anymore. 