### PR TITLE
Particle Ancestry Map

### DIFF
--- a/larsim/MergeSimSources/MergeSimSources.cxx
+++ b/larsim/MergeSimSources/MergeSimSources.cxx
@@ -201,9 +201,10 @@ void sim::MergeSimSourcesUtility::MergeAuxDetHits(std::vector<sim::AuxDetHit>& d
   std::transform(begin(src), end(src), back_inserter(dest), offsetAuxDetHitID);
 }
 
-void sim::MergeSimSourcesUtility::MergeParticleAncestryMaps(std::vector<sim::ParticleAncestryMap>& dest,
-                                                            const sim::ParticleAncestryMap& src,
-                                                            std::size_t source_index) const
+void sim::MergeSimSourcesUtility::MergeParticleAncestryMaps(
+  std::vector<sim::ParticleAncestryMap>& dest,
+  const sim::ParticleAncestryMap& src,
+  std::size_t source_index) const
 {
   const int offset = fG4TrackIDOffsets.at(source_index);
 
@@ -288,21 +289,20 @@ sim::AuxDetHit sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID(sim::AuxDetHi
   };
 } // sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID()
 
-sim::ParticleAncestryMap sim::MergeSimSourcesUtility::offsetParticleAncestryMapTrackID(sim::ParticleAncestryMap const& pam,
-                                                                                       int offset)
+sim::ParticleAncestryMap sim::MergeSimSourcesUtility::offsetParticleAncestryMapTrackID(
+  sim::ParticleAncestryMap const& pam,
+  int offset)
 {
   std::map<int, std::set<int>> newMap;
 
-  for(auto const& [ancestor, descendants] : pam.GetMap())
-    {
-      const int newAnc = (ancestor >= 0) ? ancestor + offset : ancestor - offset;
+  for (auto const& [ancestor, descendants] : pam.GetMap()) {
+    const int newAnc = (ancestor >= 0) ? ancestor + offset : ancestor - offset;
 
-      for(auto const& descendant : descendants)
-	{
-	  const int newDesc = (descendant >= 0) ? descendant + offset : descendant - offset;
-	  newMap[newAnc].insert(newDesc);
-	}
+    for (auto const& descendant : descendants) {
+      const int newDesc = (descendant >= 0) ? descendant + offset : descendant - offset;
+      newMap[newAnc].insert(newDesc);
     }
+  }
 
   return sim::ParticleAncestryMap(newMap);
 }

--- a/larsim/MergeSimSources/MergeSimSources.cxx
+++ b/larsim/MergeSimSources/MergeSimSources.cxx
@@ -201,6 +201,16 @@ void sim::MergeSimSourcesUtility::MergeAuxDetHits(std::vector<sim::AuxDetHit>& d
   std::transform(begin(src), end(src), back_inserter(dest), offsetAuxDetHitID);
 }
 
+void sim::MergeSimSourcesUtility::MergeParticleAncestryMaps(std::vector<sim::ParticleAncestryMap>& dest,
+                                                            const sim::ParticleAncestryMap& src,
+                                                            std::size_t source_index) const
+{
+  const int offset = fG4TrackIDOffsets.at(source_index);
+
+  dest.reserve(dest.size() + 1);
+  dest.push_back(offsetParticleAncestryMapTrackID(src, offset));
+}
+
 void sim::MergeSimSourcesUtility::UpdateG4TrackIDRange(std::pair<int, int> newrange,
                                                        size_t source_index)
 {
@@ -277,3 +287,22 @@ sim::AuxDetHit sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID(sim::AuxDetHi
     adh.GetExitMomentumZ(),
   };
 } // sim::MergeSimSourcesUtility::offsetAuxDetHitTrackID()
+
+sim::ParticleAncestryMap sim::MergeSimSourcesUtility::offsetParticleAncestryMapTrackID(sim::ParticleAncestryMap const& pam,
+                                                                                       int offset)
+{
+  std::map<int, std::set<int>> newMap;
+
+  for(auto const& [ancestor, descendants] : pam.GetMap())
+    {
+      const int newAnc = (ancestor >= 0) ? ancestor + offset : ancestor - offset;
+
+      for(auto const& descendant : descendants)
+	{
+	  const int newDesc = (descendant >= 0) ? descendant + offset : descendant - offset;
+	  newMap[newAnc].insert(newDesc);
+	}
+    }
+
+  return sim::ParticleAncestryMap(newMap);
+}

--- a/larsim/MergeSimSources/MergeSimSources.h
+++ b/larsim/MergeSimSources/MergeSimSources.h
@@ -16,10 +16,10 @@
 
 #include "lardataobj/Simulation/AuxDetHit.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimPhotons.h"
-#include "lardataobj/Simulation/ParticleAncestryMap.h"
 
 #include <utility> // std::pair<>
 #include <vector>
@@ -76,7 +76,9 @@ namespace sim {
 
     static sim::AuxDetHit offsetAuxDetHitTrackID(sim::AuxDetHit const&, int);
 
-    static sim::ParticleAncestryMap offsetParticleAncestryMapTrackID(sim::ParticleAncestryMap const&, int);
+    static sim::ParticleAncestryMap offsetParticleAncestryMapTrackID(
+      sim::ParticleAncestryMap const&,
+      int);
 
   }; //end MergeSimSourcesUtility class
 

--- a/larsim/MergeSimSources/MergeSimSources.h
+++ b/larsim/MergeSimSources/MergeSimSources.h
@@ -10,7 +10,7 @@
  * Typically just merges vectors/maps/etc together. But, if anything as a G4 trackID, applies
  * a user-defined offset to those IDs.
  *
-*/
+ */
 
 #include "nusimdata/SimulationBase/MCParticle.h"
 
@@ -19,6 +19,7 @@
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimPhotons.h"
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
 
 #include <utility> // std::pair<>
 #include <vector>
@@ -57,6 +58,10 @@ namespace sim {
                          const std::vector<sim::AuxDetHit>&,
                          size_t) const;
 
+    void MergeParticleAncestryMaps(std::vector<sim::ParticleAncestryMap>&,
+                                   const sim::ParticleAncestryMap&,
+                                   size_t) const;
+
     const std::vector<std::vector<size_t>>& GetMCParticleListMap() { return fMCParticleListMap; }
 
   private:
@@ -70,6 +75,8 @@ namespace sim {
     static sim::SimEnergyDeposit offsetSimEnergyDepositTrackID(sim::SimEnergyDeposit const&, int);
 
     static sim::AuxDetHit offsetAuxDetHitTrackID(sim::AuxDetHit const&, int);
+
+    static sim::ParticleAncestryMap offsetParticleAncestryMapTrackID(sim::ParticleAncestryMap const&, int);
 
   }; //end MergeSimSourcesUtility class
 

--- a/larsim/MergeSimSources/MergeSimSources_module.cc
+++ b/larsim/MergeSimSources/MergeSimSources_module.cc
@@ -115,8 +115,7 @@ public:
     fhicl::Atom<bool> FillParticleAncestryMaps{
       fhicl::Name{"FillParticleAncestryMaps"},
       fhicl::Comment{"whether to merge particle ancestry maps"},
-      true
-    };
+      true};
 
   }; // struct Config
 
@@ -231,9 +230,7 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
       }
     }
 
-    if (fFillParticleAncestryMaps) {
-      consumes<sim::ParticleAncestryMap>(tag);
-    }
+    if (fFillParticleAncestryMaps) { consumes<sim::ParticleAncestryMap>(tag); }
 
   } // for input labels
 
@@ -268,9 +265,7 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
       produces<std::vector<sim::AuxDetHit>>(auxdethit_inst);
   }
 
-  if (fFillParticleAncestryMaps) {
-    produces<std::vector<sim::ParticleAncestryMap>>();
-  }
+  if (fFillParticleAncestryMaps) { produces<std::vector<sim::ParticleAncestryMap>>(); }
 
   dumpConfiguration();
 }
@@ -367,11 +362,10 @@ void sim::MergeSimSources::produce(art::Event& e)
           auxdethitCol, e.getProduct<aux_det_hits_t>(auxdethit_tag), i_source);
       }
 
-    if (fFillParticleAncestryMaps) {
-      auto const& input_pamCol = e.getProduct<sim::ParticleAncestryMap>(input_label);
-      MergeUtility.MergeParticleAncestryMaps(*pamCol, input_pamCol, i_source);
-    }
-
+      if (fFillParticleAncestryMaps) {
+        auto const& input_pamCol = e.getProduct<sim::ParticleAncestryMap>(input_label);
+        MergeUtility.MergeParticleAncestryMaps(*pamCol, input_pamCol, i_source);
+      }
     }
   }
 
@@ -407,9 +401,7 @@ void sim::MergeSimSources::produce(art::Event& e)
     }
   }
 
-  if (fFillParticleAncestryMaps) {
-    e.put(std::move(pamCol));
-  }
+  if (fFillParticleAncestryMaps) { e.put(std::move(pamCol)); }
 }
 
 void sim::MergeSimSources::dumpConfiguration() const

--- a/larsim/MergeSimSources/MergeSimSources_module.cc
+++ b/larsim/MergeSimSources/MergeSimSources_module.cc
@@ -112,6 +112,12 @@ public:
                                "Other"} // default
     };
 
+    fhicl::Atom<bool> FillParticleAncestryMaps{
+      fhicl::Name{"FillParticleAncestryMaps"},
+      fhicl::Comment{"whether to merge particle ancestry maps"},
+      true
+    };
+
   }; // struct Config
 
   using Parameters = art::EDProducer::Table<Config>;
@@ -134,6 +140,7 @@ private:
   std::vector<std::string> const fEnergyDepositionInstances;
   bool const fFillAuxDetHits;
   std::vector<std::string> const fAuxDetHitsInstanceLabels;
+  bool const fFillParticleAncestryMaps;
 
   static std::string const ReflectedLabel;
 
@@ -176,6 +183,7 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
   , fEnergyDepositionInstances(params().EnergyDepositInstanceLabels())
   , fFillAuxDetHits(params().FillAuxDetHits())
   , fAuxDetHitsInstanceLabels(params().AuxDetHitsInstanceLabels())
+  , fFillParticleAncestryMaps(params().FillParticleAncestryMaps())
 {
 
   if (fInputSourcesLabels.size() != fTrackIDOffsets.size()) {
@@ -223,6 +231,10 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
       }
     }
 
+    if (fFillParticleAncestryMaps) {
+      consumes<sim::ParticleAncestryMap>(tag);
+    }
+
   } // for input labels
 
   if (fFillMCParticles) {
@@ -256,6 +268,10 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
       produces<std::vector<sim::AuxDetHit>>(auxdethit_inst);
   }
 
+  if (fFillParticleAncestryMaps) {
+    produces<std::vector<sim::ParticleAncestryMap>>();
+  }
+
   dumpConfiguration();
 }
 
@@ -271,6 +287,7 @@ void sim::MergeSimSources::produce(art::Event& e)
   auto tpassn =
     std::make_unique<art::Assns<simb::MCTruth, simb::MCParticle, sim::GeneratedParticleInfo>>();
   auto adCol = std::make_unique<std::vector<sim::AuxDetSimChannel>>();
+  auto pamCol = std::make_unique<std::vector<sim::ParticleAncestryMap>>();
 
   using edeps_t = std::vector<sim::SimEnergyDeposit>;
   std::vector<edeps_t> edepCols;
@@ -349,6 +366,12 @@ void sim::MergeSimSources::produce(art::Event& e)
         MergeUtility.MergeAuxDetHits(
           auxdethitCol, e.getProduct<aux_det_hits_t>(auxdethit_tag), i_source);
       }
+
+    if (fFillParticleAncestryMaps) {
+      auto const& input_pamCol = e.getProduct<sim::ParticleAncestryMap>(input_label);
+      MergeUtility.MergeParticleAncestryMaps(*pamCol, input_pamCol, i_source);
+    }
+
     }
   }
 
@@ -382,6 +405,10 @@ void sim::MergeSimSources::produce(art::Event& e)
          util::zip(fAuxDetHitsInstanceLabels, auxdethitCols)) {
       e.put(std::make_unique<aux_det_hits_t>(move(auxdethitCol)), auxdethit_inst);
     }
+  }
+
+  if (fFillParticleAncestryMaps) {
+    e.put(std::move(pamCol));
   }
 }
 
@@ -425,6 +452,8 @@ void sim::MergeSimSources::dumpConfiguration() const
       log << " '" << label << "'";
     log << ")";
   }
+
+  if (fFillParticleAncestryMaps) log << "\n - filling ParticleAncestryMaps";
 
 } // sim::MergeSimSources::dumpConfiguration()
 


### PR DESCRIPTION
Linked to LArSoft/lardataobj#34

This PR adds the new `sim::ParticleAncestryMap` to the MergeSimSources module.