### PR TITLE
Add option `StoreDroppedMCParticles` to LegacyLArG4 + allow MCReco module to read `sim::MCMiniPart` and `sim::SimEnergyDepositLite`

### DIFF
--- a/larsim/LegacyLArG4/LArG4_module.cc
+++ b/larsim/LegacyLArG4/LArG4_module.cc
@@ -565,7 +565,8 @@ namespace larg4 {
     fparticleListAction = new larg4::ParticleListAction(lgp->ParticleKineticEnergyCut(),
                                                         lgp->StoreTrajectories(),
                                                         lgp->KeepEMShowerDaughters(),
-                                                        fMakeMCParticles);
+                                                        fMakeMCParticles,
+                                                        fStoreDroppedMCParticles);
     uaManager->AddAndAdoptAction(fparticleListAction);
 
     // UserActionManager is now configured so continue G4 initialization
@@ -755,21 +756,10 @@ namespace larg4 {
 
           for (auto const& partPair : droppedParticleList) {
             simb::MCParticle& p = *(partPair.second);
+            if (ParticleListAction::isDropped(&p)) continue;
+            if (p.StatusCode() != 1) continue;
 
-            sim::MCMiniPart mini_mcp;
-            mini_mcp.Reset();
-
-            mini_mcp.TrackID( (unsigned int)p.TrackId() );
-            mini_mcp.PdgCode( p.PdgCode() );
-            mini_mcp.Mother( (unsigned int) p.Mother() );
-            mini_mcp.Process( p.Process() );
-            mini_mcp.StartVtx( p.Position() );
-            mini_mcp.StartMom( p.Momentum() );
-            mini_mcp.EndVtx( p.EndPosition() );
-            mini_mcp.EndMom( p.EndMomentum() );
-            // Change units to LArSoft (MeV, cm, us)
-            mini_mcp.ScaleStartMom(1.e3);
-            mini_mcp.ScaleEndMom(1.e3);
+            sim::MCMiniPart mini_mcp(p);
             mini_mcp.Origin( mct->Origin() );
 
             droppedPartCol->push_back(std::move(mini_mcp));

--- a/larsim/LegacyLArG4/LArG4_module.cc
+++ b/larsim/LegacyLArG4/LArG4_module.cc
@@ -73,7 +73,7 @@
 #include "nug4/G4Base/UserActionManager.h"
 #include "nug4/ParticleNavigation/ParticleList.h"
 #include "nusimdata/SimulationBase/MCTruth.h"
-#include "lardataobj/MCBase/MCMiniPart.h"
+#include "lardataobj/MCBase/MCParticleLite.h"
 
 // G4 Includes
 #include "Geant4/G4LogicalVolumeStore.hh"
@@ -333,7 +333,7 @@ namespace larg4 {
                                  ///< executed before main MC processing.
     bool fCheckOverlaps;         ///< Whether to use the G4 overlap checker
     bool fMakeMCParticles;       ///< Whether to keep a `sim::MCParticle` list
-    bool fStoreDroppedMCParticles;///< Whether to keep a `sim::MCMiniPart` list of dropped particles
+    bool fStoreDroppedMCParticles;///< Whether to keep a `sim::MCParticleLite` list of dropped particles
     bool fdumpParticleList;      ///< Whether each event's sim::ParticleList will be displayed.
     bool fdumpSimChannels;       ///< Whether each event's sim::Channel will be displayed.
     bool fUseLitePhotons;
@@ -492,7 +492,7 @@ namespace larg4 {
       produces<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>();
     }
     if (fStoreDroppedMCParticles) {
-      produces<std::vector<sim::MCMiniPart>>();
+      produces<std::vector<sim::MCParticleLite>>();
     }
     if (!lgp->NoElectronPropagation()) produces<std::vector<sim::SimChannel>>();
     produces<std::vector<sim::AuxDetSimChannel>>();
@@ -656,7 +656,7 @@ namespace larg4 {
       nullptr;
     auto droppedPartCol =
       fStoreDroppedMCParticles ?
-      std::make_unique<std::vector<sim::MCMiniPart>>() :
+      std::make_unique<std::vector<sim::MCParticleLite>>() :
       nullptr;
     auto PhotonCol = std::make_unique<std::vector<sim::SimPhotons>>();
     auto PhotonColRefl = std::make_unique<std::vector<sim::SimPhotons>>();
@@ -750,7 +750,7 @@ namespace larg4 {
 
         if (fStoreDroppedMCParticles && droppedPartCol) {
           // Request a list of dropped particles
-          // Store them in MCMiniPart format
+          // Store them in MCParticleLite format
           sim::ParticleList droppedParticleList = fparticleListAction->YieldDroppedList();
           droppedPartCol->reserve(droppedParticleList.size());
 
@@ -759,7 +759,7 @@ namespace larg4 {
             if (ParticleListAction::isDropped(&p)) continue;
             if (p.StatusCode() != 1) continue;
 
-            sim::MCMiniPart mini_mcp(p);
+            sim::MCParticleLite mini_mcp(p);
             mini_mcp.Origin( mct->Origin() );
 
             droppedPartCol->push_back(std::move(mini_mcp));

--- a/larsim/LegacyLArG4/ParticleListAction.cxx
+++ b/larsim/LegacyLArG4/ParticleListAction.cxx
@@ -225,7 +225,7 @@ namespace larg4 {
 
         // if we still can't find the parent in the particle navigator,
         // we have to give up
-        if (!fparticleList->KnownParticle(pid) && (!fdroppedParticleList || !fdroppedParticleList->KnownParticle(pid))) {
+        if (!fparticleList->KnownParticle(pid) && !(fdroppedParticleList && fdroppedParticleList->KnownParticle(pid))) {
           MF_LOG_WARNING("ParticleListAction")
             << "can't find parent id: " << parentID << " in the particle list, or fParentIDMap."
             << " Make " << parentID << " the mother ID for"

--- a/larsim/LegacyLArG4/ParticleListAction.h
+++ b/larsim/LegacyLArG4/ParticleListAction.h
@@ -50,6 +50,7 @@ namespace larg4 {
 
       cet::exempt_ptr<simb::MCParticle> particle; ///< Object representing particle.
       bool keep = false;                          ///< if there was decision to keep
+      bool drop = false;                          ///< For EM shower daughters, whether to drop them (independently of `keep`)
       /// Index of the particle in the original generator truth record.
       GeneratedParticleIndex_t truthIndex = simb::NoGeneratedParticleIndex;
 
@@ -59,6 +60,7 @@ namespace larg4 {
       {
         particle = nullptr;
         keep = false;
+        drop = false;
         truthIndex = simb::NoGeneratedParticleIndex;
       }
 
@@ -76,7 +78,7 @@ namespace larg4 {
         return simb::isGeneratedParticleIndex(truthIndex);
       }
 
-      /// Rerturns whether there is a particle known to be kept
+      /// Returns whether there is a particle known to be kept
       bool
       keepParticle() const
       {
@@ -155,6 +157,9 @@ namespace larg4 {
     // Yields the ParticleList accumulated during the current event.
     sim::ParticleList&& YieldList();
 
+    /// Yields the (dropped) ParticleList accumulated during the current event.
+    sim::ParticleList&& YieldDroppedList();
+
     /// returns whether the specified particle has been marked as dropped
     static bool isDropped(simb::MCParticle const* p);
 
@@ -169,6 +174,8 @@ namespace larg4 {
                                      ///< for a single particle.
     std::unique_ptr<sim::ParticleList> fparticleList; ///< The accumulated particle information for
                                                       ///< all particles in the event.
+    std::unique_ptr<sim::ParticleList> fdroppedParticleList; ///< The accumulated particle information for
+                                                             ///< all dropped particles in the event.
     G4bool fstoreTrajectories;       ///< Whether to store particle trajectories with each particle.
     std::map<int, int> fParentIDMap; ///< key is current track ID, value is parent ID
     static int fCurrentTrackID;      ///< track ID of the current particle, set to eve ID

--- a/larsim/LegacyLArG4/ParticleListAction.h
+++ b/larsim/LegacyLArG4/ParticleListAction.h
@@ -98,7 +98,8 @@ namespace larg4 {
     ParticleListAction(double energyCut,
                        bool storeTrajectories = false,
                        bool keepEMShowerDaughters = false,
-                       bool keepMCParticleList = true);
+                       bool keepMCParticleList = true,
+                       bool storeDroppedMCParticles = false);
 
     // UserActions method that we'll override, to obtain access to
     // Geant4's particle tracks and trajectories.
@@ -184,6 +185,7 @@ namespace larg4 {
     static int fTrackIDOffset;       ///< offset added to track ids when running over
                                      ///< multiple MCTruth objects.
     bool fKeepEMShowerDaughters;     ///< whether to keep EM shower secondaries, tertiaries, etc
+    bool fstoreDroppedMCParticles;   ///< Whether to keep the dropped EM shower secondaries, tertiaries etc in a separate list
 
     std::unique_ptr<util::PositionInVolumeFilter> fFilter; ///< filter for particles to be kept
 

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -12,8 +12,6 @@
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 #include "larcoreobj/SimpleTypesAndConstants/RawTypes.h"
-#include "lardataobj/Simulation/SimChannel.h"
-#include "lardataobj/Simulation/SimEnergyDeposit.h"
 
 #include "MCRecoEdep.h"
 
@@ -261,6 +259,15 @@ namespace sim {
     }
 
     return;
+  }
+
+  void MCRecoEdep::MakeMCEdep(const std::vector<sim::SimEnergyDepositLite>& sedArray) {
+    // Create a substitue array of sim::SimEnergyDeposit to avoid duplicating code...
+    // Note that this makes use of the explicit conversion operator
+    // defined in SimEnergyDepositLite class. Information will be partial.
+    // Most notably for MakeMCEdep, charge (numElectrons) will be 0.
+    std::vector<sim::SimEnergyDeposit> new_sedArray(sedArray.begin(), sedArray.end());
+    MakeMCEdep(new_sedArray);
   }
 
 

--- a/larsim/MCSTReco/MCRecoEdep.h
+++ b/larsim/MCSTReco/MCRecoEdep.h
@@ -4,6 +4,7 @@
 // LArSoft
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
+#include "lardataobj/Simulation/SimEnergyDepositLite.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 
 // Framework includes
@@ -102,6 +103,8 @@ namespace sim
     void MakeMCEdep(const std::vector<sim::SimChannel>& schArray);
 
     void MakeMCEdep(const std::vector<sim::SimEnergyDeposit>& sedArray);
+
+    void MakeMCEdep(const std::vector<sim::SimEnergyDepositLite>& sedArray);
 
     bool ExistTrack(const unsigned int track_id) const
     { return (_track_index.find(track_id) != _track_index.end()); }

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -190,22 +190,21 @@ namespace sim {
       TLorentzVector vec(mcp.Momentum(index));
       for(size_t i=0; i<4; ++i) vec[i] *= 1.e3;
 
-      det_path.push_back(std::make_pair(mcp.Position(index),vec));
+      det_path.emplace_back(mcp.Position(index), vec);
 
     }
-    mini_mcp.DetPath(det_path);
+    mini_mcp.DetPath(std::move(det_path));
   }
       } // end if in _pdg_list
     } // end for loop over mcp_v
 
     // Now loop over dropped particles
-    for(size_t i=0; i < mcmp_v.size(); ++i) {
+    for(auto const& mcmp : mcmp_v) {
 
-      auto const& mcmp = mcmp_v[i];
-
-      _track_index.insert(std::make_pair((size_t)(mcmp.TrackID()),(size_t)(this->size())));
+      _track_index.try_emplace(mcmp.TrackID(), this->size());
 
       this->push_back(mcmp);
+
     } // end for loop over mcmp_v
   } // end AddParticles
 }

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -127,7 +127,7 @@ namespace sim {
   //--------------------------------------------------------------------------------------------
   void MCRecoPart::AddParticles(const std::vector<simb::MCParticle>& mcp_v,
         const std::vector<simb::Origin_t>&   orig_v,
-        const std::vector<sim::MCMiniPart>&  mcmp_v)
+        const std::vector<sim::MCParticleLite>&  mcmp_v)
   //--------------------------------------------------------------------------------------------
   {
     if(orig_v.size() != mcp_v.size()) throw cet::exception(__FUNCTION__) << "MCParticle and Origin_t vector size not same!";
@@ -203,7 +203,7 @@ namespace sim {
 
       _track_index.try_emplace(mcmp.TrackID(), this->size());
 
-      this->push_back(mcmp);
+      this->push_back(sim::MCMiniPart(mcmp));
 
     } // end for loop over mcmp_v
   } // end AddParticles

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -44,21 +44,21 @@ namespace sim {
   {
     if(this->size() <= part_index) return ::sim::kINVALID_UINT;
 
-    unsigned int result = this->at(part_index)._mother;
+    unsigned int result = this->at(part_index).Mother();
 
-    if(!result) return this->at(part_index)._track_id;
+    if(!result) return this->at(part_index).TrackID();
 
     if(TrackToParticleIndex(result) != ::sim::kINVALID_UINT) return result;
 
     //std::cout<< "\033[95mWarning:\033[00m Mother particle not in the particle list!"<<std::endl;
     // Do brute search
-    unsigned int daughter_id = this->at(part_index)._track_id;
+    unsigned int daughter_id = this->at(part_index).TrackID();
 
     for(auto const& part : *this) {
 
-      if(part._daughters.find(daughter_id) != part._daughters.end())
+      if(part.HasDaughter(daughter_id) )
 
-	return part._track_id;
+        return part.TrackID();
 
     }
     return result;
@@ -70,13 +70,13 @@ namespace sim {
   {
     if(part_index >= this->size()) return kINVALID_UINT;
 
-    if((*this)[part_index]._ancestor != kINVALID_UINT) return (*this)[part_index]._ancestor;
+    if((*this)[part_index].Ancestor() != kINVALID_UINT) return (*this)[part_index].Ancestor();
 
-    unsigned int result = MotherTrackID(part_index);
+    auto result = MotherTrackID(part_index);
 
-    if(result == this->at(part_index)._track_id) return result;
+    if(result == this->at(part_index).TrackID()) return result;
 
-    if(!result) return this->at(part_index)._track_id;
+    if(!result) return this->at(part_index).TrackID();
 
     auto mother_index = TrackToParticleIndex(result);
 
@@ -84,49 +84,50 @@ namespace sim {
 
       if(mother_index != kINVALID_UINT) {
 
-	auto const new_result = MotherTrackID(mother_index);
+  auto const new_result = MotherTrackID(mother_index);
 
-	if(new_result == this->at(mother_index)._track_id) break;
+  if(new_result == this->at(mother_index).TrackID()) break;
 
-	result = new_result;
+  result = new_result;
 
       }else{
 
-	// Look for a particle that has a daughter = this mother
-	auto const old_result = result;
-	for(auto const& p : *this) {
+  // Look for a particle that has a daughter = this mother
+  auto const old_result = result;
+  for(auto const& p : *this) {
 
-	  if(p._daughters.find(result) != p._daughters.end()) {
-	    result = p._track_id;
-	    break;
-	  }
-	}
-	if(result == old_result)
-	  break;
+    if(p.HasDaughter(result)) {
+      result = p.TrackID();
+      break;
+    }
+  }
+  if(result == old_result)
+    break;
       }
 
       mother_index = TrackToParticleIndex(result);
 
     }
 
-    (*this)[part_index]._ancestor = result;
+    (*this)[part_index].Ancestor(result);
     return result;
   }
 
   //--------------------------------------------------------------------------------------------
   bool MCRecoPart::InDetector(const double& x,
-			      const double& y,
-			      const double& z) const
+            const double& y,
+            const double& z) const
   //--------------------------------------------------------------------------------------------
   {
     return !( x > _x_max || x < _x_min ||
-	      z > _z_max || z < _z_min ||
-	      y > _y_max || y < _y_min );
+        z > _z_max || z < _z_min ||
+        y > _y_max || y < _y_min );
   }
 
   //--------------------------------------------------------------------------------------------
   void MCRecoPart::AddParticles(const std::vector<simb::MCParticle>& mcp_v,
-				const std::vector<simb::Origin_t>&   orig_v)
+        const std::vector<simb::Origin_t>&   orig_v,
+        const std::vector<sim::MCMiniPart>&  mcmp_v)
   //--------------------------------------------------------------------------------------------
   {
     if(orig_v.size() != mcp_v.size()) throw cet::exception(__FUNCTION__) << "MCParticle and Origin_t vector size not same!";
@@ -146,63 +147,65 @@ namespace sim {
 
       auto& mini_mcp = (*this->rbegin());
 
-      for(size_t i=0; i<(size_t)(mcp.NumberDaughters()); ++i)
-	mini_mcp._daughters.insert(mcp.Daughter(i));
-
-      mini_mcp._track_id  = mcp.TrackId();
-      mini_mcp._pdgcode   = mcp.PdgCode();
-      mini_mcp._mother    = mcp.Mother();
-      mini_mcp._process   = mcp.Process();
-      mini_mcp._start_vtx = mcp.Position();
-      mini_mcp._start_mom = mcp.Momentum();
-      mini_mcp._end_vtx   = mcp.EndPosition();
-      mini_mcp._end_mom   = mcp.EndMomentum();
-      mini_mcp._origin    = orig_v[i];
+      for(size_t i=0; i<(size_t)(mcp.NumberDaughters()); ++i) {
+        mini_mcp.AddDaughter( (unsigned int) mcp.Daughter(i) );
+      }
+      mini_mcp.TrackID((unsigned int) mcp.TrackId());
+      mini_mcp.PdgCode(mcp.PdgCode());
+      mini_mcp.Mother( (unsigned int) mcp.Mother() );
+      mini_mcp.Process( mcp.Process() );
+      mini_mcp.StartVtx( mcp.Position() );
+      mini_mcp.StartMom( mcp.Momentum() );
+      mini_mcp.EndVtx( mcp.EndPosition() );
+      mini_mcp.EndMom( mcp.EndMomentum() );
+      mini_mcp.Origin( orig_v[i] );
 
       // Change units to LArSoft (MeV, cm, us)
-      for(size_t i=0; i<4; ++i) {
-	mini_mcp._start_mom[i] *= 1.e3;
-	mini_mcp._end_mom[i]   *= 1.e3;
-      }
-      /*
-      for(size_t i=0; i<3; ++i) {
-	mini_mcp._start_vtx[i] /= 10.;
-	mini_mcp._end_vtx[i] /= 10.;
-      }
-      mini_mcp.start_vtx[3] /= 1.e-3;
-      mini_mcp.end_vtx[3]   /= 1.e-3;
-      */
+      mini_mcp.ScaleStartMom(1.e3);
+      mini_mcp.ScaleEndMom(1.e3);
 
       if(_pdg_list.find(mcp.PdgCode()) != _pdg_list.end()) {
 
-	std::set<size_t> det_path_index;
+  std::set<size_t> det_path_index;
 
-	for(size_t i=0; i<mcp.NumberTrajectoryPoints(); ++i) {
+  for(size_t i=0; i<mcp.NumberTrajectoryPoints(); ++i) {
 
-	  if(InDetector(mcp.Vx(i),mcp.Vy(i),mcp.Vz(i)))
+    if(InDetector(mcp.Vx(i),mcp.Vy(i),mcp.Vz(i)))
 
-	    det_path_index.insert(i);
+      det_path_index.insert(i);
 
-	}
-
-	if(det_path_index.size()) {
-	  if( (*det_path_index.begin()) )
-	    det_path_index.insert( (*det_path_index.begin())-1 );
-	  if( det_path_index.size()>1 ) {
-	    if( ((*det_path_index.rbegin())+1) < mcp.NumberTrajectoryPoints() )
-	      det_path_index.insert( (*det_path_index.rbegin())+1 );
-	  }
-	  mini_mcp._det_path.reserve(det_path_index.size());
-	  for(auto const& index : det_path_index) {
-
-	    TLorentzVector vec(mcp.Momentum(index));
-	    for(size_t i=0; i<4; ++i) vec[i] *= 1.e3;
-
-	    mini_mcp._det_path.push_back(std::make_pair(mcp.Position(index),vec));
-
-	  }
-	}
-      }
-    }
   }
+
+  if(det_path_index.size()) {
+    if( (*det_path_index.begin()) )
+      det_path_index.insert( (*det_path_index.begin())-1 );
+    if( det_path_index.size()>1 ) {
+      if( ((*det_path_index.rbegin())+1) < mcp.NumberTrajectoryPoints() )
+        det_path_index.insert( (*det_path_index.rbegin())+1 );
+    }
+    std::vector<std::pair<TLorentzVector,TLorentzVector>> det_path;
+    det_path.reserve(det_path_index.size());
+    for(auto const& index : det_path_index) {
+
+      TLorentzVector vec(mcp.Momentum(index));
+      for(size_t i=0; i<4; ++i) vec[i] *= 1.e3;
+
+      det_path.push_back(std::make_pair(mcp.Position(index),vec));
+
+    }
+    mini_mcp.DetPath(det_path);
+  }
+      } // end if in _pdg_list
+    } // end for loop over mcp_v
+
+    // Now loop over dropped particles
+    for(size_t i=0; i < mcmp_v.size(); ++i) {
+
+      auto const& mcmp = mcmp_v[i];
+
+      _track_index.insert(std::make_pair((size_t)(mcmp.TrackID()),(size_t)(this->size())));
+
+      this->push_back(mcmp);
+    } // end for loop over mcmp_v
+  } // end AddParticles
 }

--- a/larsim/MCSTReco/MCRecoPart.h
+++ b/larsim/MCSTReco/MCRecoPart.h
@@ -6,6 +6,7 @@ namespace fhicl { class ParameterSet; }
 
 // LArSoft
 #include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
+#include "lardataobj/MCBase/MCMiniPart.h" // sim::MCMiniPart
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
 
@@ -18,48 +19,6 @@ namespace fhicl { class ParameterSet; }
 
 namespace sim
 {
-
-  class MCMiniPart {
-
-  public:
-
-    MCMiniPart() {Reset();}
-
-    virtual ~MCMiniPart(){}
-
-    unsigned int   _track_id;
-    std::string    _process;
-    unsigned int   _mother;
-    unsigned int   _ancestor;
-    int            _pdgcode;
-    TLorentzVector _start_vtx;
-    TLorentzVector _start_mom;
-    TLorentzVector _end_vtx;
-    TLorentzVector _end_mom;
-    std::vector<std::pair<TLorentzVector,TLorentzVector> > _det_path;
-    std::set<unsigned int> _daughters;
-    ::simb::Origin_t _origin;
-
-    void Reset(){
-      _track_id = _mother = _ancestor = kINVALID_UINT;
-      _pdgcode  = kINVALID_INT;
-      _process  = "";
-      _origin   = ::simb::kUnknown;
-
-      TLorentzVector invalid(kINVALID_DOUBLE,
-			     kINVALID_DOUBLE,
-			     kINVALID_DOUBLE,
-			     kINVALID_DOUBLE);
-      _start_vtx = invalid;
-      _start_mom = invalid;
-      _end_vtx = invalid;
-      _end_mom = invalid;
-      _daughters.clear();
-      _det_path.clear();
-    }
-
-  };
-
   class MCRecoPart : public std::vector<sim::MCMiniPart> {
 
   public:
@@ -71,7 +30,8 @@ namespace sim
     virtual ~MCRecoPart(){};
 
     void AddParticles(const std::vector<simb::MCParticle>& mcp_v,
-		      const std::vector<simb::Origin_t>&   orig_v);
+                      const std::vector<simb::Origin_t>&   orig_v,
+                      const std::vector<sim::MCMiniPart>&  mcmp_v = {});
 
     unsigned int AncestorTrackID(const unsigned int part_index);
 
@@ -89,8 +49,8 @@ namespace sim
     }
 
     bool InDetector(const double& x,
-		    const double& y,
-		    const double& z) const;
+                    const double& y,
+                    const double& z) const;
 
   public:
 

--- a/larsim/MCSTReco/MCRecoPart.h
+++ b/larsim/MCSTReco/MCRecoPart.h
@@ -7,6 +7,7 @@ namespace fhicl { class ParameterSet; }
 // LArSoft
 #include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
 #include "lardataobj/MCBase/MCMiniPart.h" // sim::MCMiniPart
+#include "lardataobj/MCBase/MCParticleLite.h" // sim::MCParticleLite
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
 
@@ -31,7 +32,7 @@ namespace sim
 
     void AddParticles(const std::vector<simb::MCParticle>& mcp_v,
                       const std::vector<simb::Origin_t>&   orig_v,
-                      const std::vector<sim::MCMiniPart>&  mcmp_v = {});
+                      const std::vector<sim::MCParticleLite>&  mcmp_v = {});
 
     unsigned int AncestorTrackID(const unsigned int part_index);
 

--- a/larsim/MCSTReco/MCReco_module.cc
+++ b/larsim/MCSTReco/MCReco_module.cc
@@ -68,6 +68,9 @@ MCReco::MCReco(fhicl::ParameterSet const & pset)
     fMCMiniPartLabel = pset.get<art::InputTag>("G4ModName","largeant");
     fSimChannelLabel = pset.get<art::InputTag>("G4ModName","largeant");
   }
+  else {
+    fMCMiniPartLabel = pset.get<art::InputTag>("MCMiniPartLabel", "largeant");
+  }
 
   fUseSimEnergyDeposit = pset.get<bool>("UseSimEnergyDeposit",false);
   fUseSimEnergyDepositLite = pset.get<bool>("UseSimEnergyDepositLite",false);

--- a/larsim/MCSTReco/MCReco_module.cc
+++ b/larsim/MCSTReco/MCReco_module.cc
@@ -37,7 +37,7 @@ private:
 
   // Declare member data here.
   art::InputTag fMCParticleLabel;
-  art::InputTag fMCMiniPartLabel;
+  art::InputTag fMCParticleLiteLabel;
   art::InputTag fSimChannelLabel;
   bool fUseSimEnergyDeposit;
   bool fUseSimEnergyDepositLite;
@@ -65,11 +65,11 @@ MCReco::MCReco(fhicl::ParameterSet const & pset)
             << "\nUse 'MCParticleLabel' and 'SimChannelLabel' instead.";
 
     fMCParticleLabel = pset.get<art::InputTag>("G4ModName","largeant");
-    fMCMiniPartLabel = pset.get<art::InputTag>("G4ModName","largeant");
+    fMCParticleLiteLabel = pset.get<art::InputTag>("G4ModName","largeant");
     fSimChannelLabel = pset.get<art::InputTag>("G4ModName","largeant");
   }
   else {
-    fMCMiniPartLabel = pset.get<art::InputTag>("MCMiniPartLabel", "largeant");
+    fMCParticleLiteLabel = pset.get<art::InputTag>("MCParticleLiteLabel", "largeant");
   }
 
   fUseSimEnergyDeposit = pset.get<bool>("UseSimEnergyDeposit",false);
@@ -111,7 +111,7 @@ void MCReco::produce(art::Event & evt)
   const std::vector<simb::MCParticle>& mcp_array(*mcpHandle);
 
   if (fIncludeDroppedParticles) {
-    auto const& mcmp_array = *evt.getValidHandle<std::vector<sim::MCMiniPart>>(fMCMiniPartLabel);
+    auto const& mcmp_array = *evt.getValidHandle<std::vector<sim::MCParticleLite>>(fMCParticleLiteLabel);
     fPart.AddParticles(mcp_array, orig_array, mcmp_array);
   } // end if fIncludeDroppedParticles
   else {

--- a/larsim/MCSTReco/MCReco_module.cc
+++ b/larsim/MCSTReco/MCReco_module.cc
@@ -31,13 +31,17 @@ public:
 //  virtual ~MCReco();
 
   void produce(art::Event & e) override;
+  template <typename T> void MakeMCEdep(art::Event& evt, const std::string& errorMessage);
 
 private:
 
   // Declare member data here.
   art::InputTag fMCParticleLabel;
+  art::InputTag fMCMiniPartLabel;
   art::InputTag fSimChannelLabel;
   bool fUseSimEnergyDeposit;
+  bool fUseSimEnergyDepositLite;
+  bool fIncludeDroppedParticles;
 
   ::sim::MCRecoPart fPart;
   ::sim::MCRecoEdep fEdep;
@@ -58,13 +62,20 @@ MCReco::MCReco(fhicl::ParameterSet const & pset)
        pset.get_if_present<art::InputTag>("SimChannelLabel",fSimChannelLabel)) ){
 
     mf::LogWarning("MCReco_module") << "USING DEPRECATED G4ModName CONFIG IN MCRECO_MODULE"
-				    << "\nUse 'MCParticleLabel' and 'SimChannelLabel' instead.";
+            << "\nUse 'MCParticleLabel' and 'SimChannelLabel' instead.";
 
     fMCParticleLabel = pset.get<art::InputTag>("G4ModName","largeant");
+    fMCMiniPartLabel = pset.get<art::InputTag>("G4ModName","largeant");
     fSimChannelLabel = pset.get<art::InputTag>("G4ModName","largeant");
   }
 
   fUseSimEnergyDeposit = pset.get<bool>("UseSimEnergyDeposit",false);
+  fUseSimEnergyDepositLite = pset.get<bool>("UseSimEnergyDepositLite",false);
+  fIncludeDroppedParticles = pset.get<bool>("IncludeDroppedParticles",false);
+
+  if (fUseSimEnergyDepositLite && fUseSimEnergyDeposit) {
+    mf::LogWarning("MCReco_module") << "Asked to use both SimEnergyDeposit and SimEnergyDepositLite - will use SimEnergyDeposit.";
+  }
 
   produces< std::vector< sim::MCShower> >();
   produces< std::vector< sim::MCTrack>  >();
@@ -95,28 +106,32 @@ void MCReco::produce(art::Event & evt)
   }
 
   const std::vector<simb::MCParticle>& mcp_array(*mcpHandle);
-  fPart.AddParticles(mcp_array,orig_array);
 
+  if (fIncludeDroppedParticles) {
+    art::Handle<std::vector<sim::MCMiniPart> > mcmpHandle;
+    evt.getByLabel(fMCMiniPartLabel,mcmpHandle);
+    if(!mcmpHandle.isValid()) throw cet::exception(__FUNCTION__) << "Failed to retrieve sim::MCMiniPart";;
+
+    const std::vector<sim::MCMiniPart>& mcmp_array(*mcmpHandle);
+
+    fPart.AddParticles(mcp_array, orig_array, mcmp_array);
+
+  } // end if fIncludeDroppedParticles
+  else {
+    fPart.AddParticles(mcp_array,orig_array);
+  }
 
   // change implemented by David Caratelli to allow for MCRECO to run without SimChannels and using
   // SimEnergyDeposits instead
   if (fUseSimEnergyDeposit == true) {
-    // Retrieve SimEnergyDeposit
-    art::Handle<std::vector<sim::SimEnergyDeposit> > sedHandle;
-    evt.getByLabel(fSimChannelLabel,sedHandle);
-    if(!sedHandle.isValid()) throw cet::exception(__FUNCTION__) << "Failed to retrieve sim::SimEnergyDeposit";
-
-    const std::vector<sim::SimEnergyDeposit>&  sed_array(*sedHandle);
-    fEdep.MakeMCEdep(sed_array);
+    MakeMCEdep<sim::SimEnergyDeposit>(evt, "sim::SimEnergyDeposit");
+  }
+  // change implemented by Laura Domine to allow for MCRECO to run with SimEnergyDepositLite
+  else if (fUseSimEnergyDepositLite == true) {
+    MakeMCEdep<sim::SimEnergyDepositLite>(evt, "sim::SimEnergyDepositLite");
   }
   else {
-    // Retrieve SimChannel
-    art::Handle<std::vector<sim::SimChannel> > schHandle;
-    evt.getByLabel(fSimChannelLabel,schHandle);
-    if(!schHandle.isValid()) throw cet::exception(__FUNCTION__) << "Failed to retrieve sim::SimChannel";
-
-    const std::vector<sim::SimChannel>&  sch_array(*schHandle);
-    fEdep.MakeMCEdep(sch_array);
+    MakeMCEdep<sim::SimChannel>(evt, "sim::SimChannel");
   }
 
   //Add MCShowers and MCTracks to the event
@@ -125,6 +140,16 @@ void MCReco::produce(art::Event & evt)
 
   fEdep.Clear();
   fPart.clear();
+}
+
+template <typename T> void MCReco::MakeMCEdep(art::Event& evt, const std::string& errorMessage) {
+  // Retrieve T
+  art::Handle<std::vector<T> > sedHandle;
+  evt.getByLabel(fSimChannelLabel, sedHandle);
+  if(!sedHandle.isValid()) throw cet::exception(__FUNCTION__) << "Failed to retrieve " << errorMessage;
+
+  const std::vector<T>&  sed_array(*sedHandle);
+  fEdep.MakeMCEdep(sed_array);
 }
 
 DEFINE_ART_MODULE(MCReco)

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -93,13 +93,15 @@ namespace sim {
 
       // Skip if mother energy is less than the enery threshold
       if(shower_g4_energy < fMinShowerEnergy) {
-  if(fDebugMode)
-    std::cout << " ... below energy threshold: skipping!"<<std::endl;
-  continue;
+        if(fDebugMode)
+          std::cout << " ... below energy threshold: skipping!"<<std::endl;
+
+        continue;
       }else if(shower_part.Daughters().size() < fMinNumDaughters) {
-  if(fDebugMode)
-    std::cout << " ... below # daughter particle count threshold: skipping!"<<std::endl;
-  continue;
+        if(fDebugMode)
+          std::cout << " ... below # daughter particle count threshold: skipping!"<<std::endl;
+
+        continue;
       }else if(fDebugMode) {
   std::cout << " ... condition matched. Storing this MCShower..."<<std::endl;
       }
@@ -140,7 +142,7 @@ namespace sim {
 
       for(auto const& index : fPartAlg.ShowerDaughters(shower_index))
 
-  daughter_track_id.push_back( part_v.at(index).TrackID() );
+        daughter_track_id.push_back( part_v.at(index).TrackID() );
 
       shower_prof.DaughterTrackID(daughter_track_id);
 
@@ -151,6 +153,7 @@ namespace sim {
 
     if(fDebugMode)
       std::cout << " Found " << mcshower.size() << " MCShowers. Now computing DetProfile position..." << std::endl;
+
 
     //
     // Daughter vtx

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -43,7 +43,7 @@ namespace sim {
 
   std::unique_ptr<std::vector<sim::MCShower>>
                MCShowerRecoAlg::Reconstruct(MCRecoPart& part_v,
-				    MCRecoEdep& edep_v)
+            MCRecoEdep& edep_v)
   {
 
     art::ServiceHandle<geo::Geometry const> geo;
@@ -71,7 +71,7 @@ namespace sim {
 
       if(mother_track == kINVALID_UINT || ancestor_track == kINVALID_UINT)
 
-	throw cet::exception(__FUNCTION__) << "LOGIC ERROR: mother/ancestor track ID is invalid!";
+  throw cet::exception(__FUNCTION__) << "LOGIC ERROR: mother/ancestor track ID is invalid!";
 
       MCMiniPart mother_part;
       MCMiniPart ancestor_part;
@@ -80,28 +80,28 @@ namespace sim {
       unsigned int ancestor_index = part_v.TrackToParticleIndex(ancestor_track);
 
       if(mother_index != kINVALID_UINT)   mother_part   = part_v[mother_index];
-      else mother_part._track_id = mother_track;
+      else mother_part.TrackID(mother_track);
 
       if(ancestor_index != kINVALID_UINT) ancestor_part = part_v[ancestor_index];
-      else ancestor_part._track_id = ancestor_track;
+      else ancestor_part.TrackID(ancestor_track);
 
-      double shower_g4_energy = shower_part._start_mom[3];
+      double shower_g4_energy = shower_part.StartMom()[3];
 
       if(fDebugMode)
 
-	std::cout << "Found MCShower with mother energy: " << shower_g4_energy << " MeV";
+  std::cout << "Found MCShower with mother energy: " << shower_g4_energy << " MeV";
 
       // Skip if mother energy is less than the enery threshold
       if(shower_g4_energy < fMinShowerEnergy) {
-	if(fDebugMode)
-	  std::cout << " ... below energy threshold: skipping!"<<std::endl;
-	continue;
-      }else if(shower_part._daughters.size() < fMinNumDaughters) {
-	if(fDebugMode)
-	  std::cout << " ... below # daughter particle count threshold: skipping!"<<std::endl;
-	continue;
+  if(fDebugMode)
+    std::cout << " ... below energy threshold: skipping!"<<std::endl;
+  continue;
+      }else if(shower_part.Daughters().size() < fMinNumDaughters) {
+  if(fDebugMode)
+    std::cout << " ... below # daughter particle count threshold: skipping!"<<std::endl;
+  continue;
       }else if(fDebugMode) {
-	std::cout << " ... condition matched. Storing this MCShower..."<<std::endl;
+  std::cout << " ... condition matched. Storing this MCShower..."<<std::endl;
       }
 
       // Record this MCShower
@@ -109,30 +109,30 @@ namespace sim {
 
       if(fDebugMode)
 
-	std::cout << " Storage index " << mcshower.size() << " => Shower index " << shower_index
-		  << std::endl;
+  std::cout << " Storage index " << mcshower.size() << " => Shower index " << shower_index
+      << std::endl;
 
       ::sim::MCShower shower_prof;
 
-      shower_prof.Origin  ( shower_part._origin   );
-      shower_prof.PdgCode ( shower_part._pdgcode  );
-      shower_prof.TrackID ( shower_part._track_id );
-      shower_prof.Process ( shower_part._process  );
+      shower_prof.Origin  ( shower_part.Origin()   );
+      shower_prof.PdgCode ( shower_part.PdgCode()  );
+      shower_prof.TrackID ( shower_part.TrackID() );
+      shower_prof.Process ( shower_part.Process()  );
 
-      shower_prof.MotherPdgCode ( mother_part._pdgcode  );
-      shower_prof.MotherTrackID ( mother_part._track_id );
-      shower_prof.MotherProcess ( mother_part._process  );
+      shower_prof.MotherPdgCode ( mother_part.PdgCode()  );
+      shower_prof.MotherTrackID ( mother_part.TrackID() );
+      shower_prof.MotherProcess ( mother_part.Process()  );
 
-      shower_prof.AncestorPdgCode ( ancestor_part._pdgcode  );
-      shower_prof.AncestorTrackID ( ancestor_part._track_id );
-      shower_prof.AncestorProcess ( ancestor_part._process  );
+      shower_prof.AncestorPdgCode ( ancestor_part.PdgCode()  );
+      shower_prof.AncestorTrackID ( ancestor_part.TrackID()  );
+      shower_prof.AncestorProcess ( ancestor_part.Process()  );
 
-      shower_prof.Start         ( MCStep ( shower_part._start_vtx,   shower_part._start_mom   ) );
-      shower_prof.End           ( MCStep ( shower_part._end_vtx,     shower_part._end_mom     ) );
-      shower_prof.MotherStart   ( MCStep ( mother_part._start_vtx,   mother_part._start_mom   ) );
-      shower_prof.MotherEnd     ( MCStep ( mother_part._end_vtx,     mother_part._end_mom     ) );
-      shower_prof.AncestorStart ( MCStep ( ancestor_part._start_vtx, ancestor_part._start_mom ) );
-      shower_prof.AncestorEnd   ( MCStep ( ancestor_part._end_vtx,   ancestor_part._end_mom   ) );
+      shower_prof.Start         ( MCStep ( shower_part.StartVtx(),   shower_part.StartMom()   ) );
+      shower_prof.End           ( MCStep ( shower_part.EndVtx(),     shower_part.EndMom()     ) );
+      shower_prof.MotherStart   ( MCStep ( mother_part.StartVtx(),   mother_part.StartMom()   ) );
+      shower_prof.MotherEnd     ( MCStep ( mother_part.EndVtx(),     mother_part.EndMom()     ) );
+      shower_prof.AncestorStart ( MCStep ( ancestor_part.StartVtx(), ancestor_part.StartMom() ) );
+      shower_prof.AncestorEnd   ( MCStep ( ancestor_part.EndVtx(),   ancestor_part.EndMom()   ) );
 
       // Daughter list
       std::vector<unsigned int> daughter_track_id;
@@ -140,7 +140,7 @@ namespace sim {
 
       for(auto const& index : fPartAlg.ShowerDaughters(shower_index))
 
-	daughter_track_id.push_back( part_v.at(index)._track_id );
+  daughter_track_id.push_back( part_v.at(index).TrackID() );
 
       shower_prof.DaughterTrackID(daughter_track_id);
 
@@ -156,9 +156,9 @@ namespace sim {
     // Daughter vtx
     //
     std::vector<TLorentzVector> mcs_daughter_vtx_v(mcshower.size(),TLorentzVector(sim::kINVALID_DOUBLE,
-										   sim::kINVALID_DOUBLE,
-										   sim::kINVALID_DOUBLE,
-										   sim::kINVALID_DOUBLE));
+                       sim::kINVALID_DOUBLE,
+                       sim::kINVALID_DOUBLE,
+                       sim::kINVALID_DOUBLE));
     std::vector<TLorentzVector> mcs_daughter_mom_v      ( mcshower.size(), TLorentzVector() );
 
     std::vector< std::vector<double> >         plane_charge_v          ( mcshower.size(), std::vector<double>(3,0) );
@@ -181,216 +181,216 @@ namespace sim {
 
       for(auto const& daughter_trk_id : mcshower[mcs_index].DaughterTrackID()) {
 
-	auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
+  auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
 
-	auto const& daughter_part = part_v[daughter_part_index];
+  auto const& daughter_part = part_v[daughter_part_index];
 
-	auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
+  auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
 
-	if(daughter_edep_index<0) continue;
+  if(daughter_edep_index<0) continue;
 
-	auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
+  auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
 
-	if(!(daughter_edep.size())) continue;
+  if(!(daughter_edep.size())) continue;
 
-	// Record first daughter's vtx point
-	double min_dist = sim::kINVALID_DOUBLE;
-	for(auto const& edep : daughter_edep) {
+  // Record first daughter's vtx point
+  double min_dist = sim::kINVALID_DOUBLE;
+  for(auto const& edep : daughter_edep) {
 
-	  double dist = sqrt( pow(edep.pos._x - daughter_part._start_vtx[0],2) +
-			      pow(edep.pos._y - daughter_part._start_vtx[1],2) +
-			      pow(edep.pos._z - daughter_part._start_vtx[2],2) );
+    double dist = sqrt( pow(edep.pos._x - daughter_part.StartVtx()[0],2) +
+            pow(edep.pos._y - daughter_part.StartVtx()[1],2) +
+            pow(edep.pos._z - daughter_part.StartVtx()[2],2) );
 
-	  if(dist < min_dist) {
-	    min_dist = dist;
-	    mcs_daughter_vtx[0] = edep.pos._x;
-	    mcs_daughter_vtx[1] = edep.pos._y;
-	    mcs_daughter_vtx[2] = edep.pos._z;
-	    mcs_daughter_vtx[3] = (dist/100. / 2.998e8)*1.e9 + daughter_part._start_vtx[3];
-	  }
+    if(dist < min_dist) {
+      min_dist = dist;
+      mcs_daughter_vtx[0] = edep.pos._x;
+      mcs_daughter_vtx[1] = edep.pos._y;
+      mcs_daughter_vtx[2] = edep.pos._z;
+      mcs_daughter_vtx[3] = (dist/100. / 2.998e8)*1.e9 + daughter_part.StartVtx()[3];
+    }
 
-	}
-	if(!daughter_stored) {
-	  // If daughter is not stored, and shower id energetic enough, attempt to include angle info
-	  std::vector<double> shower_dir(3,0);
-	  shower_dir[0] = mcshower[mcs_index].Start().Px();
-	  shower_dir[1] = mcshower[mcs_index].Start().Py();
-	  shower_dir[2] = mcshower[mcs_index].Start().Pz();
-	  double magnitude = 0;
-	  for(size_t i=0; i<3; ++i)
-	    magnitude += pow(shower_dir[i],2);
+  }
+  if(!daughter_stored) {
+    // If daughter is not stored, and shower id energetic enough, attempt to include angle info
+    std::vector<double> shower_dir(3,0);
+    shower_dir[0] = mcshower[mcs_index].Start().Px();
+    shower_dir[1] = mcshower[mcs_index].Start().Py();
+    shower_dir[2] = mcshower[mcs_index].Start().Pz();
+    double magnitude = 0;
+    for(size_t i=0; i<3; ++i)
+      magnitude += pow(shower_dir[i],2);
 
-	  magnitude = sqrt(magnitude);
+    magnitude = sqrt(magnitude);
 
-	  if(magnitude > 1.e-10) {
-	    // If enough momentum, include angle info
-	    min_dist = sim::kINVALID_DOUBLE;
+    if(magnitude > 1.e-10) {
+      // If enough momentum, include angle info
+      min_dist = sim::kINVALID_DOUBLE;
 
-	    for(auto& v : shower_dir) v /= magnitude;
+      for(auto& v : shower_dir) v /= magnitude;
 
-	    for(auto const& edep : daughter_edep) {
-	      std::vector<double> shower_dep_dir(3,0);
-	      shower_dep_dir[0] = edep.pos._x - mcshower[mcs_index].Start().X();
-	      shower_dep_dir[1] = edep.pos._y - mcshower[mcs_index].Start().Y();
-	      shower_dep_dir[2] = edep.pos._z - mcshower[mcs_index].Start().Z();
+      for(auto const& edep : daughter_edep) {
+        std::vector<double> shower_dep_dir(3,0);
+        shower_dep_dir[0] = edep.pos._x - mcshower[mcs_index].Start().X();
+        shower_dep_dir[1] = edep.pos._y - mcshower[mcs_index].Start().Y();
+        shower_dep_dir[2] = edep.pos._z - mcshower[mcs_index].Start().Z();
 
-	      double dist = sqrt( pow(shower_dep_dir[0],2) + pow(shower_dep_dir[1],2) + pow(shower_dep_dir[2],2) );
-	      for(auto& v : shower_dep_dir) v /= dist;
+        double dist = sqrt( pow(shower_dep_dir[0],2) + pow(shower_dep_dir[1],2) + pow(shower_dep_dir[2],2) );
+        for(auto& v : shower_dep_dir) v /= dist;
 
-	      double angle = acos( shower_dep_dir[0] * shower_dir[0] +
-				   shower_dep_dir[1] * shower_dir[1] +
-				   shower_dep_dir[2] * shower_dir[2] ) / TMath::Pi() * 180.;
+        double angle = acos( shower_dep_dir[0] * shower_dir[0] +
+           shower_dep_dir[1] * shower_dir[1] +
+           shower_dep_dir[2] * shower_dir[2] ) / TMath::Pi() * 180.;
 
-	      if(dist < min_dist && angle < 10) {
+        if(dist < min_dist && angle < 10) {
 
-		min_dist = dist;
-		mcs_daughter_vtx[0] = edep.pos._x;
-		mcs_daughter_vtx[1] = edep.pos._y;
-		mcs_daughter_vtx[2] = edep.pos._z;
-		mcs_daughter_vtx[3] = (dist/100. / 2.998e8)*1.e9 + mcshower[mcs_index].Start().T();
-	      }
-	    }
-	  }
-	}
-	break;
+    min_dist = dist;
+    mcs_daughter_vtx[0] = edep.pos._x;
+    mcs_daughter_vtx[1] = edep.pos._y;
+    mcs_daughter_vtx[2] = edep.pos._z;
+    mcs_daughter_vtx[3] = (dist/100. / 2.998e8)*1.e9 + mcshower[mcs_index].Start().T();
+        }
+      }
+    }
+  }
+  break;
       }
       // Now take care of momentum & plane charge
 
       std::vector<double> mom(3,0);
       for(auto const& daughter_trk_id : mcshower[mcs_index].DaughterTrackID()) {
 
-	//auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
+  //auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
 
-	// for c2: daughter_part is unused
-	//auto const& daughter_part = part_v[daughter_part_index];
+  // for c2: daughter_part is unused
+  //auto const& daughter_part = part_v[daughter_part_index];
 
-	auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
+  auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
 
-	if(daughter_edep_index<0) continue;
+  if(daughter_edep_index<0) continue;
 
-	auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
+  auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
 
-	if(!(daughter_edep.size())) continue;
+  if(!(daughter_edep.size())) continue;
 
-	//bool first=true;  // unused
-	for(auto const& edep : daughter_edep) {
+  //bool first=true;  // unused
+  for(auto const& edep : daughter_edep) {
 
-	  // Compute unit vector to this energy deposition
-	  mom[0] = edep.pos._x - mcs_daughter_vtx[0];
-	  mom[1] = edep.pos._y - mcs_daughter_vtx[1];
-	  mom[2] = edep.pos._z - mcs_daughter_vtx[2];
+    // Compute unit vector to this energy deposition
+    mom[0] = edep.pos._x - mcs_daughter_vtx[0];
+    mom[1] = edep.pos._y - mcs_daughter_vtx[1];
+    mom[2] = edep.pos._z - mcs_daughter_vtx[2];
 
-	  // Weight by energy (momentum)
-	  double magnitude = sqrt(pow(mom.at(0),2) + pow(mom.at(1),2) + pow(mom.at(2),2));
+    // Weight by energy (momentum)
+    double magnitude = sqrt(pow(mom.at(0),2) + pow(mom.at(1),2) + pow(mom.at(2),2));
 
-	  double energy = 0;
-	  double npid = 0;
-	  for(auto const& pid_energy : edep.deps) {
-	    npid++;
-	    energy += pid_energy.energy;
+    double energy = 0;
+    double npid = 0;
+    for(auto const& pid_energy : edep.deps) {
+      npid++;
+      energy += pid_energy.energy;
 
-	  }
-	  energy /= npid;
-	  if(magnitude>1.e-10) {
-	    mom.at(0) = mom.at(0) * energy / magnitude;
-	    mom.at(1) = mom.at(1) * energy / magnitude;
-	    mom.at(2) = mom.at(2) * energy / magnitude;
-	    mcs_daughter_mom[0] += mom.at(0);
-	    mcs_daughter_mom[1] += mom.at(1);
-	    mcs_daughter_mom[2] += mom.at(2);
-	  }
-	  //Determine the direction of the shower right at the start point
-	  double E = 0;
-	  double N = 0;
-	  if(sqrt( pow( edep.pos._x - mcs_daughter_vtx[0],2) +
-		   pow( edep.pos._y - mcs_daughter_vtx[1],2) +
-		   pow( edep.pos._z - mcs_daughter_vtx[2],2)) < 2.4 && magnitude>1.e-10){
+    }
+    energy /= npid;
+    if(magnitude>1.e-10) {
+      mom.at(0) = mom.at(0) * energy / magnitude;
+      mom.at(1) = mom.at(1) * energy / magnitude;
+      mom.at(2) = mom.at(2) * energy / magnitude;
+      mcs_daughter_mom[0] += mom.at(0);
+      mcs_daughter_mom[1] += mom.at(1);
+      mcs_daughter_mom[2] += mom.at(2);
+    }
+    //Determine the direction of the shower right at the start point
+    double E = 0;
+    double N = 0;
+    if(sqrt( pow( edep.pos._x - mcs_daughter_vtx[0],2) +
+       pow( edep.pos._y - mcs_daughter_vtx[1],2) +
+       pow( edep.pos._z - mcs_daughter_vtx[2],2)) < 2.4 && magnitude>1.e-10){
 
-	    mcs_daughter_dir[0] += mom.at(0);
-	    mcs_daughter_dir[1] += mom.at(1);
-	    mcs_daughter_dir[2] += mom.at(2);
-	    E += energy;
-	    N += 1;
-	  }
+      mcs_daughter_dir[0] += mom.at(0);
+      mcs_daughter_dir[1] += mom.at(1);
+      mcs_daughter_dir[2] += mom.at(2);
+      E += energy;
+      N += 1;
+    }
 
-	  if(E > 0) E /= N;
-	  mcs_daughter_dedxRAD += E;
+    if(E > 0) E /= N;
+    mcs_daughter_dedxRAD += E;
 
-	  mcs_daughter_mom[3] += energy;
+    mcs_daughter_mom[3] += energy;
 
-	  // Charge
-	  auto const pid = edep.pid;
+    // Charge
+    auto const pid = edep.pid;
           auto q_i = pindex.find(pid);
           if(q_i != pindex.end())
             plane_charge[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
 
-	}///Looping through the MCShower daughter's energy depositions
+  }///Looping through the MCShower daughter's energy depositions
 
       }///Looping through MCShower daughters
       mcs_daughter_dedxRAD /= 2.4;
 
       for(auto const& daughter_trk_id : mcshower[mcs_index].DaughterTrackID()) {
 
-	//auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
+  //auto const daughter_part_index = part_v.TrackToParticleIndex(daughter_trk_id);
 
-	// for c2: daughter_part is unused
-	//auto const& daughter_part = part_v[daughter_part_index];
+  // for c2: daughter_part is unused
+  //auto const& daughter_part = part_v[daughter_part_index];
 
-	auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
+  auto const daughter_edep_index = edep_v.TrackToEdepIndex(daughter_trk_id);
 
-	if(daughter_edep_index<0) continue;
+  if(daughter_edep_index<0) continue;
 
-	auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
+  auto const& daughter_edep = edep_v.GetEdepArrayAt(daughter_edep_index);
 
-	if(!(daughter_edep.size())) continue;
+  if(!(daughter_edep.size())) continue;
 
-	for(auto const& edep : daughter_edep) {
+  for(auto const& edep : daughter_edep) {
 
-	  //Defining dEdx
-	  //Need to define a plane through the shower start point (x_0, y_0, z_0) with a normal along the momentum vector of the shower
-	  //The plane will be defined in the typical way:
-	  // a*x + b*y + c*z + d = 0
-	  // where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
-	  // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
-	  // D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
+    //Defining dEdx
+    //Need to define a plane through the shower start point (x_0, y_0, z_0) with a normal along the momentum vector of the shower
+    //The plane will be defined in the typical way:
+    // a*x + b*y + c*z + d = 0
+    // where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
+    // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
+    // D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
 
 
 
-	  double p_mag = sqrt( pow(mcs_daughter_dir[0],2) + pow(mcs_daughter_dir[1],2) + pow(mcs_daughter_dir[2],2) );
-	  double a = 0, b = 0, c = 0, d = 0;
-	  if(p_mag > 1.e-10){
-	    a = mcs_daughter_dir[0]/p_mag;
-	    b = mcs_daughter_dir[1]/p_mag;
-	    c = mcs_daughter_dir[2]/p_mag;
-	    d = -1*(a*mcs_daughter_vtx[0] + b*mcs_daughter_vtx[1] + c*mcs_daughter_vtx[2]);
-	  }
-	  else{mcs_daughter_dedx += 0; continue;}
-	  //Radial Distance
-	  if( (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) < 2.4 &&
-	      (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) > 0){
+    double p_mag = sqrt( pow(mcs_daughter_dir[0],2) + pow(mcs_daughter_dir[1],2) + pow(mcs_daughter_dir[2],2) );
+    double a = 0, b = 0, c = 0, d = 0;
+    if(p_mag > 1.e-10){
+      a = mcs_daughter_dir[0]/p_mag;
+      b = mcs_daughter_dir[1]/p_mag;
+      c = mcs_daughter_dir[2]/p_mag;
+      d = -1*(a*mcs_daughter_vtx[0] + b*mcs_daughter_vtx[1] + c*mcs_daughter_vtx[2]);
+    }
+    else{mcs_daughter_dedx += 0; continue;}
+    //Radial Distance
+    if( (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) < 2.4 &&
+        (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) > 0){
 
-	    double E = 0;
-	    double N = 0;
+      double E = 0;
+      double N = 0;
 
-	    for(auto const& pid_energy : edep.deps) {
-	      N += 1;
-	      E += pid_energy.energy;
-	    }
+      for(auto const& pid_energy : edep.deps) {
+        N += 1;
+        E += pid_energy.energy;
+      }
 
-	    if(N > 0){
-	      E /= N;
-	    }
-	    else{ E = 0;}
+      if(N > 0){
+        E /= N;
+      }
+      else{ E = 0;}
 
-	    mcs_daughter_dedx += E;
+      mcs_daughter_dedx += E;
 
-	    // Charge
-	    auto const pid = edep.pid;
-	    auto q_i = pindex.find(pid);
+      // Charge
+      auto const pid = edep.pid;
+      auto q_i = pindex.find(pid);
             if(q_i != pindex.end())
               plane_dqdx[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
-	  }
-	}
+    }
+  }
       }
       mcs_daughter_dedx /= 2.4;
       plane_dqdx.at(0) /= 2.4;
@@ -417,11 +417,11 @@ namespace sim {
       double magnitude = sqrt(pow(daughter_mom[0],2)+pow(daughter_mom[1],2)+pow(daughter_mom[2],2));
 
       if(daughter_mom[3]>1.e-10) {
-	daughter_mom[0] *= daughter_mom[3]/magnitude;
-	daughter_mom[1] *= daughter_mom[3]/magnitude;
-	daughter_mom[2] *= daughter_mom[3]/magnitude;
+  daughter_mom[0] *= daughter_mom[3]/magnitude;
+  daughter_mom[1] *= daughter_mom[3]/magnitude;
+  daughter_mom[2] *= daughter_mom[3]/magnitude;
       }else
-	for(size_t i=0; i<4; ++i) daughter_mom[i]=0;
+  for(size_t i=0; i<4; ++i) daughter_mom[i]=0;
 
       mcshower.at(mcs_index).DetProfile( MCStep( daughter_vtx, daughter_mom ) );
       mcshower.at(mcs_index).Charge(plane_charge);
@@ -436,37 +436,37 @@ namespace sim {
 
       for(auto const& prof : mcshower) {
 
-	std::cout
+  std::cout
 
-	  << Form("  Shower particle:     PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.PdgCode(), prof.TrackID(),
-		  prof.Start().X(),prof.Start().Y(),prof.Start().Z(),prof.Start().T(),
-		  prof.Start().Px(),prof.Start().Py(),prof.Start().Pz(),prof.Start().E())
-	  << std::endl
-	  << Form("    Mother particle:   PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.MotherPdgCode(), prof.MotherTrackID(),
-		  prof.MotherStart().X(),prof.MotherStart().Y(),prof.MotherStart().Z(),prof.MotherStart().T(),
-		  prof.MotherStart().Px(),prof.MotherStart().Py(),prof.MotherStart().Pz(),prof.MotherStart().E())
-	  << std::endl
-	  << Form("    Ancestor particle: PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.AncestorPdgCode(), prof.AncestorTrackID(),
-		  prof.AncestorStart().X(),prof.AncestorStart().Y(),prof.AncestorStart().Z(),prof.AncestorStart().T(),
-		  prof.AncestorStart().Px(),prof.AncestorStart().Py(),prof.AncestorStart().Pz(),prof.AncestorStart().E())
-	  << std::endl
-	  << Form("    ... with %zu daughters: Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.DaughterTrackID().size(),
-		  prof.DetProfile().X(),prof.DetProfile().Y(),prof.DetProfile().Z(),prof.DetProfile().T(),
-		  prof.DetProfile().Px(),prof.DetProfile().Py(),prof.DetProfile().Pz(),prof.DetProfile().E())
-	  << std::endl
-	  << "    Charge per plane: ";
-	size_t const nPlanes = prof.Charge().size();
-	for(size_t i=0; i<nPlanes; ++i) {
+    << Form("  Shower particle:     PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.PdgCode(), prof.TrackID(),
+      prof.Start().X(),prof.Start().Y(),prof.Start().Z(),prof.Start().T(),
+      prof.Start().Px(),prof.Start().Py(),prof.Start().Pz(),prof.Start().E())
+    << std::endl
+    << Form("    Mother particle:   PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.MotherPdgCode(), prof.MotherTrackID(),
+      prof.MotherStart().X(),prof.MotherStart().Y(),prof.MotherStart().Z(),prof.MotherStart().T(),
+      prof.MotherStart().Px(),prof.MotherStart().Py(),prof.MotherStart().Pz(),prof.MotherStart().E())
+    << std::endl
+    << Form("    Ancestor particle: PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.AncestorPdgCode(), prof.AncestorTrackID(),
+      prof.AncestorStart().X(),prof.AncestorStart().Y(),prof.AncestorStart().Z(),prof.AncestorStart().T(),
+      prof.AncestorStart().Px(),prof.AncestorStart().Py(),prof.AncestorStart().Pz(),prof.AncestorStart().E())
+    << std::endl
+    << Form("    ... with %zu daughters: Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.DaughterTrackID().size(),
+      prof.DetProfile().X(),prof.DetProfile().Y(),prof.DetProfile().Z(),prof.DetProfile().T(),
+      prof.DetProfile().Px(),prof.DetProfile().Py(),prof.DetProfile().Pz(),prof.DetProfile().E())
+    << std::endl
+    << "    Charge per plane: ";
+  size_t const nPlanes = prof.Charge().size();
+  for(size_t i=0; i<nPlanes; ++i) {
 
-	  std::cout << " | Plane " << i << std::flush;
-	  std::cout << " ... Q = " << prof.Charge(i) << std::flush;
+    std::cout << " | Plane " << i << std::flush;
+    std::cout << " ... Q = " << prof.Charge(i) << std::flush;
 
-	}
-	std::cout<<std::endl<<std::endl;
+  }
+  std::cout<<std::endl<<std::endl;
       }
     }
     return result;

--- a/larsim/MCSTReco/MCShowerRecoPart.cxx
+++ b/larsim/MCSTReco/MCShowerRecoPart.cxx
@@ -42,52 +42,52 @@ namespace sim {
       auto const& mcp = part_v[i];
 
       int candidate_mom_index=-1;
-      if( mcp._pdgcode == 22 ||
-          mcp._pdgcode == 11 ||
-          mcp._pdgcode == -11 )
-	candidate_mom_index = i;
+      if( mcp.PdgCode() == 22 ||
+          mcp.PdgCode() == 11 ||
+          mcp.PdgCode() == -11 )
+  candidate_mom_index = i;
 
-      unsigned int mom_track = mcp._mother;
+      unsigned int mom_track = mcp.Mother();
       auto mom_iter = part_v._track_index.find(mom_track);
       while(mom_iter != part_v._track_index.end()) {
 
         unsigned int mom_index = (*mom_iter).second;
 
-        if( part_v.at(mom_index)._pdgcode == 22 || part_v.at(mom_index)._pdgcode == 11 || part_v.at(mom_index)._pdgcode == -11 )
+        if( part_v.at(mom_index).PdgCode() == 22 || part_v.at(mom_index).PdgCode() == 11 || part_v.at(mom_index).PdgCode() == -11 )
 
           candidate_mom_index = mom_index;
 
-        mom_iter = part_v._track_index.find(part_v.at(mom_index)._mother);
+        mom_iter = part_v._track_index.find(part_v.at(mom_index).Mother());
 
       }
 
       if(candidate_mom_index >= 0) {
 
-	auto candidate_mom_iter = _shower_index.find(candidate_mom_index);
-	if(candidate_mom_iter == _shower_index.end()) {
-	  _shower_index.insert(std::make_pair((unsigned int)candidate_mom_index, (unsigned int)_shower_index.size()));
-	  daughter_map.push_back(std::multimap<double,unsigned int>());
-	}
-	unsigned int shower_index = (*_shower_index.find(candidate_mom_index)).second;
-	daughter_map.at(shower_index).insert(std::make_pair((double)(mcp._start_vtx[3]),(unsigned int)i));
-	_shower_id.at(i) = shower_index;
+  auto candidate_mom_iter = _shower_index.find(candidate_mom_index);
+  if(candidate_mom_iter == _shower_index.end()) {
+    _shower_index.insert(std::make_pair((unsigned int)candidate_mom_index, (unsigned int)_shower_index.size()));
+    daughter_map.push_back(std::multimap<double,unsigned int>());
+  }
+  unsigned int shower_index = (*_shower_index.find(candidate_mom_index)).second;
+  daughter_map.at(shower_index).insert(std::make_pair((double)(mcp.StartVtx()[3]),(unsigned int)i));
+  _shower_id.at(i) = shower_index;
 
       } else if(_debug_mode) {
 
-	std::cout
-	  << "Found a particle that does not belong to a shower!" << std::endl
-	  << Form(" PDGID: %d ... Track %d @ (%g,%g,%g,%g) with (%g,%g,%g,%g)",
-		  mcp._pdgcode,
-		  mcp._track_id,
-		  mcp._start_vtx[0],
-		  mcp._start_vtx[1],
-		  mcp._start_vtx[2],
-		  mcp._start_vtx[3],
-		  mcp._start_mom[0],
-		  mcp._start_mom[1],
-		  mcp._start_mom[2],
-		  mcp._start_mom[3])
-	  << std::endl << std::endl;
+  std::cout
+    << "Found a particle that does not belong to a shower!" << std::endl
+    << Form(" PDGID: %d ... Track %d @ (%g,%g,%g,%g) with (%g,%g,%g,%g)",
+      mcp.PdgCode(),
+      mcp.TrackID(),
+      mcp.StartVtx()[0],
+      mcp.StartVtx()[1],
+      mcp.StartVtx()[2],
+      mcp.StartVtx()[3],
+      mcp.StartMom()[0],
+      mcp.StartMom()[1],
+      mcp.StartMom()[2],
+      mcp.StartMom()[3])
+    << std::endl << std::endl;
 
       }
     }
@@ -95,7 +95,7 @@ namespace sim {
 
     if(_debug_mode)
       std::cout
-	<< Form("Found %zu MCShowers....",_shower_index.size()) << std::endl;
+  << Form("Found %zu MCShowers....",_shower_index.size()) << std::endl;
 
     _shower_daughters.resize(_shower_index.size(),std::vector<unsigned int>());
     for(auto const &mom : _shower_index) {
@@ -103,24 +103,24 @@ namespace sim {
       _shower_daughters.at(mom.second).reserve(daughter_map.at(mom.second).size());
       for(auto const &part_index : daughter_map.at(mom.second))
 
-	_shower_daughters.at(mom.second).push_back(part_index.second);
+  _shower_daughters.at(mom.second).push_back(part_index.second);
 
       auto const& mcp = part_v.at(mom.first);
       if(_debug_mode)
-	std::cout
-	  << Form("PDGID: %d ... Track %d @ (%g,%g,%g,%g) with (%g,%g,%g,%g) ... %zu daughters!",
-		  mcp._pdgcode,
-		  mcp._track_id,
-		  mcp._start_vtx[0],
-		  mcp._start_vtx[1],
-		  mcp._start_vtx[2],
-		  mcp._start_vtx[3],
-		  mcp._start_mom[0],
-		  mcp._start_mom[1],
-		  mcp._start_mom[2],
-		  mcp._start_mom[3],
-		  _shower_daughters.at(mom.second).size())
-	  << std::endl;
+  std::cout
+    << Form("PDGID: %d ... Track %d @ (%g,%g,%g,%g) with (%g,%g,%g,%g) ... %zu daughters!",
+      mcp.PdgCode(),
+      mcp.TrackID(),
+      mcp.StartVtx()[0],
+      mcp.StartVtx()[1],
+      mcp.StartVtx()[2],
+      mcp.StartVtx()[3],
+      mcp.StartMom()[0],
+      mcp.StartMom()[1],
+      mcp.StartMom()[2],
+      mcp.StartMom()[3],
+      _shower_daughters.at(mom.second).size())
+    << std::endl;
     }
 
     if(_debug_mode)

--- a/larsim/MCSTReco/MCTrackRecoAlg.cxx
+++ b/larsim/MCSTReco/MCTrackRecoAlg.cxx
@@ -29,7 +29,7 @@ namespace sim {
   }
 
   std::unique_ptr<std::vector<sim::MCTrack>> MCTrackRecoAlg::Reconstruct(MCRecoPart& part_v,
-				   MCRecoEdep& edep_v)
+           MCRecoEdep& edep_v)
   {
     auto result = std::make_unique<std::vector<sim::MCTrack>>();
     auto& mctracks = *result;
@@ -37,7 +37,7 @@ namespace sim {
 
     for(size_t i=0; i<part_v.size(); ++i) {
       auto const& mini_part = part_v[i];
-      if( part_v._pdg_list.find(mini_part._pdgcode) == part_v._pdg_list.end() ) continue;
+      if( part_v._pdg_list.find(mini_part.PdgCode()) == part_v._pdg_list.end() ) continue;
 
       ::sim::MCTrack mini_track;
 
@@ -45,19 +45,19 @@ namespace sim {
       std::vector<std::vector<double> > dQdx;
       dQdx.resize(3);
 
-      mini_track.Origin  ( mini_part._origin   );
-      mini_track.PdgCode ( mini_part._pdgcode  );
-      mini_track.TrackID ( mini_part._track_id );
-      mini_track.Process ( mini_part._process  );
-      mini_track.Start   ( MCStep( mini_part._start_vtx, mini_part._start_mom ) );
-      mini_track.End     ( MCStep( mini_part._end_vtx,   mini_part._end_mom   ) );
+      mini_track.Origin  ( mini_part.Origin()   );
+      mini_track.PdgCode ( mini_part.PdgCode()  );
+      mini_track.TrackID ( mini_part.TrackID() );
+      mini_track.Process ( mini_part.Process()  );
+      mini_track.Start   ( MCStep( mini_part.StartVtx(), mini_part.StartMom() ) );
+      mini_track.End     ( MCStep( mini_part.EndVtx(),   mini_part.EndMom()   ) );
 
       unsigned int mother_track   = part_v.MotherTrackID(i);
       unsigned int ancestor_track = part_v.AncestorTrackID(i);
 
       if(mother_track == kINVALID_UINT || ancestor_track == kINVALID_UINT)
 
-	throw cet::exception(__FUNCTION__) << "LOGIC ERROR: mother/ancestor track ID is invalid!";
+  throw cet::exception(__FUNCTION__) << "LOGIC ERROR: mother/ancestor track ID is invalid!";
 
       MCMiniPart mother_part;
       MCMiniPart ancestor_part;
@@ -66,39 +66,39 @@ namespace sim {
       unsigned int ancestor_index = part_v.TrackToParticleIndex(ancestor_track);
 
       if(mother_index != kINVALID_UINT)   mother_part   = part_v[mother_index];
-      else mother_part._track_id = mother_track;
+      else mother_part.TrackID(mother_track);
 
       if(ancestor_index != kINVALID_UINT) ancestor_part = part_v[ancestor_index];
-      else ancestor_part._track_id = ancestor_track;
+      else ancestor_part.TrackID(ancestor_track);
 
-      mini_track.MotherPdgCode ( mother_part._pdgcode  );
-      mini_track.MotherTrackID ( mother_part._track_id );
-      mini_track.MotherProcess ( mother_part._process  );
-      mini_track.MotherStart   ( MCStep( mother_part._start_vtx, mother_part._start_mom ) );
-      mini_track.MotherEnd     ( MCStep( mother_part._end_vtx,   mother_part._end_mom   ) );
+      mini_track.MotherPdgCode ( mother_part.PdgCode()  );
+      mini_track.MotherTrackID ( mother_part.TrackID() );
+      mini_track.MotherProcess ( mother_part.Process()  );
+      mini_track.MotherStart   ( MCStep( mother_part.StartVtx(), mother_part.StartMom() ) );
+      mini_track.MotherEnd     ( MCStep( mother_part.EndVtx(),   mother_part.EndMom()   ) );
 
-      mini_track.AncestorPdgCode ( ancestor_part._pdgcode  );
-      mini_track.AncestorTrackID ( ancestor_part._track_id );
-      mini_track.AncestorProcess ( ancestor_part._process  );
-      mini_track.AncestorStart   ( MCStep( ancestor_part._start_vtx, ancestor_part._start_mom ) );
-      mini_track.AncestorEnd     ( MCStep( ancestor_part._end_vtx,   ancestor_part._end_mom   ) );
+      mini_track.AncestorPdgCode ( ancestor_part.PdgCode()  );
+      mini_track.AncestorTrackID ( ancestor_part.TrackID() );
+      mini_track.AncestorProcess ( ancestor_part.Process()  );
+      mini_track.AncestorStart   ( MCStep( ancestor_part.StartVtx(), ancestor_part.StartMom() ) );
+      mini_track.AncestorEnd     ( MCStep( ancestor_part.EndVtx(),   ancestor_part.EndMom()   ) );
 
 
       // Fill trajectory points
 
-      for(auto const& vtx_mom : mini_part._det_path){
-	mini_track.push_back(MCStep(vtx_mom.first,vtx_mom.second));
+      for(auto const& vtx_mom : mini_part.DetPath()){
+        mini_track.push_back(MCStep(vtx_mom.first,vtx_mom.second));
       }
 
       // No calorimetry for zero length tracks...
       // JZ : I think we should remove zero length MCTracks because I do not see their utility
       // JZ : Someone could make this a fcl parameter, I did not
       if(mini_track.size() == 0){
-	mctracks.push_back(mini_track);
-	continue;
+        mctracks.push_back(mini_track);
+        continue;
       }
 
-      auto const& edep_index = edep_v.TrackToEdepIndex(mini_part._track_id);
+      auto const& edep_index = edep_v.TrackToEdepIndex(mini_part.TrackID());
       if(edep_index < 0 ) continue;
       auto const& edeps = edep_v.GetEdepArrayAt(edep_index);
 
@@ -107,122 +107,122 @@ namespace sim {
       for(auto const& step_trk : mini_track){
 
         if( int(&step_trk - &mini_track[0])+1 == int(mini_track.size()) ){  //annoying way to check if this is last step
-	  continue;}
+    continue;}
 
 
-	auto const& nxt_step_trk = mini_track.at(int(&step_trk - &mini_track[0])+1);
+  auto const& nxt_step_trk = mini_track.at(int(&step_trk - &mini_track[0])+1);
 
-	//Defining the track step-by-step dEdx and dQdx
+  //Defining the track step-by-step dEdx and dQdx
 
-	//Find the distance between two adjacent MCSteps
-	double dist = sqrt(pow(step_trk.X() - nxt_step_trk.X(),2) +
-			   pow(step_trk.Y() - nxt_step_trk.Y(),2) +
-			   pow(step_trk.Z() - nxt_step_trk.Z(),2));
+  //Find the distance between two adjacent MCSteps
+  double dist = sqrt(pow(step_trk.X() - nxt_step_trk.X(),2) +
+         pow(step_trk.Y() - nxt_step_trk.Y(),2) +
+         pow(step_trk.Z() - nxt_step_trk.Z(),2));
 
-	//Make a plane at the step pointed at the next step
+  //Make a plane at the step pointed at the next step
 
-	//Need to define a plane through the first MCStep with a normal along the momentum vector of the step
-	//The plane will be defined in the typical way:
-	// a*x + b*y + c*z + d = 0
-	// where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
-	// then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
-	// D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
+  //Need to define a plane through the first MCStep with a normal along the momentum vector of the step
+  //The plane will be defined in the typical way:
+  // a*x + b*y + c*z + d = 0
+  // where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
+  // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
+  // D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
 
-	double a = 0, b = 0, c = 0, d = 0;
-	a = nxt_step_trk.X() - step_trk.X();
-	b = nxt_step_trk.Y() - step_trk.Y();
-	c = nxt_step_trk.Z() - step_trk.Z();
-	d = -1*(a*step_trk.X() + b*step_trk.Y() + c*step_trk.Z());
+  double a = 0, b = 0, c = 0, d = 0;
+  a = nxt_step_trk.X() - step_trk.X();
+  b = nxt_step_trk.Y() - step_trk.Y();
+  c = nxt_step_trk.Z() - step_trk.Z();
+  d = -1*(a*step_trk.X() + b*step_trk.Y() + c*step_trk.Z());
 
-	//Make a line connecting the two points and find the distance from that line
-	//
-	//                        [A dot B]^2     [A dot B]^2
-	// distance^2 = A^2 - 2* ____________ + ______________
-	//                            B^2             B^2
-	// Test point == x_0
-	// First Step == x_1
-	// Next step == x_2
-	// A = x_1 - x_0
-	// B = x_2 - x_1
+  //Make a line connecting the two points and find the distance from that line
+  //
+  //                        [A dot B]^2     [A dot B]^2
+  // distance^2 = A^2 - 2* ____________ + ______________
+  //                            B^2             B^2
+  // Test point == x_0
+  // First Step == x_1
+  // Next step == x_2
+  // A = x_1 - x_0
+  // B = x_2 - x_1
 
-	// 'B' definition
-	TVector3 B(nxt_step_trk.Position().X() - step_trk.Position().X(),
-		   nxt_step_trk.Position().Y() - step_trk.Position().Y(),
-		   nxt_step_trk.Position().Z() - step_trk.Position().Z());
+  // 'B' definition
+  TVector3 B(nxt_step_trk.Position().X() - step_trk.Position().X(),
+       nxt_step_trk.Position().Y() - step_trk.Position().Y(),
+       nxt_step_trk.Position().Z() - step_trk.Position().Z());
 
 
-	//Initialize the step-by-step dEdx and dQdx containers
-	double step_dedx = 0;
-	std::vector<double> step_dqdx;
-	step_dqdx.resize(3);
+  //Initialize the step-by-step dEdx and dQdx containers
+  double step_dedx = 0;
+  std::vector<double> step_dqdx;
+  step_dqdx.resize(3);
 
-	//Iterate through all the energy deposition points
-	for(auto const& edep : edeps){
-	  // 'x_0' definition
-	  TVector3 x_0(edep.pos._x, edep.pos._y, edep.pos._z);
-	  // 'A' definition
-	  TVector3 A(step_trk.Position().X() - x_0.X(),
-		     step_trk.Position().Y() - x_0.Y(),
-		     step_trk.Position().Z() - x_0.Z());
+  //Iterate through all the energy deposition points
+  for(auto const& edep : edeps){
+    // 'x_0' definition
+    TVector3 x_0(edep.pos._x, edep.pos._y, edep.pos._z);
+    // 'A' definition
+    TVector3 A(step_trk.Position().X() - x_0.X(),
+         step_trk.Position().Y() - x_0.Y(),
+         step_trk.Position().Z() - x_0.Z());
 
-	  // Distance from the line connecting x_1 and x_2
-	  double LineDist = 0;
+    // Distance from the line connecting x_1 and x_2
+    double LineDist = 0;
 
-	  if(B.Mag2() != 0){
-	    LineDist = sqrt(A.Mag2() - 2*pow(A*B,2)/B.Mag2() + pow(A*B,2)/B.Mag2());
-	  }
-	  else{LineDist = 0;}
+    if(B.Mag2() != 0){
+      LineDist = sqrt(A.Mag2() - 2*pow(A*B,2)/B.Mag2() + pow(A*B,2)/B.Mag2());
+    }
+    else{LineDist = 0;}
 
-	  //Planar Distance and Radial Line Distance Cuts
-	  // Add in a voxel before and after to account for MCSteps
-	  // the line distance allows for 1mm GEANT multiple columb scattering correction,
-	  // small compared to average MCStep-to-MCStep distance
-	  if( (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) <= dist + 0.03 &&
-	      (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) >=    0 - 0.03 &&
-	      LineDist < 0.1){
+    //Planar Distance and Radial Line Distance Cuts
+    // Add in a voxel before and after to account for MCSteps
+    // the line distance allows for 1mm GEANT multiple columb scattering correction,
+    // small compared to average MCStep-to-MCStep distance
+    if( (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) <= dist + 0.03 &&
+        (a*edep.pos._x + b*edep.pos._y + c*edep.pos._z + d)/sqrt( pow(a,2) + pow(b,2) + pow(c,2)) >=    0 - 0.03 &&
+        LineDist < 0.1){
 
-	    //dEdx Calculation
-	    int npid = 0;
-	    double engy = 0;
+      //dEdx Calculation
+      int npid = 0;
+      double engy = 0;
 
-	    for(auto const& pid_energy : edep.deps){
-	      engy += pid_energy.energy;
-	      npid++;
-	    }
+      for(auto const& pid_energy : edep.deps){
+        engy += pid_energy.energy;
+        npid++;
+      }
 
-	    if(npid != 0){
-	      engy /= npid;}
-	    else{engy = 0;}
+      if(npid != 0){
+        engy /= npid;}
+      else{engy = 0;}
 
-	    step_dedx += engy;
-	  auto const pid = edep.pid;
+      step_dedx += engy;
+    auto const pid = edep.pid;
           auto q_i = pindex.find(pid);
           if(q_i != pindex.end())
             step_dqdx[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
-	  }
-	}
+    }
+  }
 
-	// Normalize to the 3D distance between the MCSteps
+  // Normalize to the 3D distance between the MCSteps
 
-	//Disregard any energy deposition when 2 MCSteps are separated less than the voxel size
-	if(dist > 0.03){
-	  step_dedx /= dist;
-	  step_dqdx[0] /= dist;
-	  step_dqdx[1] /= dist;
-	  step_dqdx[2] /= dist;
-	}
-	else{
-	  step_dedx = 0;
-	  step_dqdx[0] = 0;
-	  step_dqdx[1] = 0;
-	  step_dqdx[2] = 0;
-	}
+  //Disregard any energy deposition when 2 MCSteps are separated less than the voxel size
+  if(dist > 0.03){
+    step_dedx /= dist;
+    step_dqdx[0] /= dist;
+    step_dqdx[1] /= dist;
+    step_dqdx[2] /= dist;
+  }
+  else{
+    step_dedx = 0;
+    step_dqdx[0] = 0;
+    step_dqdx[1] = 0;
+    step_dqdx[2] = 0;
+  }
 
-	// Build the vector(s) to add to data product
-	dEdx.push_back(step_dedx);
-	dQdx[0].push_back(step_dqdx[0]);
-	dQdx[1].push_back(step_dqdx[1]);
-	dQdx[2].push_back(step_dqdx[2]);
+  // Build the vector(s) to add to data product
+  dEdx.push_back(step_dedx);
+  dQdx[0].push_back(step_dqdx[0]);
+  dQdx[1].push_back(step_dqdx[1]);
+  dQdx[2].push_back(step_dqdx[2]);
 
 
 
@@ -243,37 +243,37 @@ namespace sim {
 
       for(auto const& prof : mctracks) {
 
-	std::cout
+  std::cout
 
-	  << Form("  Track particle:      PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.PdgCode(),prof.TrackID(),
-		  prof.Start().X(),prof.Start().Y(),prof.Start().Z(),prof.Start().T(),
-		  prof.Start().Px(),prof.Start().Py(),prof.Start().Pz(),prof.Start().E())
-	  << std::endl
-	  << Form("    Mother particle:   PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.MotherPdgCode(),prof.MotherTrackID(),
-		  prof.MotherStart().X(),prof.MotherStart().Y(),prof.MotherStart().Z(),prof.MotherStart().T(),
-		  prof.MotherStart().Px(),prof.MotherStart().Py(),prof.MotherStart().Pz(),prof.MotherStart().E())
-	  << std::endl
-	  << Form("    Ancestor particle: PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		  prof.AncestorPdgCode(),prof.AncestorTrackID(),
-		  prof.AncestorStart().X(),prof.AncestorStart().Y(),prof.AncestorStart().Z(),prof.AncestorStart().T(),
-		  prof.AncestorStart().Px(),prof.AncestorStart().Py(),prof.AncestorStart().Pz(),prof.AncestorStart().E())
-	  << std::endl
-	  << Form("    ... with %zu trajectory points!",prof.size())
-	  << std::endl;
+    << Form("  Track particle:      PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.PdgCode(),prof.TrackID(),
+      prof.Start().X(),prof.Start().Y(),prof.Start().Z(),prof.Start().T(),
+      prof.Start().Px(),prof.Start().Py(),prof.Start().Pz(),prof.Start().E())
+    << std::endl
+    << Form("    Mother particle:   PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.MotherPdgCode(),prof.MotherTrackID(),
+      prof.MotherStart().X(),prof.MotherStart().Y(),prof.MotherStart().Z(),prof.MotherStart().T(),
+      prof.MotherStart().Px(),prof.MotherStart().Py(),prof.MotherStart().Pz(),prof.MotherStart().E())
+    << std::endl
+    << Form("    Ancestor particle: PDG=%d : Track ID=%d Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+      prof.AncestorPdgCode(),prof.AncestorTrackID(),
+      prof.AncestorStart().X(),prof.AncestorStart().Y(),prof.AncestorStart().Z(),prof.AncestorStart().T(),
+      prof.AncestorStart().Px(),prof.AncestorStart().Py(),prof.AncestorStart().Pz(),prof.AncestorStart().E())
+    << std::endl
+    << Form("    ... with %zu trajectory points!",prof.size())
+    << std::endl;
 
-	if(prof.size()) {
-	  std::cout
-	    << Form("        Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		    prof[0].X(), prof[0].Y(), prof[0].Z(), prof[0].T(),
-		    prof[0].Px(), prof[0].Py(), prof[0].Pz(), prof[0].E())
-	    << std::endl
-	    << Form("        End @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
-		    (*prof.rbegin()).X(), (*prof.rbegin()).Y(), (*prof.rbegin()).Z(), (*prof.rbegin()).T(),
-		    (*prof.rbegin()).Px(), (*prof.rbegin()).Py(), (*prof.rbegin()).Pz(), (*prof.rbegin()).E())
-	    << std::endl;
-	}
+  if(prof.size()) {
+    std::cout
+      << Form("        Start @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+        prof[0].X(), prof[0].Y(), prof[0].Z(), prof[0].T(),
+        prof[0].Px(), prof[0].Py(), prof[0].Pz(), prof[0].E())
+      << std::endl
+      << Form("        End @ (%g,%g,%g,%g) with Momentum (%g,%g,%g,%g)",
+        (*prof.rbegin()).X(), (*prof.rbegin()).Y(), (*prof.rbegin()).Z(), (*prof.rbegin()).T(),
+        (*prof.rbegin()).Px(), (*prof.rbegin()).Py(), (*prof.rbegin()).Pz(), (*prof.rbegin()).E())
+      << std::endl;
+  }
       }
 
       std::cout<<std::endl<<std::endl;


### PR DESCRIPTION
This PR is part of an effort from the ICARUS ML group to merge our pipeline back into the official production workflow.

* Introduce fhicl option `StoreDroppedMCParticles` in LegacyLArG4. When `KeepEMShowerDaughters` is set to `true` and `StoreDroppedMCParticles` is `true`, this will store all shower daughters in a lite version of `simb::MCParticle`.
* Update MCReco module to read `sim::MCMiniPart` in addition to `simb::MCParticle` list
* Update MCReco to read `sim::SimEnergyDepositLite` instead of `sim::SimEnergyDeposit`
* Introduce fhicl options `UseSimEnergyDepositLite` and `IncludeDroppedParticles` in MCReco to read respectively `sim::SimEnergyDepositLite` (instead of `sim::SimEnergyDeposit`) and `sim::MCMiniPart` (in addition to `simb::MCParticle`)
* The class `sim::MCMiniPart` was moved from `larsim'MCST/MCRecoPart.h` to lardataobj (see below).

**What needs to happen before this can be merged**
I have a draft [PR in `lardataobj`](https://github.com/LArSoft/lardataobj/pull/30) for the new objects `sim::SimEnergyDepositLite` and `sim::MCMiniPart` that needs to be merged before this one can be merged.