### PR TITLE
Fix to address rollup in flash purity calculation

### DIFF
--- a/larsim/MCCheater/PhotonBackTracker.cc
+++ b/larsim/MCCheater/PhotonBackTracker.cc
@@ -150,7 +150,7 @@ namespace cheat {
       for (size_t e = 0; e < simSDPs.size(); ++e) {
         if (simSDPs[e].trackID == sim::NoParticleId) continue;
         sim::TrackSDP info;
-        info.trackID = simSDPs[e].trackID;
+        info.trackID = std::abs(simSDPs[e].trackID);
         info.energyFrac = simSDPs[e].energy / totalE;
         info.energy = simSDPs[e].energy;
         tSDPs.push_back(info);


### PR DESCRIPTION
When EM shower daughters rollup is enabled, any non-saved shower daughter has its energy depositions assigned to the following ID: -1 * primary parent ID. This is the default configuration for the DUNE far detectors, for example, since it makes simulation faster and renders smaller files. Without the change that is being proposed in this PR, when the purity of a flash (i.e. what fraction of PEs that make the flash comes from the primary particle) is calculated, it does not consider any rollup shower, since it is asking for the ID and not the absolute value of the ID of the particle. The proposed change addresses the optical flash purity calculation when simulation has this option on (KeepEMShowerDaughters=false) by changing the trackID to abs(trackID) in the PhotonBackTracker::OpDetToTrackSDPs function. This is not a breaking change and makes no difference in the calculation when this option is true.