### PR TITLE
Refactoring of PhotonPropagation classes to substantially reduce overhead

### DIFF
--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -17,6 +17,7 @@ cet_make_library(LIBRARY_NAME PhotonVisibilityTypes INTERFACE
 cet_make_library(SOURCE
   PhotonLibrary.cxx
   PhotonLibraryHybrid.cxx
+  PhotonPropagationUtils.cxx
   PropagationTimeModel.cxx
   SemiAnalyticalModel.cxx
   LIBRARIES

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -128,8 +128,6 @@ namespace phot {
     void produce(art::Event&) override;
 
   private:
-    void Initialization();
-
     void detectedNumPhotons(std::vector<int>& DetectedNumPhotons,
                             const std::vector<double>& OpDetVisibilities,
                             const int NumPhotons) const;
@@ -139,9 +137,7 @@ namespace phot {
                      const sim::OpDetBacktrackerRecord& btr) const;
 
     bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
-
-    // ISTPC
-    larg4::ISTPC fISTPC;
+    std::vector<geo::Point_t> opDetCenters() const;
 
     // semi-analytical model
     std::unique_ptr<SemiAnalyticalModel> fVisibilityModel;
@@ -153,22 +149,18 @@ namespace phot {
     CLHEP::HepRandomEngine& fPhotonEngine;
     std::unique_ptr<CLHEP::RandPoissonQ> fRandPoissPhot;
     CLHEP::HepRandomEngine& fScintTimeEngine;
-
-    size_t fNOpChannels; // Pulled from geom during Initialization()
+    std::unique_ptr<ScintTime> fScintTime; // Tool to retrieve timinig of scintillation
 
     // geometry properties
-    std::vector<geo::BoxBoundedGeo> fActiveVolumes;
-    int fNTPC;
-
-    // optical detector properties
-    std::vector<geo::Point_t> fOpDetCenter;
-
-    //////////////////////
-    // Input Parameters //
-    //////////////////////
+    geo::GeometryCore const& fGeom;
+    larg4::ISTPC fISTPC;
+    const size_t fNOpChannels;
+    const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
+    const int fNTPC;
+    const std::vector<geo::Point_t> fOpDetCenter;
 
     // Module behavior
-    const art::InputTag simTag;
+    const art::InputTag fSimTag;
     const bool fDoFastComponent;
     const bool fDoSlowComponent;
     const bool fDoReflectedLight;
@@ -179,30 +171,30 @@ namespace phot {
     const bool fOpaqueCathode;
     const bool fOnlyActiveVolume;
     const bool fOnlyOneCryostat;
-    std::unique_ptr<ScintTime> fScintTime; // Tool to retrive timinig of scintillation
-
-    // Parameterized Simulation
-    fhicl::ParameterSet fVUVTimingParams;
-    fhicl::ParameterSet fVISTimingParams;
-    fhicl::ParameterSet fVUVHitsParams;
-    fhicl::ParameterSet fVISHitsParams;
   };
 
   //......................................................................
   PDFastSimPAR::PDFastSimPAR(Parameters const& config)
     : art::EDProducer{config}
-    , fISTPC{*(lar::providerFrom<geo::Geometry>())}
     , fPhotonEngine(art::ServiceHandle<rndm::NuRandomService>()->createEngine(*this,
                                                                               "HepJamesRandom",
                                                                               "photon",
                                                                               config.get_PSet(),
                                                                               "SeedPhoton"))
+    , fRandPoissPhot(std::make_unique<CLHEP::RandPoissonQ>(fPhotonEngine))
     , fScintTimeEngine(art::ServiceHandle<rndm::NuRandomService>()->createEngine(*this,
                                                                                  "HepJamesRandom",
                                                                                  "scinttime",
                                                                                  config.get_PSet(),
                                                                                  "SeedScintTime"))
-    , simTag(config().SimulationLabel())
+    , fScintTime{art::make_tool<phot::ScintTime>(config().ScintTimeTool.get<fhicl::ParameterSet>())}
+    , fGeom(*(lar::providerFrom<geo::Geometry>()))
+    , fISTPC{fGeom}
+    , fNOpChannels(fGeom.NOpDets())
+    , fActiveVolumes(fISTPC.extractActiveLArVolume(fGeom))
+    , fNTPC(fGeom.NTPC())
+    , fOpDetCenter(opDetCenters())
+    , fSimTag(config().SimulationLabel())
     , fDoFastComponent(config().DoFastComponent())
     , fDoSlowComponent(config().DoSlowComponent())
     , fDoReflectedLight(config().DoReflectedLight())
@@ -213,39 +205,72 @@ namespace phot {
     , fOpaqueCathode(config().OpaqueCathode())
     , fOnlyActiveVolume(config().OnlyActiveVolume())
     , fOnlyOneCryostat(config().OnlyOneCryostat())
-    , fScintTime{art::make_tool<phot::ScintTime>(config().ScintTimeTool.get<fhicl::ParameterSet>())}
-    , fVUVHitsParams(config().VUVHits.get<fhicl::ParameterSet>())
   {
+    mf::LogInfo("PDFastSimPAR") << "Initializing PDFastSimPAR." << std::endl;
+
+    // Parameterized Simulation
+    fhicl::ParameterSet VUVHitsParams = config().VUVHits.get<fhicl::ParameterSet>();
+    fhicl::ParameterSet VUVTimingParams;
+    fhicl::ParameterSet VISHitsParams;
+    fhicl::ParameterSet VISTimingParams;
+
     // Validate configuration options
     if (fIncludePropTime &&
-        !config().VUVTiming.get_if_present<fhicl::ParameterSet>(fVUVTimingParams)) {
+        !config().VUVTiming.get_if_present<fhicl::ParameterSet>(VUVTimingParams)) {
       throw art::Exception(art::errors::Configuration)
         << "Propagation time simulation requested, but VUVTiming not specified."
         << "\n";
     }
-
-    if (fDoReflectedLight &&
-        !config().VISHits.get_if_present<fhicl::ParameterSet>(fVISHitsParams)) {
+    if ((fDoReflectedLight || fIncludeAnodeReflections) &&
+        !config().VISHits.get_if_present<fhicl::ParameterSet>(VISHitsParams)) {
       throw art::Exception(art::errors::Configuration)
-        << "Reflected light simulation requested, but VisHits not specified."
+        << "Reflected light or anode reflections simulation requested, but VisHits not specified."
         << "\n";
     }
-
     if (fDoReflectedLight && fIncludePropTime &&
-        !config().VISTiming.get_if_present<fhicl::ParameterSet>(fVISTimingParams)) {
+        !config().VISTiming.get_if_present<fhicl::ParameterSet>(VISTimingParams)) {
       throw art::Exception(art::errors::Configuration)
         << "Reflected light propagation time simulation requested, but VISTiming not specified."
         << "\n";
     }
-
-    if (fIncludeAnodeReflections &&
-        !config().VISHits.get_if_present<fhicl::ParameterSet>(fVISHitsParams)) {
-      throw art::Exception(art::errors::Configuration)
-        << "Anode reflections light simulation requested, but VisHits not specified."
-        << "\n";
+    if (fGeom.Ncryostats() > 1U) {
+      if (fOnlyOneCryostat) {
+        mf::LogWarning("PDFastSimPAR")
+          << std::string(80, '=') << "\nA detector with " << fGeom.Ncryostats()
+          << " cryostats is configured"
+          << " , and semi-analytic model is requested for scintillation photon propagation."
+          << " THIS CONFIGURATION IS NOT SUPPORTED and it is open to bugs"
+          << " (e.g. scintillation may be detected only in cryostat #0)."
+          << "\nThis would be normally a fatal error, but it has been forcibly overridden."
+          << "\n"
+          << std::string(80, '=');
+      }
+      else {
+        throw art::Exception(art::errors::Configuration)
+          << "Photon propagation via semi-analytic model is not supported yet"
+          << " on detectors with more than one cryostat.";
+      }
     }
 
-    Initialization();
+    // Initialise the Scintillation Time
+    fScintTime->initRand(fScintTimeEngine);
+
+    // photo-detector visibility model (semi-analytical model)
+    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(
+      VUVHitsParams, VISHitsParams, fDoReflectedLight, fIncludeAnodeReflections);
+
+    // propagation time model
+    if (fIncludePropTime)
+      fPropTimeModel = std::make_unique<PropagationTimeModel>(
+        VUVTimingParams, VISTimingParams, fScintTimeEngine, fDoReflectedLight, fGeoPropTimeOnly);
+
+    {
+      auto log = mf::LogTrace("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
+                                              << fActiveVolumes.size() << " volumes:";
+      for (auto const& [iCryo, box] : util::enumerate(fActiveVolumes)) {
+        log << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
+      }
+    }
 
     if (fUseLitePhotons) {
       mf::LogInfo("PDFastSimPAR") << "Using Lite Photons";
@@ -265,6 +290,9 @@ namespace phot {
         produces<std::vector<sim::SimPhotons>>("Reflected");
       }
     }
+    mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR Initialization finish.\n"
+                                << "Simulate using semi-analytic model for number of hits."
+                                << std::endl;
   }
 
   //......................................................................
@@ -306,8 +334,8 @@ namespace phot {
     }
 
     art::Handle<std::vector<sim::SimEnergyDeposit>> edepHandle;
-    if (!event.getByLabel(simTag, edepHandle)) {
-      mf::LogError("PDFastSimPAR") << "PDFastSimPAR Module Cannot getByLabel: " << simTag;
+    if (!event.getByLabel(fSimTag, edepHandle)) {
+      mf::LogError("PDFastSimPAR") << "PDFastSimPAR Module Cannot getByLabel: " << fSimTag;
       return;
     }
 
@@ -407,13 +435,9 @@ namespace phot {
               num_fastdp += n;
               for (int i = 0; i < n; ++i) {
                 // calculates the time at which the photon was produced
-                fScintTime->GenScintTime(true, fScintTimeEngine);
-                int time;
-                if (fIncludePropTime)
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime() +
-                                          transport_time[i]);
-                else
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                double dtime = edepi.StartT() + fScintTime->fastScintTime();
+                if (fIncludePropTime) dtime += transport_time[i];
+                int time = static_cast<int>(std::round(dtime));
                 if (Reflected)
                   ++ref_phlitcol[channel].DetectedPhotons[time];
                 else
@@ -425,13 +449,9 @@ namespace phot {
               int n = ndetected_slow;
               num_slowdp += n;
               for (int i = 0; i < n; ++i) {
-                fScintTime->GenScintTime(false, fScintTimeEngine);
-                int time;
-                if (fIncludePropTime)
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime() +
-                                          transport_time[ndetected_fast + i]);
-                else
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                double dtime = edepi.StartT() + fScintTime->slowScintTime();
+                if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
+                int time = static_cast<int>(std::round(dtime));
                 if (Reflected)
                   ++ref_phlitcol[channel].DetectedPhotons[time];
                 else
@@ -453,18 +473,15 @@ namespace phot {
               photon.Energy = 2.9 * CLHEP::eV; // 430 nm
             else
               photon.Energy = 9.7 * CLHEP::eV; // 128 nm
+            // TODO: un-hardcode and add another energy for Xe scintillation
             if (ndetected_fast > 0 && fDoFastComponent) {
               int n = ndetected_fast;
               num_fastdp += n;
               for (int i = 0; i < n; ++i) {
                 // calculates the time at which the photon was produced
-                fScintTime->GenScintTime(true, fScintTimeEngine);
-                int time;
-                if (fIncludePropTime)
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime() +
-                                          transport_time[i]);
-                else
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                double dtime = edepi.StartT() + fScintTime->fastScintTime();
+                if (fIncludePropTime) dtime += transport_time[i];
+                int time = static_cast<int>(std::round(dtime));
                 photon.Time = time;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
@@ -476,13 +493,9 @@ namespace phot {
               int n = ndetected_slow;
               num_slowdp += n;
               for (int i = 0; i < n; ++i) {
-                fScintTime->GenScintTime(false, fScintTimeEngine);
-                int time;
-                if (fIncludePropTime)
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime() +
-                                          transport_time[ndetected_fast + i]);
-                else
-                  time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
+                double dtime = edepi.StartT() + fScintTime->slowScintTime();
+                if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
+                int time = static_cast<int>(std::round(dtime));
                 photon.Time = time;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
@@ -541,63 +554,6 @@ namespace phot {
   }
 
   //......................................................................
-  void PDFastSimPAR::Initialization()
-  {
-    std::cout << "PDFastSimPAR Initialization" << std::endl;
-    std::cout << "Initializing the geometry of the detector." << std::endl;
-    std::cout << "Simulate using semi-analytic model for number of hits." << std::endl;
-
-    fRandPoissPhot = std::make_unique<CLHEP::RandPoissonQ>(fPhotonEngine);
-    geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry>());
-
-    // photo-detector visibility model (semi-analytical model)
-    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(
-      fVUVHitsParams, fVISHitsParams, fDoReflectedLight, fIncludeAnodeReflections);
-
-    // propagation time model
-    if (fIncludePropTime)
-      fPropTimeModel = std::make_unique<PropagationTimeModel>(
-        fVUVTimingParams, fVISTimingParams, fScintTimeEngine, fDoReflectedLight, fGeoPropTimeOnly);
-
-    // Store info from the Geometry service
-    fNOpChannels = geom.NOpDets();
-    fActiveVolumes = fISTPC.extractActiveLArVolume(geom);
-    fNTPC = geom.NTPC();
-
-    {
-      auto log = mf::LogTrace("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
-                                              << fActiveVolumes.size() << " volumes:";
-      for (auto const& [iCryo, box] : util::enumerate(fActiveVolumes)) {
-        log << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
-      }
-    } // local scope
-
-    if (geom.Ncryostats() > 1U) {
-      if (fOnlyOneCryostat) {
-        mf::LogWarning("PDFastSimPAR")
-          << std::string(80, '=') << "\nA detector with " << geom.Ncryostats()
-          << " cryostats is configured"
-          << " , and semi-analytic model is requested for scintillation photon propagation."
-          << " THIS CONFIGURATION IS NOT SUPPORTED and it is open to bugs"
-          << " (e.g. scintillation may be detected only in cryostat #0)."
-          << "\nThis would be normally a fatal error, but it has been forcibly overridden."
-          << "\n"
-          << std::string(80, '=');
-      }
-      else {
-        throw art::Exception(art::errors::Configuration)
-          << "Photon propagation via semi-analytic model is not supported yet"
-          << " on detectors with more than one cryostat.";
-      }
-    }
-
-    for (size_t const i : util::counter(fNOpChannels)) {
-      geo::OpDetGeo const& opDet = geom.OpDetGeoFromOpDet(i);
-      fOpDetCenter.push_back(opDet.GetCenter());
-    }
-  }
-
-  //......................................................................
   // calculates number of photons detected given visibility and emitted number of photons
   void PDFastSimPAR::detectedNumPhotons(std::vector<int>& DetectedNumPhotons,
                                         const std::vector<double>& OpDetVisibilities,
@@ -623,6 +579,15 @@ namespace phot {
     return true;
   }
 
+  std::vector<geo::Point_t> PDFastSimPAR::opDetCenters() const
+  {
+    std::vector<geo::Point_t> opDetCenter;
+    for (size_t const i : util::counter(fNOpChannels)) {
+      geo::OpDetGeo const& opDet = fGeom.OpDetGeoFromOpDet(i);
+      opDetCenter.push_back(opDet.GetCenter());
+    }
+    return opDetCenter;
+  }
   // ---------------------------------------------------------------------------
 
 } // namespace phot

--- a/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
+++ b/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
@@ -1,0 +1,135 @@
+////////////////////////////////////////////////////////////////////////
+// Description:
+// Utility functions
+////////////////////////////////////////////////////////////////////////
+#include "larsim/PhotonPropagation/PhotonPropagationUtils.h"
+
+namespace phot {
+
+  //......................................................................
+  double fast_acos(double x)
+  {
+    double negate = double(x < 0.);
+    x = std::abs(x);
+    x -= double(x > 1.) * (x - 1.); // <- equivalent to min(1.,x), but faster
+    double ret = -0.0187293;
+    ret = ret * x;
+    ret = ret + 0.0742610;
+    ret = ret * x;
+    ret = ret - 0.2121144;
+    ret = ret * x;
+    ret = ret + 1.5707288;
+    ret = ret * std::sqrt(1. - x);
+    ret = ret - 2. * negate * ret;
+    return negate * 3.14159265358979 + ret;
+  }
+
+  //......................................................................
+  // Returns interpolated value at x from parallel arrays ( xData, yData )
+  // Assumes that xData has at least two elements, is sorted and is strictly
+  // monotonic increasing boolean argument extrapolate determines behaviour
+  // beyond ends of array (if needed)
+  double interpolate(const std::vector<double>& xData,
+                     const std::vector<double>& yData,
+                     const double x,
+                     const bool extrapolate,
+                     size_t i)
+  {
+    if (i == 0) {
+      size_t size = xData.size();
+      if (x >= xData[size - 2]) { // special case: beyond right end
+        i = size - 2;
+      }
+      else {
+        while (x > xData[i + 1])
+          i++;
+      }
+    }
+    double xL = xData[i];
+    double xR = xData[i + 1];
+    double yL = yData[i];
+    double yR = yData[i + 1]; // points on either side (unless beyond ends)
+    if (!extrapolate) {       // if beyond ends of array and not extrapolating
+      if (x < xL) return yL;
+      if (x > xR) return yL;
+    }
+    const double dydx = (yR - yL) / (xR - xL); // gradient
+    return yL + dydx * (x - xL);               // linear interpolation
+  }
+
+  double interpolate2(const std::vector<double>& xDistances,
+                      const std::vector<double>& rDistances,
+                      const std::vector<std::vector<std::vector<double>>>& parameters,
+                      const double x,
+                      const double r,
+                      const size_t k)
+  {
+    // interpolate in x for each r bin, for angle bin k
+    const size_t nbins_r = parameters[k].size();
+    std::vector<double> interp_vals(nbins_r, 0.);
+
+    size_t idx = 0;
+    size_t size = xDistances.size();
+    if (x >= xDistances[size - 2])
+      idx = size - 2;
+    else {
+      while (x > xDistances[idx + 1])
+        idx++;
+    }
+    for (size_t i = 0; i < nbins_r; ++i) {
+      interp_vals[i] = interpolate(xDistances, parameters[k][i], x, false, idx);
+    }
+
+    // interpolate in r
+    double border_correction = interpolate(rDistances, interp_vals, r, false);
+    return border_correction;
+  }
+
+  //......................................................................
+  void interpolate3(std::array<double, 3>& inter,
+                    const std::vector<double>& xData,
+                    const std::vector<double>& yData1,
+                    const std::vector<double>& yData2,
+                    const std::vector<double>& yData3,
+                    const double x,
+                    const bool extrapolate)
+  {
+    size_t size = xData.size();
+    size_t i = 0;               // find left end of interval for interpolation
+    if (x >= xData[size - 2]) { // special case: beyond right end
+      i = size - 2;
+    }
+    else {
+      while (x > xData[i + 1])
+        i++;
+    }
+    double xL = xData[i];
+    double xR = xData[i + 1]; // points on either side (unless beyond ends)
+    double yL1 = yData1[i];
+    double yR1 = yData1[i + 1];
+    double yL2 = yData2[i];
+    double yR2 = yData2[i + 1];
+    double yL3 = yData3[i];
+    double yR3 = yData3[i + 1];
+
+    if (!extrapolate) { // if beyond ends of array and not extrapolating
+      if (x < xL) {
+        inter[0] = yL1;
+        inter[1] = yL2;
+        inter[2] = yL3;
+        return;
+      }
+      if (x > xR) {
+        inter[0] = yL1;
+        inter[1] = yL2;
+        inter[2] = yL3;
+        return;
+      }
+    }
+    const double m = (x - xL) / (xR - xL);
+    inter[0] = m * (yR1 - yL1) + yL1;
+    inter[1] = m * (yR2 - yL2) + yL2;
+    inter[2] = m * (yR3 - yL3) + yL3;
+  }
+
+} // namespace phot

--- a/larsim/PhotonPropagation/PhotonPropagationUtils.h
+++ b/larsim/PhotonPropagation/PhotonPropagationUtils.h
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////
+// Description:
+// Utility functions
+////////////////////////////////////////////////////////////////////////
+#ifndef PhotonPropagationUtils_H
+#define PhotonPropagationUtils_H
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace phot {
+  double fast_acos(double x);
+  double interpolate(const std::vector<double>& xData,
+                     const std::vector<double>& yData,
+                     const double x,
+                     const bool extrapolate,
+                     size_t i = 0);
+  double interpolate2(const std::vector<double>& xDistances,
+                      const std::vector<double>& rDistances,
+                      const std::vector<std::vector<std::vector<double>>>& parameters,
+                      const double x,
+                      const double r,
+                      const size_t k);
+  void interpolate3(std::array<double, 3>& inter,
+                    const std::vector<double>& xData,
+                    const std::vector<double>& yData1,
+                    const std::vector<double>& yData2,
+                    const std::vector<double>& yData3,
+                    const double x,
+                    const bool extrapolate);
+
+  // implements relative method - do not use for comparing with zero
+  // use this most of the time, tolerance needs to be meaningful in your context
+  template <typename TReal>
+  inline constexpr static bool
+  isApproximatelyEqual(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = std::fabs(a - b);
+    if (diff <= tolerance) return true;
+    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
+    return false;
+  }
+
+  // supply tolerance that is meaningful in your context
+  // for example, default tolerance may not work if you are comparing double with
+  // float
+  template <typename TReal>
+  inline constexpr static bool isApproximatelyZero(
+    TReal a,
+    TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    if (std::fabs(a) <= tolerance) return true;
+    return false;
+  }
+
+  // use this when you want to be on safe side
+  // for example, don't start rover unless signal is above 1
+  template <typename TReal>
+  inline constexpr static bool
+  isDefinitelyLessThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = a - b;
+    if (diff < tolerance) return true;
+    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
+    return false;
+  }
+
+  template <typename TReal>
+  inline constexpr static bool
+  isDefinitelyGreaterThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
+  {
+    TReal diff = a - b;
+    if (diff > tolerance) return true;
+    if (diff > std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
+    return false;
+  }
+
+} // namespace phot
+#endif

--- a/larsim/PhotonPropagation/PropagationTimeModel.cxx
+++ b/larsim/PhotonPropagation/PropagationTimeModel.cxx
@@ -1,4 +1,5 @@
 #include "PropagationTimeModel.h"
+#include "larsim/PhotonPropagation/PhotonPropagationUtils.h"
 
 // LArSoft libraries
 #include "larcore/CoreUtils/ServiceUtil.h"
@@ -7,7 +8,6 @@
 #include "larcorealg/Geometry/CryostatGeo.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/OpDetGeo.h"
-#include "larcorealg/Geometry/geo_vectors_utils_TVector.h" // geo::vect::toTVector3()
 
 // support libraries
 #include "cetlib_except/exception.h"
@@ -17,557 +17,454 @@
 
 #include <iostream>
 
-// constructor
-PropagationTimeModel::PropagationTimeModel(fhicl::ParameterSet VUVTimingParams,
-                                           fhicl::ParameterSet VISTimingParams,
-                                           CLHEP::HepRandomEngine& ScintTimeEngine,
-                                           bool doReflectedLight,
-                                           bool GeoPropTimeOnly)
-  : fVUVTimingParams(VUVTimingParams)
-  , fVISTimingParams(VISTimingParams)
-  , fdoReflectedLight(doReflectedLight)
-  , fGeoPropTimeOnly(GeoPropTimeOnly)
-  , fISTPC{*(lar::providerFrom<geo::Geometry>())}
-  , fScintTimeEngine(ScintTimeEngine)
-  , fUniformGen(fScintTimeEngine)
-{
-  // initialise parameters and geometry
-  mf::LogInfo("PropagationTimeModel") << "Photon propagation time model initalized." << std::endl;
-  Initialization();
-}
+namespace phot {
 
-// initialization
-void PropagationTimeModel::Initialization()
-{
-  // load photon propagation time model parameters
-  if (!fGeoPropTimeOnly) {
+  PropagationTimeModel::PropagationTimeModel(const fhicl::ParameterSet& VUVTimingParams,
+                                             const fhicl::ParameterSet& VISTimingParams,
+                                             CLHEP::HepRandomEngine& scintTimeEngine,
+                                             const bool doReflectedLight,
+                                             const bool GeoPropTimeOnly)
+    : fGeoPropTimeOnly(GeoPropTimeOnly)
+    , fUniformGen(scintTimeEngine)
+    , fGeom(*(lar::providerFrom<geo::Geometry>()))
+    , fplane_depth(std::abs(fGeom.TPC().GetCathodeCenter().X()))
+    , fOpDetCenter(opDetCenters())
+    , fOpDetOrientation(opDetOrientations())
+  {
+    mf::LogInfo("PropagationTimeModel")
+      << "Initializing Photon propagation time model." << std::endl;
+    if (!fGeoPropTimeOnly) {
+      // Direct / VUV
+      mf::LogInfo("PropagationTimeModel") << "Using VUV timing parameterization";
+      fstep_size = VUVTimingParams.get<double>("step_size");
+      fmin_d = VUVTimingParams.get<double>("min_d");
+      fvuv_vgroup_mean = VUVTimingParams.get<double>("vuv_vgroup_mean");
+      fvuv_vgroup_max = VUVTimingParams.get<double>("vuv_vgroup_max");
+      finflexion_point_distance = VUVTimingParams.get<double>("inflexion_point_distance");
+      fangle_bin_timing_vuv = VUVTimingParams.get<double>("angle_bin_timing_vuv");
+      generateVUVParams(VUVTimingParams, scintTimeEngine);
 
-    // Direct / VUV
-    mf::LogInfo("PropagationTimeModel") << "Using VUV timing parameterization";
-
-    fparameters[0] = std::vector(1, fVUVTimingParams.get<std::vector<double>>("Distances_landau"));
-    fparameters[1] = fVUVTimingParams.get<std::vector<std::vector<double>>>("Norm_over_entries");
-    fparameters[2] = fVUVTimingParams.get<std::vector<std::vector<double>>>("Mpv");
-    fparameters[3] = fVUVTimingParams.get<std::vector<std::vector<double>>>("Width");
-    fparameters[4] = std::vector(1, fVUVTimingParams.get<std::vector<double>>("Distances_exp"));
-    fparameters[5] = fVUVTimingParams.get<std::vector<std::vector<double>>>("Slope");
-    fparameters[6] =
-      fVUVTimingParams.get<std::vector<std::vector<double>>>("Expo_over_Landau_norm");
-
-    fstep_size = fVUVTimingParams.get<double>("step_size");
-    fmax_d = fVUVTimingParams.get<double>("max_d");
-    fmin_d = fVUVTimingParams.get<double>("min_d");
-    fvuv_vgroup_mean = fVUVTimingParams.get<double>("vuv_vgroup_mean");
-    fvuv_vgroup_max = fVUVTimingParams.get<double>("vuv_vgroup_max");
-    finflexion_point_distance = fVUVTimingParams.get<double>("inflexion_point_distance");
-    fangle_bin_timing_vuv = fVUVTimingParams.get<double>("angle_bin_timing_vuv");
-
-    // create vector of empty TF1s that will be replaced with the sampled
-    // parameterisations that are generated as they are required
-    const size_t num_params =
-      (fmax_d - fmin_d) /
-      fstep_size; // for d < fmin_d, no parameterisaton, a delta function is used instead
-    const size_t num_angles = std::round(90 / fangle_bin_timing_vuv);
-    fVUV_timing = std::vector(num_angles, std::vector(num_params, TF1()));
-
-    // initialise vectors to contain range parameterisations sampled to in each case
-    // when using TF1->GetRandom(xmin,xmax), must be in same range otherwise sampling
-    // is regenerated, this is the slow part!
-    fVUV_max = std::vector(num_angles, std::vector(num_params, 0.0));
-    fVUV_min = std::vector(num_angles, std::vector(num_params, 0.0));
-
-    // generate VUV parameters
-    for (size_t angle_bin = 0; angle_bin < num_angles; ++angle_bin) {
-      for (size_t index = 0; index < num_params; ++index) {
-        generateParam(index, angle_bin);
+      // Reflected / Visible
+      if (doReflectedLight) {
+        mf::LogInfo("PropagationTimeModel") << "Using VIS (reflected) timing parameterization";
+        fdistances_refl = VISTimingParams.get<std::vector<double>>("Distances_refl");
+        fradial_distances_refl = VISTimingParams.get<std::vector<double>>("Distances_radial_refl");
+        fcut_off_pars =
+          VISTimingParams.get<std::vector<std::vector<std::vector<double>>>>("Cut_off");
+        ftau_pars = VISTimingParams.get<std::vector<std::vector<std::vector<double>>>>("Tau");
+        fvis_vmean = VISTimingParams.get<double>("vis_vmean");
+        fangle_bin_timing_vis = VISTimingParams.get<double>("angle_bin_timing_vis");
       }
     }
 
-    // Reflected / Visible
-    if (fdoReflectedLight) {
-      mf::LogInfo("PropagationTimeModel") << "Using VIS (reflected) timing parameterization";
-
-      fdistances_refl = fVISTimingParams.get<std::vector<double>>("Distances_refl");
-      fradial_distances_refl = fVISTimingParams.get<std::vector<double>>("Distances_radial_refl");
-      fcut_off_pars =
-        fVISTimingParams.get<std::vector<std::vector<std::vector<double>>>>("Cut_off");
-      ftau_pars = fVISTimingParams.get<std::vector<std::vector<std::vector<double>>>>("Tau");
-      fvis_vmean = fVISTimingParams.get<double>("vis_vmean");
-      fangle_bin_timing_vis = fVISTimingParams.get<double>("angle_bin_timing_vis");
+    if (fGeoPropTimeOnly) {
+      mf::LogInfo("PropagationTimeModel") << "Using geometric VUV time propagation";
+      fvuv_vgroup_mean = VUVTimingParams.get<double>("vuv_vgroup_mean");
     }
+
+    mf::LogInfo("PropagationTimeModel") << "Photon propagation time model initalized." << std::endl;
   }
 
-  if (fGeoPropTimeOnly) {
-    mf::LogInfo("PropagationTimeModel") << "Using geometric VUV time propagation";
-    fvuv_vgroup_mean = fVUVTimingParams.get<double>("vuv_vgroup_mean");
-  }
+  //......................................................................
+  // Propagation time calculation function
+  void PropagationTimeModel::propagationTime(std::vector<double>& arrivalTimes,
+                                             const geo::Point_t& x0,
+                                             const size_t OpChannel,
+                                             const bool Reflected)
+  {
+    if (!fGeoPropTimeOnly) {
+      // Get VUV photons transport time distribution from the parametrization
+      geo::Point_t const& opDetCenter = fOpDetCenter[OpChannel];
+      if (!Reflected) {
+        double distance =
+          std::hypot(x0.X() - opDetCenter.X(), x0.Y() - opDetCenter.Y(), x0.Z() - opDetCenter.Z());
+        double cosine;
+        if (fOpDetOrientation[OpChannel] == 1)
+          cosine = std::abs(x0.Y() - opDetCenter.Y()) / distance;
+        else
+          cosine = std::abs(x0.X() - opDetCenter.X()) / distance;
 
-  // access information from the geometry service
-  geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry>());
-
-  // get TPC information
-  fplane_depth = std::abs(geom.TPC().GetCathodeCenter().X());
-  fActiveVolumes = fISTPC.extractActiveLArVolume(geom);
-  fcathode_centre = {
-    geom.TPC().GetCathodeCenter().X(), fActiveVolumes[0].CenterY(), fActiveVolumes[0].CenterZ()};
-
-  // get PDS information
-  nOpDets = geom.NOpDets();
-
-  fOpDetOrientation.reserve(nOpDets);
-  fOpDetCenter.reserve(nOpDets);
-  for (size_t const i : util::counter(nOpDets)) {
-
-    geo::OpDetGeo const& opDet = geom.OpDetGeoFromOpDet(i);
-    fOpDetCenter.push_back(opDet.GetCenter());
-
-    if (opDet.isSphere()) { // dome PMTs
-      fOpDetOrientation.push_back(0);
-    }
-    else if (opDet.isBar()) {
-      // determine orientation to get correction OpDet dimensions
-      if (opDet.Width() > opDet.Height()) { // laterals, Y dimension smallest
-        fOpDetOrientation.push_back(1);
+        double theta = fast_acos(cosine) * 180. / CLHEP::pi;
+        int angle_bin = theta / fangle_bin_timing_vuv;
+        getVUVTimes(arrivalTimes, distance, angle_bin); // in ns
       }
-      else { // anode/cathode (default), X dimension smallest
-        fOpDetOrientation.push_back(0);
+      else {
+        getVISTimes(arrivalTimes, x0, opDetCenter); // in ns
       }
     }
-    else {
-      fOpDetOrientation.push_back(0);
-    }
-  }
-}
-
-//......................................................................
-// Propagation time calculation function
-void PropagationTimeModel::propagationTime(std::vector<double>& arrival_time_dist,
-                                           geo::Point_t const& x0,
-                                           const size_t OpChannel,
-                                           bool Reflected)
-{
-  if (!fGeoPropTimeOnly) {
-    // Get VUV photons transport time distribution from the parametrization
-    geo::Point_t const& opDetCenter = fOpDetCenter[OpChannel];
-    if (!Reflected) {
+    else if (fGeoPropTimeOnly && !Reflected) {
+      // Get VUV photons arrival time geometrically
+      geo::Point_t const& opDetCenter = fOpDetCenter[OpChannel];
       double distance =
         std::hypot(x0.X() - opDetCenter.X(), x0.Y() - opDetCenter.Y(), x0.Z() - opDetCenter.Z());
-      double cosine;
-      if (fOpDetOrientation[OpChannel] == 1)
-        cosine = std::abs(x0.Y() - opDetCenter.Y()) / distance;
-      else
-        cosine = std::abs(x0.X() - opDetCenter.X()) / distance;
-
-      double theta = fast_acos(cosine) * 180. / CLHEP::pi;
-      int angle_bin = theta / fangle_bin_timing_vuv;
-      getVUVTimes(arrival_time_dist, distance, angle_bin); // in ns
+      getVUVTimesGeo(arrivalTimes, distance); // in ns
     }
     else {
-      getVISTimes(arrival_time_dist,
-                  geo::vect::toTVector3(x0),
-                  geo::vect::toTVector3(opDetCenter)); // in ns
+      throw cet::exception("PropagationTimeModel") << "Propagation time model not found.";
     }
   }
-  else if (fGeoPropTimeOnly && !Reflected) {
-    // Get VUV photons arrival time geometrically
-    geo::Point_t const& opDetCenter = fOpDetCenter[OpChannel];
-    double distance =
-      std::hypot(x0.X() - opDetCenter.X(), x0.Y() - opDetCenter.Y(), x0.Z() - opDetCenter.Z());
-    getVUVTimesGeo(arrival_time_dist, distance); // in ns
-  }
-  else {
-    throw cet::exception("PropagationTimeModel") << "Propagation time model not found.";
-  }
-}
 
-//......................................................................
-// VUV propagation times calculation function
-void PropagationTimeModel::getVUVTimes(std::vector<double>& arrivalTimes,
-                                       const double distance,
-                                       const size_t angle_bin)
-{
-  if (distance < fmin_d) {
+  //......................................................................
+  // VUV propagation times calculation function
+  void PropagationTimeModel::getVUVTimes(std::vector<double>& arrivalTimes,
+                                         const double distance,
+                                         const size_t angle_bin)
+  {
+    if (distance < fmin_d) {
+      // times are fixed shift i.e. direct path only
+      double t_prop_correction = distance / fvuv_vgroup_mean;
+      for (size_t i = 0; i < arrivalTimes.size(); ++i) {
+        arrivalTimes[i] = t_prop_correction;
+      }
+    }
+    else {
+      // determine nearest parameterisation in discretisation
+      int index = std::round((distance - fmin_d) / fstep_size);
+      // randomly sample parameterisation for each photon
+      for (size_t i = 0; i < arrivalTimes.size(); ++i) {
+        arrivalTimes[i] = fVUVTimingGen[angle_bin][index].fire() *
+                            (fVUV_max[angle_bin][index] - fVUV_min[angle_bin][index]) +
+                          fVUV_min[angle_bin][index];
+      }
+    }
+  }
+
+  //......................................................................
+  // VUV arrival times calculation function
+  // - pure geometric approximation for use in Xenon doped scenarios
+  void PropagationTimeModel::getVUVTimesGeo(std::vector<double>& arrivalTimes,
+                                            const double distance) const
+  {
     // times are fixed shift i.e. direct path only
     double t_prop_correction = distance / fvuv_vgroup_mean;
     for (size_t i = 0; i < arrivalTimes.size(); ++i) {
       arrivalTimes[i] = t_prop_correction;
     }
   }
-  else {
-    // determine nearest parameterisation in discretisation
-    int index = std::round((distance - fmin_d) / fstep_size);
-    // randomly sample parameterisation for each photon
-    for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-      arrivalTimes[i] = fVUV_timing[angle_bin][index].GetRandom(fVUV_min[angle_bin][index],
-                                                                fVUV_max[angle_bin][index]);
-    }
-  }
-}
 
-//......................................................................
-// VUV arrival times calculation function - pure geometric approximation for use in Xenon doped scenarios
-void PropagationTimeModel::getVUVTimesGeo(std::vector<double>& arrivalTimes, const double distance)
-{
-  // times are fixed shift i.e. direct path only
-  double t_prop_correction = distance / fvuv_vgroup_mean;
-  for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-    arrivalTimes[i] = t_prop_correction;
-  }
-}
+  //......................................................................
+  // VUV propagation times parameterization generation function
+  void PropagationTimeModel::generateVUVParams(const fhicl::ParameterSet& VUVTimingParams,
+                                               CLHEP::HepRandomEngine& scintTimeEngine)
+  {
+    mf::LogInfo("PropagationTimeModel") << "Generating VUV parameters";
+    double max_d = VUVTimingParams.get<double>("max_d");
+    const size_t num_params =
+      (max_d - fmin_d) / fstep_size; // for d < fmin_d, no parameterisaton, a
+                                     // delta function is used instead
+    const size_t num_angles = std::round(90. / fangle_bin_timing_vuv);
 
-//......................................................................
-// VUV propagation times parameterization generation function
-void PropagationTimeModel::generateParam(const size_t index, const size_t angle_bin)
-{
-  // get distance
-  double distance_in_cm = (index * fstep_size) + fmin_d;
+    // initialise vectors to contain range parameterisations
+    double dummy[1] = {1.};
+    fVUVTimingGen = std::vector(num_angles, std::vector(num_params, CLHEP::RandGeneral(dummy, 1)));
+    fVUV_max = std::vector(num_angles, std::vector(num_params, 0.0));
+    fVUV_min = std::vector(num_angles, std::vector(num_params, 0.0));
 
-  // time range
-  const double signal_t_range = 5000.;
+    std::vector<std::vector<double>> parameters[7];
+    parameters[0] = std::vector(1, VUVTimingParams.get<std::vector<double>>("Distances_landau"));
+    parameters[1] = VUVTimingParams.get<std::vector<std::vector<double>>>("Norm_over_entries");
+    parameters[2] = VUVTimingParams.get<std::vector<std::vector<double>>>("Mpv");
+    parameters[3] = VUVTimingParams.get<std::vector<std::vector<double>>>("Width");
+    parameters[4] = std::vector(1, VUVTimingParams.get<std::vector<double>>("Distances_exp"));
+    parameters[5] = VUVTimingParams.get<std::vector<std::vector<double>>>("Slope");
+    parameters[6] = VUVTimingParams.get<std::vector<std::vector<double>>>("Expo_over_Landau_norm");
 
-  // parameterisation TF1
-  TF1 VUVTiming;
+    // time range
+    const double signal_t_range = 5000.;
 
-  // direct path transport time
-  double t_direct_mean = distance_in_cm / fvuv_vgroup_mean;
-  double t_direct_min = distance_in_cm / fvuv_vgroup_max;
+    for (size_t index = 0; index < num_params; ++index) {
+      double distance_in_cm = (index * fstep_size) + fmin_d;
 
-  // Defining the model function(s) describing the photon transportation timing vs distance
-  // Getting the landau parameters from the time parametrization
-  std::array<double, 3> pars_landau;
-  interpolate3(pars_landau,
-               fparameters[0][0],
-               fparameters[2][angle_bin],
-               fparameters[3][angle_bin],
-               fparameters[1][angle_bin],
-               distance_in_cm,
-               true);
-  // Deciding which time model to use (depends on the distance)
-  // defining useful times for the VUV arrival time shapes
-  if (distance_in_cm >= finflexion_point_distance) {
-    double pars_far[4] = {t_direct_min, pars_landau[0], pars_landau[1], pars_landau[2]};
-    // Set model: Landau
-    VUVTiming = TF1("VUVTiming", model_far, 0, signal_t_range, 4);
-    VUVTiming.SetParameters(pars_far);
-  }
-  else {
-    // Set model: Landau + Exponential
-    VUVTiming = TF1("VUVTiming", model_close, 0, signal_t_range, 7);
-    // Exponential parameters
-    double pars_expo[2];
-    // Getting the exponential parameters from the time parametrization
-    pars_expo[1] = interpolate(fparameters[4][0], fparameters[5][angle_bin], distance_in_cm, true);
-    pars_expo[0] = interpolate(fparameters[4][0], fparameters[6][angle_bin], distance_in_cm, true);
-    pars_expo[0] *= pars_landau[2];
-    pars_expo[0] = std::log(pars_expo[0]);
-    // this is to find the intersection point between the two functions:
-    TF1 fint = TF1("fint", finter_d, pars_landau[0], 4 * t_direct_mean, 5);
-    double parsInt[5] = {
-      pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
-    fint.SetParameters(parsInt);
-    double t_int = fint.GetMinimumX();
-    double minVal = fint.Eval(t_int);
-    // the functions must intersect - output warning if they don't
-    if (minVal > 0.015) {
-      mf::LogWarning("PropagationTimeModel")
-        << "WARNING: Parametrization of VUV light discontinuous for distance = " << distance_in_cm
-        << std::endl;
-      mf::LogWarning("PropagationTimeModel")
-        << "WARNING: This shouldn't be happening " << std::endl;
-    }
-    double parsfinal[7] = {t_int,
-                           pars_landau[0],
-                           pars_landau[1],
-                           pars_landau[2],
-                           pars_expo[0],
-                           pars_expo[1],
-                           t_direct_min};
-    VUVTiming.SetParameters(parsfinal);
-  }
+      // direct path transport time
+      double t_direct_mean = distance_in_cm / fvuv_vgroup_mean;
+      double t_direct_min = distance_in_cm / fvuv_vgroup_max;
 
-  // set the number of points used to sample parameterisation
-  // for shorter distances, peak is sharper so more sensitive sampling required
-  int fsampling;
-  if (distance_in_cm < 50)
-    fsampling = 10000;
-  else if (distance_in_cm < 100)
-    fsampling = 5000;
-  else
-    fsampling = 1000;
-  VUVTiming.SetNpx(fsampling);
+      // number of sampling points, for shorter distances, peak is
+      // sharper so more sensitive sampling required
+      int sampling;
+      if (distance_in_cm < 2. * fmin_d)
+        sampling = 10000;
+      else if (distance_in_cm < 4. * fmin_d)
+        sampling = 5000;
+      else
+        sampling = 1000;
 
-  // calculate max and min distance relevant to sample parameterisation
-  // max
-  const size_t nq_max = 1;
-  double xq_max[nq_max];
-  double yq_max[nq_max];
-  xq_max[0] = 0.975; // include 97.5% of tail
-  VUVTiming.GetQuantiles(nq_max, yq_max, xq_max);
-  double max = yq_max[0];
-  // min
-  double min = t_direct_min;
-
-  // store TF1 and min/max, this allows identical TF1 to be used every time sampling
-  // the first call of GetRandom generates the timing sampling and stores it in the TF1 object, this is the slow part
-  // all subsequent calls check if it has been generated previously and are ~100+ times quicker
-  fVUV_timing[angle_bin][index] = VUVTiming;
-  fVUV_max[angle_bin][index] = max;
-  fVUV_min[angle_bin][index] = min;
-}
-
-//......................................................................
-// VIS arrival times calculation functions
-void PropagationTimeModel::getVISTimes(std::vector<double>& arrivalTimes,
-                                       const TVector3& ScintPoint,
-                                       const TVector3& OpDetPoint)
-{
-  // *************************************************************************************************
-  //     Calculation of earliest arrival times and corresponding unsmeared
-  //     distribution
-  // *************************************************************************************************
-
-  // set plane_depth for correct TPC:
-  double plane_depth;
-  if (ScintPoint[0] < 0)
-    plane_depth = -fplane_depth;
-  else
-    plane_depth = fplane_depth;
-
-  // calculate point of reflection for shortest path
-  TVector3 bounce_point(plane_depth, ScintPoint[1], ScintPoint[2]);
-
-  // calculate distance travelled by VUV light and by vis light
-  double VUVdist = (bounce_point - ScintPoint).Mag();
-  double Visdist = (OpDetPoint - bounce_point).Mag();
-
-  // calculate times taken by VUV part of path
-  int angle_bin_vuv = 0; // on-axis by definition
-  getVUVTimes(arrivalTimes, VUVdist, angle_bin_vuv);
-
-  // sum parts to get total transport times times
-  for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-    arrivalTimes[i] += Visdist / fvis_vmean;
-  }
-
-  // *************************************************************************************************
-  //      Smearing of arrival time distribution
-  // *************************************************************************************************
-  // calculate fastest time possible
-  // vis part
-  double vis_time = Visdist / fvis_vmean;
-  // vuv part
-  double vuv_time;
-  if (VUVdist < fmin_d) { vuv_time = VUVdist / fvuv_vgroup_max; }
-  else {
-    // find index of required parameterisation
-    const size_t index = std::round((VUVdist - fmin_d) / fstep_size);
-    // find shortest time
-    vuv_time = fVUV_min[angle_bin_vuv][index];
-  }
-  // sum
-  double fastest_time = vis_time + vuv_time;
-
-  // calculate angle theta between bound_point and optical detector
-  double cosine_theta = std::abs(OpDetPoint[0] - bounce_point[0]) / Visdist;
-  double theta = fast_acos(cosine_theta) * 180. / CLHEP::pi;
-
-  // determine smearing parameters using interpolation of generated points:
-  // 1). tau = exponential smearing factor, varies with distance and angle
-  // 2). cutoff = largest smeared time allowed, preventing excessively large
-  //     times caused by exponential distance to cathode
-  double distance_cathode_plane = std::abs(plane_depth - ScintPoint[0]);
-  // angular bin
-  size_t theta_bin = theta / fangle_bin_timing_vis;
-  // radial distance from centre of TPC (y,z plane)
-  double r = std::hypot(ScintPoint[1] - fcathode_centre[1], ScintPoint[2] - fcathode_centre[2]);
-
-  // cut-off and tau
-  // cut-off
-  // interpolate in d_c for each r bin
-  std::vector<double> interp_vals(fcut_off_pars[theta_bin].size(), 0.0);
-  for (size_t i = 0; i < fcut_off_pars[theta_bin].size(); i++) {
-    interp_vals[i] =
-      interpolate(fdistances_refl, fcut_off_pars[theta_bin][i], distance_cathode_plane, true);
-  }
-  // interpolate in r
-  double cutoff = interpolate(fradial_distances_refl, interp_vals, r, true);
-
-  // tau
-  // interpolate in x for each r bin
-  std::vector<double> interp_vals_tau(ftau_pars[theta_bin].size(), 0.0);
-  for (size_t i = 0; i < ftau_pars[theta_bin].size(); i++) {
-    interp_vals_tau[i] =
-      interpolate(fdistances_refl, ftau_pars[theta_bin][i], distance_cathode_plane, true);
-  }
-  // interpolate in r
-  double tau = interpolate(fradial_distances_refl, interp_vals_tau, r, true);
-
-  // apply smearing:
-  for (size_t i = 0; i < arrivalTimes.size(); ++i) {
-    double arrival_time_smeared;
-    // if time is already greater than cutoff, do not apply smearing
-    if (arrivalTimes[i] >= cutoff) { continue; }
-    // otherwise smear
-    else {
-      unsigned int counter = 0;
-      // loop until time generated is within cutoff limit
-      // most are within single attempt, very few take more than two
-      do {
-        // don't attempt smearings too many times
-        if (counter >= 10) {
-          arrival_time_smeared = arrivalTimes[i]; // don't smear
-          break;
+      for (size_t angle_bin = 0; angle_bin < num_angles; ++angle_bin) {
+        // Defining the model function(s) describing the photon
+        // transportation timing vs distance.
+        // Getting the landau parameters from the time parametrization
+        std::array<double, 3> pars_landau;
+        interpolate3(pars_landau,
+                     parameters[0][0],
+                     parameters[2][angle_bin],
+                     parameters[3][angle_bin],
+                     parameters[1][angle_bin],
+                     distance_in_cm,
+                     true);
+        TF1 VUVTiming;
+        // Deciding which time model to use (depends on the distance)
+        // defining useful times for the VUV arrival time shapes
+        if (distance_in_cm >= finflexion_point_distance) {
+          // Set model: Landau
+          double pars_far[4] = {t_direct_min, pars_landau[0], pars_landau[1], pars_landau[2]};
+          VUVTiming = TF1("VUVTiming", model_far, 0., signal_t_range, 4);
+          VUVTiming.SetParameters(pars_far);
         }
         else {
-          // generate random number in appropriate range
-          double x = fUniformGen.fire(0.5, 1.0);
-          // apply the exponential smearing
-          arrival_time_smeared =
-            arrivalTimes[i] + (arrivalTimes[i] - fastest_time) * (std::pow(x, -tau) - 1);
+          // Set model: Landau + Exponential
+          double pars_expo[2];
+          // Getting the exponential parameters from the time parametrization
+          pars_expo[1] =
+            interpolate(parameters[4][0], parameters[5][angle_bin], distance_in_cm, true);
+          pars_expo[0] =
+            interpolate(parameters[4][0], parameters[6][angle_bin], distance_in_cm, true);
+          pars_expo[0] *= pars_landau[2];
+          pars_expo[0] = std::log(pars_expo[0]);
+          // this is to find the intersection point between the two functions:
+          TF1 fint = TF1("fint", finter_d, pars_landau[0], 4. * t_direct_mean, 5);
+          double parsInt[5] = {
+            pars_landau[0], pars_landau[1], pars_landau[2], pars_expo[0], pars_expo[1]};
+          fint.SetParameters(parsInt);
+          double t_int = fint.GetMinimumX();
+          double minVal = fint.Eval(t_int);
+          // the functions must intersect - output warning if they don't
+          if (minVal > 0.015) {
+            mf::LogWarning("PropagationTimeModel")
+              << "WARNING: Parametrization of VUV light discontinuous for "
+                 "distance = "
+              << distance_in_cm << "\n"
+              << "This shouldn't be happening " << std::endl;
+          }
+          double parsfinal[7] = {t_int,
+                                 pars_landau[0],
+                                 pars_landau[1],
+                                 pars_landau[2],
+                                 pars_expo[0],
+                                 pars_expo[1],
+                                 t_direct_min};
+          VUVTiming = TF1("VUVTiming", model_close, 0., signal_t_range, 7);
+          VUVTiming.SetParameters(parsfinal);
         }
-        counter++;
-      } while (arrival_time_smeared > cutoff);
-    }
-    arrivalTimes[i] = arrival_time_smeared;
+
+        // store min/max, necessary to transform to the domain of the
+        // original distribution
+        // const size_t nq_max = 1;
+        double xq_max[1] = {0.975}; // include 97.5% of tail
+        double yq_max[1];
+        VUVTiming.SetNpx(sampling);
+        VUVTiming.GetQuantiles(1, yq_max, xq_max);
+        double max = yq_max[0];
+        double min = t_direct_min;
+        VUVTiming.SetRange(min, max);
+        fVUV_max[angle_bin][index] = max;
+        fVUV_min[angle_bin][index] = min;
+
+        // create the distributions that represent the parametrised timing,
+        // and use those to create a RNG that samples said distributions
+        auto hh = (TH1D*)VUVTiming.GetHistogram();
+        std::vector<double> vuv_timings(sampling, 0.);
+        for (int i = 0; i < sampling; ++i)
+          vuv_timings[i] = hh->GetBinContent(i + 1);
+        fVUVTimingGen[angle_bin][index] =
+          CLHEP::RandGeneral(scintTimeEngine, vuv_timings.data(), vuv_timings.size());
+      } // index < num_params
+    }   // angle_bin < num_angles
   }
-}
 
-//......................................................................
-double PropagationTimeModel::fast_acos(double x) const
-{
-  double negate = double(x < 0);
-  x = std::abs(x);
-  x -= double(x > 1.0) * (x - 1.0); // <- equivalent to min(1.0,x), but faster
-  double ret = -0.0187293;
-  ret = ret * x;
-  ret = ret + 0.0742610;
-  ret = ret * x;
-  ret = ret - 0.2121144;
-  ret = ret * x;
-  ret = ret + 1.5707288;
-  ret = ret * std::sqrt(1.0 - x);
-  ret = ret - 2. * negate * ret;
-  return negate * 3.14159265358979 + ret;
-}
+  //......................................................................
+  // VIS arrival times calculation functions
+  void PropagationTimeModel::getVISTimes(std::vector<double>& arrivalTimes,
+                                         const geo::Point_t& scintPoint,
+                                         const geo::Point_t& opDetPoint)
+  {
+    // ***************************************************************************
+    //     Calculation of earliest arrival times and corresponding unsmeared
+    //     distribution
+    // ***************************************************************************
 
-//......................................................................
-// Returns interpolated value at x from parallel arrays ( xData, yData )
-// Assumes that xData has at least two elements, is sorted and is strictly
-// monotonic increasing boolean argument extrapolate determines behaviour
-// beyond ends of array (if needed)
-double PropagationTimeModel::interpolate(const std::vector<double>& xData,
-                                         const std::vector<double>& yData,
-                                         double x,
-                                         bool extrapolate,
-                                         size_t i) const
-{
-  if (i == 0) {
-    size_t size = xData.size();
-    if (x >= xData[size - 2]) { // special case: beyond right end
-      i = size - 2;
+    // set plane_depth for correct TPC:
+    double plane_depth;
+    if (scintPoint.X() < 0.)
+      plane_depth = -fplane_depth;
+    else
+      plane_depth = fplane_depth;
+
+    // calculate point of reflection for shortest path
+    geo::Point_t bounce_point(plane_depth, scintPoint.Y(), scintPoint.Z());
+
+    // calculate distance travelled by VUV light and by vis light
+    double VUVdist = std::sqrt((bounce_point - scintPoint).Mag2());
+    double Visdist = std::sqrt((opDetPoint - bounce_point).Mag2());
+
+    // calculate times taken by VUV part of path
+    int angle_bin_vuv = 0; // on-axis by definition
+    getVUVTimes(arrivalTimes, VUVdist, angle_bin_vuv);
+
+    // sum parts to get total transport times times
+    for (size_t i = 0; i < arrivalTimes.size(); ++i) {
+      arrivalTimes[i] += Visdist / fvis_vmean;
     }
+
+    // ***************************************************************************
+    //      Smearing of arrival time distribution
+    // ***************************************************************************
+    // calculate fastest time possible
+    // vis part
+    double vis_time = Visdist / fvis_vmean;
+    // vuv part
+    double vuv_time;
+    if (VUVdist < fmin_d) { vuv_time = VUVdist / fvuv_vgroup_max; }
     else {
-      while (x > xData[i + 1])
-        i++;
+      // find index of required parameterisation
+      const size_t index = std::round((VUVdist - fmin_d) / fstep_size);
+      // find shortest time
+      vuv_time = fVUV_min[angle_bin_vuv][index];
+    }
+    double fastest_time = vis_time + vuv_time;
+
+    // calculate angle theta between bound_point and optical detector
+    double cosine_theta = std::abs(opDetPoint.X() - bounce_point.X()) / Visdist;
+    double theta = fast_acos(cosine_theta) * 180. / CLHEP::pi;
+
+    // determine smearing parameters using interpolation of generated points:
+    // 1). tau = exponential smearing factor, varies with distance and angle
+    // 2). cutoff = largest smeared time allowed, preventing excessively large
+    //     times caused by exponential distance to cathode
+    double distance_cathode_plane = std::abs(plane_depth - scintPoint.X());
+    // angular bin
+    size_t theta_bin = theta / fangle_bin_timing_vis;
+    // radial distance from centre of TPC (y,z plane)
+    double r =
+      std::hypot(scintPoint.Y() - fcathode_centre.Y(), scintPoint.Z() - fcathode_centre.Z());
+
+    // cut-off and tau
+    // cut-off
+    // interpolate in d_c for each r bin
+    std::vector<double> interp_vals(fcut_off_pars[theta_bin].size(), 0.0);
+    for (size_t i = 0; i < fcut_off_pars[theta_bin].size(); i++) {
+      interp_vals[i] =
+        interpolate(fdistances_refl, fcut_off_pars[theta_bin][i], distance_cathode_plane, true);
+    }
+    // interpolate in r
+    double cutoff = interpolate(fradial_distances_refl, interp_vals, r, true);
+
+    // tau
+    // interpolate in x for each r bin
+    std::vector<double> interp_vals_tau(ftau_pars[theta_bin].size(), 0.0);
+    for (size_t i = 0; i < ftau_pars[theta_bin].size(); i++) {
+      interp_vals_tau[i] =
+        interpolate(fdistances_refl, ftau_pars[theta_bin][i], distance_cathode_plane, true);
+    }
+    // interpolate in r
+    double tau = interpolate(fradial_distances_refl, interp_vals_tau, r, true);
+
+    // apply smearing:
+    for (size_t i = 0; i < arrivalTimes.size(); ++i) {
+      double arrival_time_smeared;
+      // if time is already greater than cutoff, do not apply smearing
+      if (arrivalTimes[i] >= cutoff) { continue; }
+      // otherwise smear
+      else {
+        unsigned int counter = 0;
+        // loop until time generated is within cutoff limit
+        // most are within single attempt, very few take more than two
+        do {
+          // don't attempt smearings too many times
+          if (counter >= 10) {
+            arrival_time_smeared = arrivalTimes[i]; // don't smear
+            break;
+          }
+          else {
+            // generate random number in appropriate range
+            double x = fUniformGen.fire(0.5, 1.0);
+            // apply the exponential smearing
+            arrival_time_smeared =
+              arrivalTimes[i] + (arrivalTimes[i] - fastest_time) * (std::pow(x, -tau) - 1);
+          }
+          counter++;
+        } while (arrival_time_smeared > cutoff);
+      }
+      arrivalTimes[i] = arrival_time_smeared;
     }
   }
-  double xL = xData[i];
-  double xR = xData[i + 1];
-  double yL = yData[i];
-  double yR = yData[i + 1]; // points on either side (unless beyond ends)
-  if (!extrapolate) {       // if beyond ends of array and not extrapolating
-    if (x < xL) return yL;
-    if (x > xR) return yL;
-  }
-  const double dydx = (yR - yL) / (xR - xL); // gradient
-  return yL + dydx * (x - xL);               // linear interpolation
-}
 
-//......................................................................
-void PropagationTimeModel::interpolate3(std::array<double, 3>& inter,
-                                        const std::vector<double>& xData,
-                                        const std::vector<double>& yData1,
-                                        const std::vector<double>& yData2,
-                                        const std::vector<double>& yData3,
-                                        double x,
-                                        bool extrapolate)
-{
-  size_t size = xData.size();
-  size_t i = 0;               // find left end of interval for interpolation
-  if (x >= xData[size - 2]) { // special case: beyond right end
-    i = size - 2;
+  geo::Point_t PropagationTimeModel::cathodeCentre() const
+  {
+    larg4::ISTPC is_tpc = larg4::ISTPC{fGeom};
+    std::vector<geo::BoxBoundedGeo> activeVolumes = is_tpc.extractActiveLArVolume(fGeom);
+    geo::Point_t cathode_centre = {
+      fGeom.TPC().GetCathodeCenter().X(), activeVolumes[0].CenterY(), activeVolumes[0].CenterZ()};
+    return cathode_centre;
   }
-  else {
-    while (x > xData[i + 1])
-      i++;
-  }
-  double xL = xData[i];
-  double xR = xData[i + 1]; // points on either side (unless beyond ends)
-  double yL1 = yData1[i];
-  double yR1 = yData1[i + 1];
-  double yL2 = yData2[i];
-  double yR2 = yData2[i + 1];
-  double yL3 = yData3[i];
-  double yR3 = yData3[i + 1];
 
-  if (!extrapolate) { // if beyond ends of array and not extrapolating
-    if (x < xL) {
-      inter[0] = yL1;
-      inter[1] = yL2;
-      inter[2] = yL3;
-      return;
+  std::vector<geo::Point_t> PropagationTimeModel::opDetCenters() const
+  {
+    std::vector<geo::Point_t> opDetCenter;
+    for (size_t const i : util::counter(fGeom.NOpDets())) {
+      geo::OpDetGeo const& opDet = fGeom.OpDetGeoFromOpDet(i);
+      opDetCenter.push_back(opDet.GetCenter());
     }
-    if (x > xR) {
-      inter[0] = yL1;
-      inter[1] = yL2;
-      inter[2] = yL3;
-      return;
-    }
+    return opDetCenter;
   }
-  const double m = (x - xL) / (xR - xL);
-  inter[0] = m * (yR1 - yL1) + yL1;
-  inter[1] = m * (yR2 - yL2) + yL2;
-  inter[2] = m * (yR3 - yL3) + yL3;
-}
 
-//......................................................................
-double PropagationTimeModel::finter_d(const double* x, const double* par)
-{
-  double y1 = par[2] * TMath::Landau(x[0], par[0], par[1]);
-  double y2 = TMath::Exp(par[3] + x[0] * par[4]);
+  std::vector<int> PropagationTimeModel::opDetOrientations() const
+  {
+    std::vector<int> opDetOrientation;
+    for (size_t const i : util::counter(fGeom.NOpDets())) {
+      geo::OpDetGeo const& opDet = fGeom.OpDetGeoFromOpDet(i);
+      if (opDet.isSphere()) { // dome PMTs
+        opDetOrientation.push_back(0);
+      }
+      else if (opDet.isBar()) {
+        // determine orientation to get correction OpDet dimensions
+        if (opDet.Width() > opDet.Height()) { // laterals, Y dimension smallest
+          opDetOrientation.push_back(1);
+        }
+        else { // anode/cathode (default), X dimension smallest
+          opDetOrientation.push_back(0);
+        }
+      }
+      else {
+        opDetOrientation.push_back(0);
+      }
+    }
+    return opDetOrientation;
+  }
 
-  return TMath::Abs(y1 - y2);
-}
+  //......................................................................
+  double PropagationTimeModel::finter_d(const double* x, const double* par)
+  {
+    double y1 = par[2] * TMath::Landau(x[0], par[0], par[1]);
+    double y2 = TMath::Exp(par[3] + x[0] * par[4]);
+    return TMath::Abs(y1 - y2);
+  }
 
-//......................................................................
-double PropagationTimeModel::model_close(const double* x, const double* par)
-{
-  // par0 = joining point
-  // par1 = Landau MPV
-  // par2 = Landau width
-  // par3 = normalization
-  // par4 = Expo cte
-  // par5 = Expo tau
-  // par6 = t_min
+  //......................................................................
+  double PropagationTimeModel::model_close(const double* x, const double* par)
+  {
+    // par0 = joining point
+    // par1 = Landau MPV
+    // par2 = Landau width
+    // par3 = normalization
+    // par4 = Expo cte
+    // par5 = Expo tau
+    // par6 = t_min
+    double y1 = par[3] * TMath::Landau(x[0], par[1], par[2]);
+    double y2 = TMath::Exp(par[4] + x[0] * par[5]);
+    if (x[0] <= par[6] || x[0] > par[0]) y1 = 0.;
+    if (x[0] < par[0]) y2 = 0.;
+    return (y1 + y2);
+  }
 
-  double y1 = par[3] * TMath::Landau(x[0], par[1], par[2]);
-  double y2 = TMath::Exp(par[4] + x[0] * par[5]);
-  if (x[0] <= par[6] || x[0] > par[0]) y1 = 0.;
-  if (x[0] < par[0]) y2 = 0.;
+  //......................................................................
+  double PropagationTimeModel::model_far(const double* x, const double* par)
+  {
+    // par1 = Landau MPV
+    // par2 = Landau width
+    // par3 = normalization
+    // par0 = t_min
+    if (x[0] <= par[0]) return 0.;
+    return par[3] * TMath::Landau(x[0], par[1], par[2]);
+  }
 
-  return (y1 + y2);
-}
-
-//......................................................................
-double PropagationTimeModel::model_far(const double* x, const double* par)
-{
-  // par1 = Landau MPV
-  // par2 = Landau width
-  // par3 = normalization
-  // par0 = t_min
-
-  double y = par[3] * TMath::Landau(x[0], par[1], par[2]);
-  if (x[0] <= par[0]) y = 0.;
-
-  return y;
-}
+} // namespace phot

--- a/larsim/PhotonPropagation/PropagationTimeModel.h
+++ b/larsim/PhotonPropagation/PropagationTimeModel.h
@@ -3,8 +3,9 @@
 
 // PropagationTimeModel
 //  - parameterized fast optical simulation of photon propagation times
-//  - contains functions to calculate the propagation times of direct and reflected photons incident
-//  each photo-detector, along with the necessary ultility functions
+//  - contains functions to calculate the propagation times of direct and
+//  reflected photons incident each photo-detector, along with the necessary
+//  ultility functions
 //  - full description of model: Eur. Phys. J. C 81, 349 (2021)
 
 // Nov 2021 by P. Green
@@ -18,116 +19,97 @@
 #include "fhiclcpp/ParameterSet.h"
 
 #include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandGeneral.h"
 
 namespace CLHEP {
   class HepRandomEngine;
 }
 
-// other
+// ROOT headers
 #include "TF1.h"
-#include "TVector3.h"
+#include "TH1D.h"
 
 #include <array>
 #include <vector>
 
-class PropagationTimeModel {
+namespace phot {
 
-public:
-  // constructor
-  PropagationTimeModel(fhicl::ParameterSet VUVTimingParams,
-                       fhicl::ParameterSet VISTimingParams,
-                       CLHEP::HepRandomEngine& ScintTimeEngine,
-                       bool doReflectedLight = false,
-                       bool GeoPropTimeOnly = false);
+  class PropagationTimeModel {
 
-  // propagation time
-  void propagationTime(std::vector<double>& arrival_time_dist,
-                       geo::Point_t const& x0,
-                       const size_t OpChannel,
-                       bool Reflected = false);
+  public:
+    // constructor
+    PropagationTimeModel(const fhicl::ParameterSet& VUVTimingParams,
+                         const fhicl::ParameterSet& VISTimingParams,
+                         CLHEP::HepRandomEngine& scintTimeEngine,
+                         const bool doReflectedLight = false,
+                         const bool GeoPropTimeOnly = false);
 
-private:
-  // parameter and geometry initialization
-  void Initialization();
+    // propagation time
+    void propagationTime(std::vector<double>& arrivalTimes,
+                         const geo::Point_t& x0,
+                         const size_t OpChannel,
+                         const bool Reflected = false);
 
-  // direct / VUV light
-  void getVUVTimes(std::vector<double>& arrivalTimes,
-                   const double distance_in_cm,
-                   const size_t angle_bin);
+  private:
+    void generateVUVParams(const fhicl::ParameterSet& VUVTimingParams,
+                           CLHEP::HepRandomEngine& scintTimeEngine);
 
-  void getVUVTimesGeo(std::vector<double>& arrivalTimes, const double distance_in_cm);
+    // direct / VUV light
+    void getVUVTimes(std::vector<double>& arrivalTimes,
+                     const double distance_in_cm,
+                     const size_t angle_bin);
 
-  void generateParam(const size_t index, const size_t angle_bin);
+    void getVUVTimesGeo(std::vector<double>& arrivalTimes, const double distance_in_cm) const;
 
-  // reflected / visible light
-  void getVISTimes(std::vector<double>& arrivalTimes,
-                   const TVector3& ScintPoint,
-                   const TVector3& OpDetPoint);
+    // reflected / visible light
+    void getVISTimes(std::vector<double>& arrivalTimes,
+                     const geo::Point_t& scintPoint,
+                     const geo::Point_t& opDetPoint);
 
-  // utility functions
-  double fast_acos(double x) const;
+    geo::Point_t cathodeCentre() const;
+    std::vector<geo::Point_t> opDetCenters() const;
+    std::vector<int> opDetOrientations() const;
 
-  double interpolate(const std::vector<double>& xData,
-                     const std::vector<double>& yData,
-                     double x,
-                     bool extrapolate,
-                     size_t i = 0) const;
+    // utility functions
+    static double finter_d(const double* x, const double* par);
 
-  void interpolate3(std::array<double, 3>& inter,
-                    const std::vector<double>& xData,
-                    const std::vector<double>& yData1,
-                    const std::vector<double>& yData2,
-                    const std::vector<double>& yData3,
-                    double x,
-                    bool extrapolate);
+    static double model_close(const double* x, const double* par);
 
-  static double finter_d(const double* x, const double* par);
+    static double model_far(const double* x, const double* par);
 
-  static double model_close(const double* x, const double* par);
+    // configuration
+    const bool fGeoPropTimeOnly;
 
-  static double model_far(const double* x, const double* par);
+    // random numbers
+    CLHEP::RandFlat fUniformGen;
 
-  // fhicl parameter sets
-  const fhicl::ParameterSet fVUVTimingParams;
-  const fhicl::ParameterSet fVISTimingParams;
+    // geometry properties
+    geo::GeometryCore const& fGeom;
+    const double fplane_depth;
+    const geo::Point_t fcathode_centre;
 
-  // configuration
-  const bool fdoReflectedLight;
-  const bool fGeoPropTimeOnly;
+    // photodetector geometry properties
+    const std::vector<geo::Point_t> fOpDetCenter;
+    const std::vector<int> fOpDetOrientation;
 
-  // ISTPC class
-  larg4::ISTPC fISTPC;
+    // For VUV propagation time parametrization
+    double fstep_size, fvuv_vgroup_mean, fvuv_vgroup_max, fmin_d, finflexion_point_distance,
+      fangle_bin_timing_vuv;
+    // vector containing generated VUV timing parameterisations
+    std::vector<std::vector<CLHEP::RandGeneral>> fVUVTimingGen;
+    // vector containing min and max range VUV timing parameterisations are
+    // sampled to
+    std::vector<std::vector<double>> fVUV_max;
+    std::vector<std::vector<double>> fVUV_min;
 
-  // random numbers
-  CLHEP::HepRandomEngine& fScintTimeEngine;
-  CLHEP::RandFlat fUniformGen;
+    // For VIS propagation time parameterisation
+    double fvis_vmean, fangle_bin_timing_vis;
+    std::vector<double> fdistances_refl;
+    std::vector<double> fradial_distances_refl;
+    std::vector<std::vector<std::vector<double>>> fcut_off_pars;
+    std::vector<std::vector<std::vector<double>>> ftau_pars;
+  };
 
-  // geometry properties
-  double fplane_depth;
-  TVector3 fcathode_centre;
-  std::vector<geo::BoxBoundedGeo> fActiveVolumes;
-
-  // photodetector geometry properties
-  size_t nOpDets;
-  std::vector<geo::Point_t> fOpDetCenter;
-  std::vector<int> fOpDetOrientation;
-
-  // For VUV propagation time parametrization
-  double fstep_size, fmax_d, fmin_d, fvuv_vgroup_mean, fvuv_vgroup_max, finflexion_point_distance,
-    fangle_bin_timing_vuv;
-  std::vector<std::vector<double>> fparameters[7];
-  // vector containing generated VUV timing parameterisations
-  std::vector<std::vector<TF1>> fVUV_timing;
-  // vector containing min and max range VUV timing parameterisations are sampled to
-  std::vector<std::vector<double>> fVUV_max;
-  std::vector<std::vector<double>> fVUV_min;
-
-  // For VIS propagation time parameterisation
-  double fvis_vmean, fangle_bin_timing_vis;
-  std::vector<double> fdistances_refl;
-  std::vector<double> fradial_distances_refl;
-  std::vector<std::vector<std::vector<double>>> fcut_off_pars;
-  std::vector<std::vector<std::vector<double>>> ftau_pars;
-};
+} // namespace phot
 
 #endif

--- a/larsim/PhotonPropagation/ScintTimeTools/ScintTime.h
+++ b/larsim/PhotonPropagation/ScintTimeTools/ScintTime.h
@@ -17,8 +17,11 @@ namespace phot {
   public:
     virtual ~ScintTime() = default;
 
+    virtual void initRand(CLHEP::HepRandomEngine& engine) = 0;
     virtual void GenScintTime(bool is_fast, CLHEP::HepRandomEngine& engine) = 0;
     double GetScintTime() const { return timing; }
+    virtual double fastScintTime() = 0;
+    virtual double slowScintTime() = 0;
 
   protected:
     // FIXME: This should be private, with a protected setter.

--- a/larsim/PhotonPropagation/ScintTimeTools/ScintTimeLAr.h
+++ b/larsim/PhotonPropagation/ScintTimeTools/ScintTimeLAr.h
@@ -9,7 +9,12 @@
 #ifndef ScintTimeLAr_H
 #define ScintTimeLAr_H
 
+// Random number engine
+#include "CLHEP/Random/RandFlat.h"
+
 #include "larsim/PhotonPropagation/ScintTimeTools/ScintTime.h"
+
+#include <memory>
 
 namespace fhicl {
   class ParameterSet;
@@ -19,20 +24,25 @@ namespace phot {
   class ScintTimeLAr : public ScintTime {
   public:
     explicit ScintTimeLAr(fhicl::ParameterSet const& pset);
+    void initRand(CLHEP::HepRandomEngine& engine);
     void GenScintTime(bool is_fast, CLHEP::HepRandomEngine& engine);
+    double fastScintTime();
+    double slowScintTime();
 
   private:
     int LogLevel;
-
-    // parameters for the shape of argon scinitllation light time distribution
-    double SRTime; // PureLAr: rising time of slow LAr scinitllation;
-    double SDTime; // PureLAr: decay time of slow LAr scintillation;
-    double FRTime; // PureLAr: rising time of fast LAr scinitllation;
-    double FDTime; // PureLAr: decay time of fast LAr scintillation;
+    std::unique_ptr<CLHEP::RandFlat> fUniformGen;
+    // parameters for the shape of argon scintillation light time distribution
+    const double SRTime; // PureLAr: rising time of slow LAr scintillation;
+    const double SDTime; // PureLAr: decay time of slow LAr scintillation;
+    const double FRTime; // PureLAr: rising time of fast LAr scintillation;
+    const double FDTime; // PureLAr: decay time of fast LAr scintillation;
+    const bool fNoFastRisingTime, fNoSlowRisingTime;
 
     // general functions
     double single_exp(double t, double tau2) const;
     double bi_exp(double t, double tau1, double tau2) const;
+    double with_rising_time(double tau1, double tau2);
   };
 }
 #endif

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -1,4 +1,5 @@
 #include "SemiAnalyticalModel.h"
+#include "larsim/PhotonPropagation/PhotonPropagationUtils.h"
 
 // LArSoft Libraries
 #include "larcore/CoreUtils/ServiceUtil.h"
@@ -21,821 +22,748 @@
 #include "boost/math/special_functions/ellint_1.hpp"
 #include "boost/math/special_functions/ellint_3.hpp"
 
-// constructor
-SemiAnalyticalModel::SemiAnalyticalModel(fhicl::ParameterSet VUVHits,
-                                         fhicl::ParameterSet VISHits,
-                                         bool doReflectedLight,
-                                         bool includeAnodeReflections)
-  : fVUVHitsParams(VUVHits)
-  , fVISHitsParams(VISHits)
-  , fISTPC{*(lar::providerFrom<geo::Geometry>())}
-  , fGeom{*(lar::providerFrom<geo::Geometry>())}
-  , fNTPC(fGeom.NTPC())
-  , fActiveVolumes(fISTPC.extractActiveLArVolume(fGeom))
-  , fcathode_centre{fGeom.TPC().GetCathodeCenter().X(),
+namespace phot {
+
+  // constructor
+  SemiAnalyticalModel::SemiAnalyticalModel(const fhicl::ParameterSet& VUVHitsParams,
+                                           const fhicl::ParameterSet& VISHitsParams,
+                                           const bool doReflectedLight,
+                                           const bool includeAnodeReflections)
+    : fGeom{*(lar::providerFrom<geo::Geometry>())}
+    , fISTPC{fGeom}
+    , fNTPC(fGeom.NTPC())
+    , fActiveVolumes(fISTPC.extractActiveLArVolume(fGeom))
+    , fcathode_centre{fGeom.TPC().GetCathodeCenter().X(),
+                      fActiveVolumes[0].CenterY(),
+                      fActiveVolumes[0].CenterZ()}
+    , fanode_centre{fGeom.TPC().FirstPlane().GetCenter().X(),
                     fActiveVolumes[0].CenterY(),
                     fActiveVolumes[0].CenterZ()}
-  , fanode_centre{fGeom.TPC().FirstPlane().GetCenter().X(),
-                  fActiveVolumes[0].CenterY(),
-                  fActiveVolumes[0].CenterZ()}
-  , nOpDets(fGeom.NOpDets())
-  , fvuv_absorption_length(VUVAbsorptionLength())
-  , fDoReflectedLight(doReflectedLight)
-  , fIncludeAnodeReflections(includeAnodeReflections)
-{
-  // initialise parameters and geometry
-  mf::LogInfo("SemiAnalyticalModel") << "Semi-analytical model initialized." << std::endl;
-  Initialization();
-}
+    , fNOpDets(fGeom.NOpDets())
+    , fOpDetector(opticalDetectors())
+    , fvuv_absorption_length(VUVAbsorptionLength())
+    , fDoReflectedLight(doReflectedLight)
+    , fIncludeAnodeReflections(includeAnodeReflections)
+  {
+    mf::LogInfo("SemiAnalyticalModel") << "Initializing Semi-analytical model." << std::endl;
 
-// initialization
-void SemiAnalyticalModel::Initialization()
-{
-  // get PDS information
-  fOpDetType.reserve(nOpDets);
-  fOpDetOrientation.reserve(nOpDets);
-  fOpDetCenter.reserve(nOpDets);
-  fOpDetLength.reserve(nOpDets);
-  fOpDetHeight.reserve(nOpDets);
-  for (size_t const i : util::counter(nOpDets)) {
+    // Load Gaisser-Hillas corrections for VUV semi-analytic hits
+    mf::LogInfo("SemiAnalyticalModel") << "Using VUV visibility parameterization";
 
-    geo::OpDetGeo const& opDet = fGeom.OpDetGeoFromOpDet(i);
-    fOpDetCenter.push_back(opDet.GetCenter());
+    fIsFlatPDCorr = VUVHitsParams.get<bool>("FlatPDCorr", false);
+    fIsFlatPDCorrLat = VUVHitsParams.get<bool>("FlatPDCorrLat", false);
+    fIsDomePDCorr = VUVHitsParams.get<bool>("DomePDCorr", false);
+    fdelta_angulo_vuv = VUVHitsParams.get<double>("delta_angulo_vuv", 10);
+    fradius = VUVHitsParams.get<double>("PMT_radius", 10.16);
+    fApplyFieldCageTransparency = VUVHitsParams.get<bool>("ApplyFieldCageTransparency", false);
+    fFieldCageTransparencyLateral = VUVHitsParams.get<double>("FieldCageTransparencyLateral", 1.0);
+    fFieldCageTransparencyCathode = VUVHitsParams.get<double>("FieldCageTransparencyCathode", 1.0);
 
-    if (opDet.isSphere()) {           // dome PMTs
-      fOpDetType.push_back(1);        // dome
-      fOpDetOrientation.push_back(0); // anode/cathode (default)
-      fOpDetLength.push_back(-1);
-      fOpDetHeight.push_back(-1);
+    if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Both isFlatPDCorr/isFlatPDCorrLat and isDomePDCorr parameters are "
+           "false, at least one type of parameterisation is required for the "
+           "semi-analytic light simulation."
+        << "\n";
     }
-    else if (opDet.isBar()) {
-      fOpDetType.push_back(0); // (X)Arapucas/Bars
-      // determine orientation to get correction OpDet dimensions
-      fOpDetLength.push_back(opDet.Length());
-      if (opDet.Width() > opDet.Height()) { // laterals, Y dimension smallest
-        fOpDetOrientation.push_back(1);
-        fOpDetHeight.push_back(opDet.Width());
-      }
-      else { // anode/cathode (default), X dimension smallest
-        fOpDetOrientation.push_back(0);
-        fOpDetHeight.push_back(opDet.Height());
-      }
-    }
-    else {
-      fOpDetType.push_back(2);        // disk PMTs
-      fOpDetOrientation.push_back(0); // anode/cathode (default)
-      fOpDetLength.push_back(-1);
-      fOpDetHeight.push_back(-1);
-    }
-  }
-
-  // Load Gaisser-Hillas corrections for VUV semi-analytic hits
-  mf::LogInfo("SemiAnalyticalModel") << "Using VUV visibility parameterization";
-
-  fIsFlatPDCorr = fVUVHitsParams.get<bool>("FlatPDCorr", false);
-  fIsFlatPDCorrLat = fVUVHitsParams.get<bool>("FlatPDCorrLat", false);
-  fIsDomePDCorr = fVUVHitsParams.get<bool>("DomePDCorr", false);
-  fdelta_angulo_vuv = fVUVHitsParams.get<double>("delta_angulo_vuv", 10);
-  fradius = fVUVHitsParams.get<double>("PMT_radius", 10.16);
-  fApplyFieldCageTransparency = fVUVHitsParams.get<bool>("ApplyFieldCageTransparency", false);
-  fFieldCageTransparencyLateral = fVUVHitsParams.get<double>("FieldCageTransparencyLateral", 1.0);
-  fFieldCageTransparencyCathode = fVUVHitsParams.get<double>("FieldCageTransparencyCathode", 1.0);
-
-  if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Both isFlatPDCorr/isFlatPDCorrLat and isDomePDCorr parameters are false, at least one "
-         "type of parameterisation is required for the semi-analytic light simulation."
-      << "\n";
-  }
-  if (fIsFlatPDCorr) {
-    fGHvuvpars_flat = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_flat");
-    fborder_corr_angulo_flat = fVUVHitsParams.get<std::vector<double>>("GH_border_angulo_flat");
-    fborder_corr_flat = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_flat");
-  }
-  if (fIsFlatPDCorrLat) {
-    fGHvuvpars_flat_lateral =
-      fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_flat_lateral");
-    fborder_corr_angulo_flat_lateral =
-      fVUVHitsParams.get<std::vector<double>>("GH_border_angulo_flat_lateral");
-    fborder_corr_flat_lateral =
-      fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_flat_lateral");
-  }
-  if (fIsDomePDCorr) {
-    fGHvuvpars_dome = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_dome");
-    fborder_corr_angulo_dome = fVUVHitsParams.get<std::vector<double>>("GH_border_angulo_dome");
-    fborder_corr_dome = fVUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_dome");
-  }
-
-  // Load corrections for VIS semi-analytic hits
-  if (fDoReflectedLight) {
-    mf::LogInfo("SemiAnalyticalModel") << "Using VIS (reflected) visibility parameterization";
-    fdelta_angulo_vis = fVISHitsParams.get<double>("delta_angulo_vis");
-
     if (fIsFlatPDCorr) {
-      fvis_distances_x_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_x_flat");
-      fvis_distances_r_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_r_flat");
-      fvispars_flat =
-        fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat");
+      fGHvuvpars_flat = VUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_flat");
+      fborder_corr_angulo_flat = VUVHitsParams.get<std::vector<double>>("GH_border_angulo_flat");
+      fborder_corr_flat = VUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_flat");
+    }
+    if (fIsFlatPDCorrLat) {
+      fGHvuvpars_flat_lateral =
+        VUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_flat_lateral");
+      fborder_corr_angulo_flat_lateral =
+        VUVHitsParams.get<std::vector<double>>("GH_border_angulo_flat_lateral");
+      fborder_corr_flat_lateral =
+        VUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_flat_lateral");
     }
     if (fIsDomePDCorr) {
-      fvis_distances_x_dome = fVISHitsParams.get<std::vector<double>>("VIS_distances_x_dome");
-      fvis_distances_r_dome = fVISHitsParams.get<std::vector<double>>("VIS_distances_r_dome");
-      fvispars_dome =
-        fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_dome");
+      fGHvuvpars_dome = VUVHitsParams.get<std::vector<std::vector<double>>>("GH_PARS_dome");
+      fborder_corr_angulo_dome = VUVHitsParams.get<std::vector<double>>("GH_border_angulo_dome");
+      fborder_corr_dome = VUVHitsParams.get<std::vector<std::vector<double>>>("GH_border_dome");
     }
 
-    // set cathode plane struct for solid angle function
-    fcathode_plane.h = fActiveVolumes[0].SizeY();
-    fcathode_plane.w = fActiveVolumes[0].SizeZ();
-    fplane_depth = std::abs(fcathode_centre[0]);
-  }
+    // Load corrections for VIS semi-analytic hits
+    if (fDoReflectedLight) {
+      mf::LogInfo("SemiAnalyticalModel") << "Using VIS (reflected) visibility parameterization";
+      fdelta_angulo_vis = VISHitsParams.get<double>("delta_angulo_vis");
 
-  // Load corrections for Anode reflections configuration
-  if (fIncludeAnodeReflections) {
-    mf::LogInfo("SemiAnalyticalModel") << "Using anode reflections parameterization";
-    fdelta_angulo_vis = fVISHitsParams.get<double>("delta_angulo_vis");
-    fAnodeReflectivity = fVISHitsParams.get<double>("AnodeReflectivity");
-
-    if (fIsFlatPDCorr) {
-      fvis_distances_x_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_x_flat");
-      fvis_distances_r_flat = fVISHitsParams.get<std::vector<double>>("VIS_distances_r_flat");
-      fvispars_flat =
-        fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat");
-    }
-
-    if (fIsFlatPDCorrLat) {
-      fvis_distances_x_flat_lateral =
-        fVISHitsParams.get<std::vector<double>>("VIS_distances_x_flat_lateral");
-      fvis_distances_r_flat_lateral =
-        fVISHitsParams.get<std::vector<double>>("VIS_distances_r_flat_lateral");
-      fvispars_flat_lateral = fVISHitsParams.get<std::vector<std::vector<std::vector<double>>>>(
-        "VIS_correction_flat_lateral");
-    }
-
-    // set anode plane struct for solid angle function
-    fanode_plane.h = fActiveVolumes[0].SizeY();
-    fanode_plane.w = fActiveVolumes[0].SizeZ();
-    fanode_plane_depth = fanode_centre[0];
-  }
-}
-
-int SemiAnalyticalModel::VUVAbsorptionLength() const
-{
-  // determine LAr absorption length in cm
-  std::map<double, double> abs_length_spectrum =
-    lar::providerFrom<detinfo::LArPropertiesService>()->AbsLengthSpectrum();
-  std::vector<double> x_v, y_v;
-  for (auto elem : abs_length_spectrum) {
-    x_v.push_back(elem.first);
-    y_v.push_back(elem.second);
-  }
-  int vuv_absorption_length = std::round(interpolate(
-    x_v, y_v, 9.7, false)); // 9.7 eV: peak of VUV emission spectrum   // TO DO UNHARDCODE FOR XENON
-  if (vuv_absorption_length <= 0) {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: VUV Absorption Length is 0 or negative.\n";
-  }
-  return vuv_absorption_length;
-}
-
-//......................................................................
-// VUV semi-analytical model visibility calculation
-void SemiAnalyticalModel::detectedDirectVisibilities(std::vector<double>& DetectedVisibilities,
-                                                     geo::Point_t const& ScintPoint) const
-{
-  DetectedVisibilities.resize(nOpDets);
-  for (size_t const OpDet : util::counter(nOpDets)) {
-    if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter[OpDet])) {
-      DetectedVisibilities[OpDet] = 0.;
-      continue;
-    }
-
-    // set detector struct for solid angle function
-    const SemiAnalyticalModel::OpticalDetector op{fOpDetHeight[OpDet],
-                                                  fOpDetLength[OpDet],
-                                                  fOpDetCenter[OpDet],
-                                                  fOpDetType[OpDet],
-                                                  fOpDetOrientation[OpDet]};
-
-    DetectedVisibilities[OpDet] = VUVVisibility(ScintPoint, op);
-    ;
-  }
-}
-
-double SemiAnalyticalModel::VUVVisibility(geo::Point_t const& ScintPoint,
-                                          OpticalDetector const& opDet) const
-{
-  // distance and angle between ScintPoint and OpDetPoint
-  geo::Vector_t const relative = ScintPoint - opDet.OpDetPoint;
-  const double distance = relative.R();
-  double cosine;
-  if (opDet.orientation == 1)
-    cosine = std::abs(relative.Y()) / distance;
-  else
-    cosine = std::abs(relative.X()) / distance;
-  const double theta = fast_acos(cosine) * 180. / CLHEP::pi;
-
-  double solid_angle = 0.;
-  // ARAPUCAS/Bars (rectangle)
-  if (opDet.type == 0) {
-    // get scintillation point coordinates relative to arapuca window centre
-    geo::Vector_t const abs_relative{
-      std::abs(relative.X()), std::abs(relative.Y()), std::abs(relative.Z())};
-    solid_angle = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_relative, opDet.orientation);
-  }
-  // PMTs (dome)
-  else if (opDet.type == 1) {
-    solid_angle = Omega_Dome_Model(distance, theta);
-  }
-  // PMTs (disk)
-  else if (opDet.type == 2) {
-    const double zy_offset = std::sqrt(relative.Y() * relative.Y() + relative.Z() * relative.Z());
-    const double x_distance = std::abs(relative.X());
-    solid_angle = Disk_SolidAngle(zy_offset, x_distance, fradius);
-  }
-  else {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: Invalid optical detector shape requested - configuration error in semi-analytical "
-         "model, only rectangular, dome or disk optical detectors are supported."
-      << "\n";
-  }
-
-  // calculate visibility by geometric acceptance
-  // accounting for solid angle and LAr absorbtion length
-  double visibility_geo =
-    std::exp(-1. * distance / fvuv_absorption_length) * (solid_angle / (4 * CLHEP::pi));
-
-  // apply Gaisser-Hillas correction for Rayleigh scattering distance
-  // and angular dependence offset angle bin
-  const size_t j = (theta / fdelta_angulo_vuv);
-
-  // determine GH parameters, accounting for border effects
-  // radial distance from centre of detector (Y-Z)
-  double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
-
-  double pars_ini[4] = {0, 0, 0, 0};
-  double s1 = 0;
-  double s2 = 0;
-  double s3 = 0;
-  // flat PDs
-  if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)) {
-    if (opDet.orientation == 1 && fIsFlatPDCorrLat) { // laterals
-      pars_ini[0] = fGHvuvpars_flat_lateral[0][j];
-      pars_ini[1] = fGHvuvpars_flat_lateral[1][j];
-      pars_ini[2] = fGHvuvpars_flat_lateral[2][j];
-      pars_ini[3] = fGHvuvpars_flat_lateral[3][j];
-      s1 = interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[0], theta, true);
-      s2 = interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[1], theta, true);
-      s3 = interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[2], theta, true);
-    }
-    else if (opDet.orientation == 0 && fIsFlatPDCorr) { // cathode/anode
-      pars_ini[0] = fGHvuvpars_flat[0][j];
-      pars_ini[1] = fGHvuvpars_flat[1][j];
-      pars_ini[2] = fGHvuvpars_flat[2][j];
-      pars_ini[3] = fGHvuvpars_flat[3][j];
-      s1 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[0], theta, true);
-      s2 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[1], theta, true);
-      s3 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[2], theta, true);
-    }
-    else {
-      throw cet::exception("SemiAnalyticalModel")
-        << "Error: flat optical detectors are found, but parameters are missing - configuration "
-           "error in semi-analytical model."
-        << "\n";
-    }
-  }
-  // dome PDs
-  else if (opDet.type == 1 && fIsDomePDCorr) {
-    pars_ini[0] = fGHvuvpars_dome[0][j];
-    pars_ini[1] = fGHvuvpars_dome[1][j];
-    pars_ini[2] = fGHvuvpars_dome[2][j];
-    pars_ini[3] = fGHvuvpars_dome[3][j];
-    s1 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[0], theta, true);
-    s2 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[1], theta, true);
-    s3 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[2], theta, true);
-  }
-  else {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: Invalid optical detector shape requested or corrections are missing - "
-         "configuration error in semi-analytical model."
-      << "\n";
-  }
-
-  // add border correction to parameters
-  pars_ini[0] = pars_ini[0] + s1 * r;
-  pars_ini[1] = pars_ini[1] + s2 * r;
-  pars_ini[2] = pars_ini[2] + s3 * r;
-  pars_ini[3] = pars_ini[3];
-
-  // calculate correction
-  double GH_correction = Gaisser_Hillas(distance, pars_ini);
-
-  // apply field cage transparency factor
-  if (fApplyFieldCageTransparency) {
-    if (opDet.orientation == 1)
-      GH_correction = GH_correction * fFieldCageTransparencyLateral;
-    else if (opDet.orientation == 0)
-      GH_correction = GH_correction * fFieldCageTransparencyCathode;
-  }
-
-  // determine corrected visibility of photo-detector
-  return GH_correction * visibility_geo / cosine;
-}
-
-//......................................................................
-// VIS semi-analytical model visibility calculation
-void SemiAnalyticalModel::detectedReflectedVisibilities(
-  std::vector<double>& ReflDetectedVisibilities,
-  geo::Point_t const& ScintPoint,
-  bool AnodeMode) const
-{
-  // 1). calculate visibility of VUV photons on
-  // reflective foils via solid angle + Gaisser-Hillas
-  // corrections:
-
-  // get scintpoint coords relative to centre of cathode plane and set plane dimensions
-  geo::Vector_t ScintPoint_relative;
-  Dims plane_dimensions;
-  double plane_depth;
-  if (AnodeMode) {
-    plane_dimensions = fanode_plane;
-    plane_depth = fanode_plane_depth;
-    ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - fanode_plane_depth),
-                                       std::abs(ScintPoint.Y() - fanode_centre[1]),
-                                       std::abs(ScintPoint.Z() - fanode_centre[2]));
-  }
-  else {
-    plane_dimensions = fcathode_plane;
-    plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
-    ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - plane_depth),
-                                       std::abs(ScintPoint.Y() - fcathode_centre[1]),
-                                       std::abs(ScintPoint.Z() - fcathode_centre[2]));
-  }
-
-  // calculate solid angle of anode/cathode from the scintillation point, orientation always = 0 (anode/cathode)
-  double solid_angle_cathode = Rectangle_SolidAngle(plane_dimensions, ScintPoint_relative, 0);
-
-  // calculate distance and angle between ScintPoint and hotspot
-  // vast majority of hits in hotspot region directly infront of scintpoint,
-  // therefore consider attenuation for this distance and on axis GH instead of for the centre coordinate
-  double distance_cathode = std::abs(plane_depth - ScintPoint.X());
-  // calculate hits on cathode plane via geometric acceptance
-  double cathode_visibility_geo = std::exp(-1. * distance_cathode / fvuv_absorption_length) *
-                                  (solid_angle_cathode / (4. * CLHEP::pi));
-
-  // determine Gaisser-Hillas correction including border effects
-  // use flat correction
-  double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
-  double pars_ini[4] = {0, 0, 0, 0};
-  double s1 = 0;
-  double s2 = 0;
-  double s3 = 0;
-  if (fIsFlatPDCorr) {
-    pars_ini[0] = fGHvuvpars_flat[0][0];
-    pars_ini[1] = fGHvuvpars_flat[1][0];
-    pars_ini[2] = fGHvuvpars_flat[2][0];
-    pars_ini[3] = fGHvuvpars_flat[3][0];
-    s1 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[0], 0, true);
-    s2 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[1], 0, true);
-    s3 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[2], 0, true);
-  }
-  else {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: flat optical detector VUV correction required for reflected semi-analytic hits. - "
-         "configuration error in semi-analytical model."
-      << "\n";
-  }
-
-  // add border correction
-  pars_ini[0] = pars_ini[0] + s1 * r;
-  pars_ini[1] = pars_ini[1] + s2 * r;
-  pars_ini[2] = pars_ini[2] + s3 * r;
-  pars_ini[3] = pars_ini[3];
-
-  // calculate corrected number of hits
-  double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini);
-  const double cathode_visibility_rec = GH_correction * cathode_visibility_geo;
-
-  // 2). detemine visibility of each PD
-  const geo::Point_t hotspot = {plane_depth, ScintPoint.Y(), ScintPoint.Z()};
-  ReflDetectedVisibilities.resize(nOpDets);
-  for (size_t const OpDet : util::counter(nOpDets)) {
-    if (!isOpDetInSameTPC(ScintPoint, fOpDetCenter[OpDet])) {
-      ReflDetectedVisibilities[OpDet] = 0.;
-      continue;
-    }
-
-    // set detector struct for solid angle function
-    const OpticalDetector op{fOpDetHeight[OpDet],
-                             fOpDetLength[OpDet],
-                             fOpDetCenter[OpDet],
-                             fOpDetType[OpDet],
-                             fOpDetOrientation[OpDet]};
-
-    ReflDetectedVisibilities[OpDet] =
-      VISVisibility(ScintPoint, op, cathode_visibility_rec, hotspot, AnodeMode);
-  }
-}
-
-double SemiAnalyticalModel::VISVisibility(geo::Point_t const& ScintPoint,
-                                          OpticalDetector const& opDet,
-                                          const double cathode_visibility,
-                                          geo::Point_t const& hotspot,
-                                          bool AnodeMode) const
-{
-  // set correct plane_depth
-  double plane_depth;
-  if (AnodeMode)
-    plane_depth = fanode_plane_depth;
-  else
-    plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
-
-  // calculate visibility of the optical
-  // detector from the hotspot using solid angle:
-
-  geo::Vector_t const emission_relative = hotspot - opDet.OpDetPoint;
-
-  // calculate distances and angles for application of corrections
-  // distance from hotspot to optical detector
-  const double distance_vis = emission_relative.R();
-  //  angle between hotspot and optical detector
-  double cosine_vis;
-  if (opDet.orientation == 1) { // lateral
-    cosine_vis = std::abs(emission_relative.Y()) / distance_vis;
-  }
-  else { // anode/cathode (default)
-    cosine_vis = std::abs(emission_relative.X()) / distance_vis;
-  }
-  const double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
-
-  // calculate solid angle of optical channel
-  double solid_angle_detector = 0.;
-  // ARAPUCAS/Bars (rectangle)
-  if (opDet.type == 0) {
-    // get hotspot coordinates relative to opDet
-    geo::Vector_t const abs_emission_relative{std::abs(emission_relative.X()),
-                                              std::abs(emission_relative.Y()),
-                                              std::abs(emission_relative.Z())};
-    solid_angle_detector =
-      Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_emission_relative, opDet.orientation);
-  }
-  // PMTS (dome)
-  else if (opDet.type == 1) {
-    solid_angle_detector = Omega_Dome_Model(distance_vis, theta_vis);
-  }
-  // PMTs (disk)
-  else if (opDet.type == 2) {
-    const double zy_offset = std::sqrt(emission_relative.Y() * emission_relative.Y() +
-                                       emission_relative.Z() * emission_relative.Z());
-    const double x_distance = std::abs(emission_relative.X());
-    solid_angle_detector = Disk_SolidAngle(zy_offset, x_distance, fradius);
-  }
-  else {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: Invalid optical detector shape requested - configuration error in semi-analytical "
-         "model, only rectangular, dome or disk optical detectors are supported."
-      << "\n";
-  }
-
-  // calculate number of hits via geometeric acceptance
-  double visibility_geo = (solid_angle_detector / (2. * CLHEP::pi)) *
-                          cathode_visibility; // 2*pi due to presence of reflective foils
-
-  // determine correction factor, depending on PD type
-  const size_t k = (theta_vis / fdelta_angulo_vis); // off-set angle bin
-  double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
-  double d_c = std::abs(ScintPoint.X() - plane_depth); // distance to cathode
-  double border_correction = 0;
-  // flat PDs
-  if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)) {
-    // cathode/anode case
-    if (opDet.orientation == 0 && fIsFlatPDCorr)
-      border_correction =
-        interpolate2(fvis_distances_x_flat, fvis_distances_r_flat, fvispars_flat, d_c, r, k);
-    // laterals case
-    else if (opDet.orientation == 1 && fIsFlatPDCorrLat)
-      border_correction = interpolate2(fvis_distances_x_flat_lateral,
-                                       fvis_distances_r_flat_lateral,
-                                       fvispars_flat_lateral,
-                                       d_c,
-                                       r,
-                                       k);
-    else {
-      throw cet::exception("SemiAnalyticalModel")
-        << "Error: Invalid optical detector shape requested or corrections are missing - "
-           "configuration error in semi-analytical model."
-        << "\n";
-    }
-  }
-  // dome PDs
-  else if (opDet.type == 1 && fIsDomePDCorr)
-    border_correction =
-      interpolate2(fvis_distances_x_dome, fvis_distances_r_dome, fvispars_dome, d_c, r, k);
-  else {
-    throw cet::exception("SemiAnalyticalModel")
-      << "Error: Invalid optical detector shape requested or corrections are missing - "
-         "configuration error in semi-analytical model."
-      << "\n";
-  }
-
-  // apply anode reflectivity factor
-  if (AnodeMode) border_correction = border_correction * fAnodeReflectivity;
-
-  // apply field cage transparency factor
-  if (fApplyFieldCageTransparency) {
-    if (opDet.orientation == 1)
-      border_correction = border_correction * fFieldCageTransparencyLateral;
-    else if (opDet.orientation == 0)
-      border_correction = border_correction * fFieldCageTransparencyCathode;
-  }
-
-  return border_correction * visibility_geo / cosine_vis;
-}
-
-//......................................................................
-// Gaisser-Hillas function definition
-double SemiAnalyticalModel::Gaisser_Hillas(const double x, const double* par) const
-{
-  double X_mu_0 = par[3];
-  double Normalization = par[0];
-  double Diff = par[1] - X_mu_0;
-  double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
-  double Exponential = std::exp((par[1] - x) / par[2]);
-
-  return (Normalization * Term * Exponential);
-}
-
-//......................................................................
-// solid angle of circular aperture
-double SemiAnalyticalModel::Disk_SolidAngle(const double d, const double h, const double b) const
-{
-  if (b <= 0. || d < 0. || h <= 0.) return 0.;
-  const double leg2 = (b + d) * (b + d);
-  const double aa = std::sqrt(h * h / (h * h + leg2));
-  if (isApproximatelyZero(d)) { return 2. * CLHEP::pi * (1. - aa); }
-  double bb = 2. * std::sqrt(b * d / (h * h + leg2));
-  double cc = 4. * b * d / leg2;
-
-  if (isDefinitelyGreaterThan(d, b)) {
-    try {
-      return 2. * aa *
-             (std::sqrt(1. - cc) * boost::math::ellint_3(bb, cc, noLDoublePromote()) -
-              boost::math::ellint_1(bb, noLDoublePromote()));
-    }
-    catch (std::domain_error& e) {
-      if (isApproximatelyEqual(d, b, 1e-9)) {
-        mf::LogWarning("SemiAnalyticalModel")
-          << "Elliptic Integral in Disk_SolidAngle() given parameters "
-             "outside domain."
-          << "\nbb: " << bb << "\ncc: " << cc << "\nException message: " << e.what()
-          << "\nRelax condition and carry on.";
-        return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
+      if (fIsFlatPDCorr) {
+        fvis_distances_x_flat = VISHitsParams.get<std::vector<double>>("VIS_distances_x_flat");
+        fvis_distances_r_flat = VISHitsParams.get<std::vector<double>>("VIS_distances_r_flat");
+        fvispars_flat =
+          VISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat");
       }
-      else {
-        mf::LogError("SemiAnalyticalModel")
-          << "Elliptic Integral inside Disk_SolidAngle() given parameters "
-             "outside domain.\n"
-          << "\nbb: " << bb << "\ncc: " << cc << "Exception message: " << e.what();
-        return 0.;
+      if (fIsDomePDCorr) {
+        fvis_distances_x_dome = VISHitsParams.get<std::vector<double>>("VIS_distances_x_dome");
+        fvis_distances_r_dome = VISHitsParams.get<std::vector<double>>("VIS_distances_r_dome");
+        fvispars_dome =
+          VISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_dome");
       }
+
+      // set cathode plane struct for solid angle function
+      fcathode_plane.h = fActiveVolumes[0].SizeY();
+      fcathode_plane.w = fActiveVolumes[0].SizeZ();
+      fplane_depth = std::abs(fcathode_centre[0]);
     }
-  }
-  if (isDefinitelyLessThan(d, b)) {
-    try {
-      return 2. * CLHEP::pi -
-             2. * aa *
-               (boost::math::ellint_1(bb, noLDoublePromote()) +
-                std::sqrt(1. - cc) * boost::math::ellint_3(bb, cc, noLDoublePromote()));
-    }
-    catch (std::domain_error& e) {
-      if (isApproximatelyEqual(d, b, 1e-9)) {
-        mf::LogWarning("SemiAnalyticalModel")
-          << "Elliptic Integral in Disk_SolidAngle() given parameters "
-             "outside domain."
-          << "\nbb: " << bb << "\ncc: " << cc << "\nException message: " << e.what()
-          << "\nRelax condition and carry on.";
-        return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
+
+    // Load corrections for Anode reflections configuration
+    if (fIncludeAnodeReflections) {
+      mf::LogInfo("SemiAnalyticalModel") << "Using anode reflections parameterization";
+      fdelta_angulo_vis = VISHitsParams.get<double>("delta_angulo_vis");
+      fAnodeReflectivity = VISHitsParams.get<double>("AnodeReflectivity");
+
+      if (fIsFlatPDCorr) {
+        fvis_distances_x_flat = VISHitsParams.get<std::vector<double>>("VIS_distances_x_flat");
+        fvis_distances_r_flat = VISHitsParams.get<std::vector<double>>("VIS_distances_r_flat");
+        fvispars_flat =
+          VISHitsParams.get<std::vector<std::vector<std::vector<double>>>>("VIS_correction_flat");
       }
-      else {
-        mf::LogError("SemiAnalyticalModel")
-          << "Elliptic Integral inside Disk_SolidAngle() given parameters "
-             "outside domain.\n"
-          << "\nbb: " << bb << "\ncc: " << cc << "Exception message: " << e.what();
-        return 0.;
+
+      if (fIsFlatPDCorrLat) {
+        fvis_distances_x_flat_lateral =
+          VISHitsParams.get<std::vector<double>>("VIS_distances_x_flat_lateral");
+        fvis_distances_r_flat_lateral =
+          VISHitsParams.get<std::vector<double>>("VIS_distances_r_flat_lateral");
+        fvispars_flat_lateral = VISHitsParams.get<std::vector<std::vector<std::vector<double>>>>(
+          "VIS_correction_flat_lateral");
       }
+
+      // set anode plane struct for solid angle function
+      fanode_plane.h = fActiveVolumes[0].SizeY();
+      fanode_plane.w = fActiveVolumes[0].SizeZ();
+      fanode_plane_depth = fanode_centre[0];
     }
-  }
-  if (isApproximatelyEqual(d, b)) {
-    return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
-  }
-  return 0.;
-}
 
-//......................................................................
-// solid angle of rectangular aperture
-double SemiAnalyticalModel::Rectangle_SolidAngle(const double a,
-                                                 const double b,
-                                                 const double d) const
-{
-  double aa = a / (2. * d);
-  double bb = b / (2. * d);
-  double aux = (1. + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
-  return 4. * fast_acos(std::sqrt(aux));
-}
-
-double SemiAnalyticalModel::Rectangle_SolidAngle(Dims const& o,
-                                                 geo::Vector_t const& v,
-                                                 double OpDetOrientation) const
-{
-  // v is the position of the track segment with respect to
-  // the center position of the arapuca window
-
-  // solid angle calculation depends on orientation of PD, set correct distances to use
-  double d1;
-  double d2;
-  if (OpDetOrientation == 1) {
-    // lateral PD, arapuca plane fixed in y direction
-    d1 = std::abs(v.X());
-    d2 = std::abs(v.Y());
-  }
-  else {
-    // anode/cathode PD, arapuca plane fixed in x direction [default]
-    d1 = std::abs(v.Y());
-    d2 = std::abs(v.X());
-  }
-  // arapuca plane fixed in x direction
-  if (isApproximatelyZero(d1) && isApproximatelyZero(v.Z())) {
-    return Rectangle_SolidAngle(o.h, o.w, d2);
-  }
-  if (isDefinitelyGreaterThan(d1, o.h * .5) && isDefinitelyGreaterThan(std::abs(v.Z()), o.w * .5)) {
-    double A = d1 - o.h * .5;
-    double B = std::abs(v.Z()) - o.w * .5;
-    double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), d2) -
-                        Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
-                        Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) +
-                        Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
-                       .25;
-    return to_return;
-  }
-  if ((d1 <= o.h * .5) && (std::abs(v.Z()) <= o.w * .5)) {
-    double A = -d1 + o.h * .5;
-    double B = -std::abs(v.Z()) + o.w * .5;
-    double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), d2) +
-                        Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
-                        Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
-                        Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
-                       .25;
-    return to_return;
-  }
-  if (isDefinitelyGreaterThan(d1, o.h * .5) && (std::abs(v.Z()) <= o.w * .5)) {
-    double A = d1 - o.h * .5;
-    double B = -std::abs(v.Z()) + o.w * .5;
-    double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), d2) -
-                        Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
-                        Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) -
-                        Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
-                       .25;
-    return to_return;
-  }
-  if ((d1 <= o.h * .5) && isDefinitelyGreaterThan(std::abs(v.Z()), o.w * .5)) {
-    double A = -d1 + o.h * .5;
-    double B = std::abs(v.Z()) - o.w * .5;
-    double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), d2) -
-                        Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
-                        Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
-                        Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
-                       .25;
-    return to_return;
+    mf::LogInfo("SemiAnalyticalModel") << "Semi-analytical model initialized." << std::endl;
   }
 
-  return 0.;
-}
-
-//......................................................................
-// solid angle of dome aperture
-double SemiAnalyticalModel::Omega_Dome_Model(const double distance, const double theta) const
-{
-  // this function calculates the solid angle of a semi-sphere of radius b,
-  // as a correction to the analytic formula of the on-axix solid angle,
-  // as we move off-axis an angle theta. We have used 9-angular bins
-  // with delta_theta width.
-
-  // par0 = Radius correction close
-  // par1 = Radius correction far
-  // par2 = breaking distance betwween "close" and "far"
-
-  double par0[9] = {0., 0., 0., 0., 0., 0.597542, 1.00872, 1.46993, 2.04221};
-  double par1[9] = {0, 0, 0.19569, 0.300449, 0.555598, 0.854939, 1.39166, 2.19141, 2.57732};
-  const double delta_theta = 10.; // TODO: should this be fdelta_angulo_vuv?
-  int j = int(theta / delta_theta);
-  // PMT radius
-  const double b = fradius; // cm
-  // distance form which the model parameters break (empirical value)
-  const double d_break = 5 * b; //par2
-
-  if (distance >= d_break) {
-    double R_apparent_far = b - par1[j];
-    double ratio_square = (R_apparent_far * R_apparent_far) / (distance * distance);
-    return (2 * CLHEP::pi * (1 - std::sqrt(1 - ratio_square)));
-  }
-  else {
-    double R_apparent_close = b - par0[j];
-    double ratio_square = (R_apparent_close * R_apparent_close) / (distance * distance);
-    return (2 * CLHEP::pi * (1 - std::sqrt(1 - ratio_square)));
-  }
-}
-
-//......................................................................
-// checks photo-detector is in same TPC/argon volume as scintillation
-bool SemiAnalyticalModel::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
-                                           geo::Point_t const& OpDetPoint) const
-{
-  // method working for SBND, uBooNE, DUNE-HD 1x2x6 and DUNE-VD 1x8x6
-  // will need to be replaced to work in full DUNE geometry, ICARUS geometry
-  // check x coordinate has same sign or is close to zero, otherwise return false
-  if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10. &&
-      fNTPC == 2) { // TODO: replace with geometry service
-    return false;
-  }
-  return true;
-}
-
-//......................................................................
-double SemiAnalyticalModel::fast_acos(double x) const
-{
-  double negate = double(x < 0);
-  x = std::abs(x);
-  x -= double(x > 1.0) * (x - 1.0); // <- equivalent to min(1.0,x), but faster
-  double ret = -0.0187293;
-  ret = ret * x;
-  ret = ret + 0.0742610;
-  ret = ret * x;
-  ret = ret - 0.2121144;
-  ret = ret * x;
-  ret = ret + 1.5707288;
-  ret = ret * std::sqrt(1.0 - x);
-  ret = ret - 2. * negate * ret;
-  return negate * 3.14159265358979 + ret;
-}
-
-//......................................................................
-// Returns interpolated value at x from parallel arrays ( xData, yData )
-// Assumes that xData has at least two elements, is sorted and is strictly
-// monotonic increasing boolean argument extrapolate determines behaviour
-// beyond ends of array (if needed)
-double SemiAnalyticalModel::interpolate(const std::vector<double>& xData,
-                                        const std::vector<double>& yData,
-                                        double x,
-                                        bool extrapolate,
-                                        size_t i) const
-{
-  if (i == 0) {
-    size_t size = xData.size();
-    if (x >= xData[size - 2]) { // special case: beyond right end
-      i = size - 2;
-    }
-    else {
-      while (x > xData[i + 1])
-        i++;
-    }
-  }
-  double xL = xData[i];
-  double xR = xData[i + 1];
-  double yL = yData[i];
-  double yR = yData[i + 1]; // points on either side (unless beyond ends)
-  if (!extrapolate) {       // if beyond ends of array and not extrapolating
-    if (x < xL) return yL;
-    if (x > xR) return yL;
-  }
-  const double dydx = (yR - yL) / (xR - xL); // gradient
-  return yL + dydx * (x - xL);               // linear interpolation
-}
-
-double SemiAnalyticalModel::interpolate2(
-  const std::vector<double>& xDistances,
-  const std::vector<double>& rDistances,
-  const std::vector<std::vector<std::vector<double>>>& parameters,
-  const double x,
-  const double r,
-  const size_t k) const
-{
-  // interpolate in x for each r bin, for angle bin k
-  const size_t nbins_r = parameters[k].size();
-  std::vector<double> interp_vals(nbins_r, 0.0);
+  int SemiAnalyticalModel::VUVAbsorptionLength() const
   {
-    size_t idx = 0;
-    size_t size = xDistances.size();
-    if (x >= xDistances[size - 2])
-      idx = size - 2;
-    else {
-      while (x > xDistances[idx + 1])
-        idx++;
+    // determine LAr absorption length in cm
+    std::map<double, double> abs_length_spectrum =
+      lar::providerFrom<detinfo::LArPropertiesService>()->AbsLengthSpectrum();
+    std::vector<double> x_v, y_v;
+    for (auto elem : abs_length_spectrum) {
+      x_v.push_back(elem.first);
+      y_v.push_back(elem.second);
     }
-    for (size_t i = 0; i < nbins_r; ++i) {
-      interp_vals[i] = interpolate(xDistances, parameters[k][i], x, false, idx);
+    int vuv_absorption_length = std::round(
+      interpolate(x_v,
+                  y_v,
+                  9.7,
+                  false)); // 9.7 eV: peak of VUV emission spectrum   // TODO UNHARDCODE FOR XENON
+    if (vuv_absorption_length <= 0) {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: VUV Absorption Length is 0 or negative.\n";
+    }
+    return vuv_absorption_length;
+  }
+
+  //......................................................................
+  // VUV semi-analytical model visibility calculation
+  void SemiAnalyticalModel::detectedDirectVisibilities(std::vector<double>& DetectedVisibilities,
+                                                       geo::Point_t const& ScintPoint) const
+  {
+    DetectedVisibilities.resize(fNOpDets);
+    for (size_t const OpDet : util::counter(fNOpDets)) {
+      if (!isOpDetInSameTPC(ScintPoint, fOpDetector[OpDet].center)) {
+        DetectedVisibilities[OpDet] = 0.;
+        continue;
+      }
+
+      DetectedVisibilities[OpDet] = VUVVisibility(ScintPoint, fOpDetector[OpDet]);
+      ;
     }
   }
-  // interpolate in r
-  double border_correction = interpolate(rDistances, interp_vals, r, false);
-  return border_correction;
-}
+
+  double SemiAnalyticalModel::VUVVisibility(geo::Point_t const& ScintPoint,
+                                            OpticalDetector const& opDet) const
+  {
+    // distance and angle between ScintPoint and OpDet center
+    geo::Vector_t const relative = ScintPoint - opDet.center;
+    const double distance = relative.R();
+    double cosine;
+    if (opDet.orientation == 1)
+      cosine = std::abs(relative.Y()) / distance;
+    else
+      cosine = std::abs(relative.X()) / distance;
+    const double theta = fast_acos(cosine) * 180. / CLHEP::pi;
+
+    double solid_angle = 0.;
+    // ARAPUCAS/Bars (rectangle)
+    if (opDet.type == 0) {
+      // get scintillation point coordinates relative to arapuca window centre
+      geo::Vector_t const abs_relative{
+        std::abs(relative.X()), std::abs(relative.Y()), std::abs(relative.Z())};
+      solid_angle = Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_relative, opDet.orientation);
+    }
+    // PMTs (dome)
+    else if (opDet.type == 1) {
+      solid_angle = Omega_Dome_Model(distance, theta);
+    }
+    // PMTs (disk)
+    else if (opDet.type == 2) {
+      const double zy_offset = std::sqrt(relative.Y() * relative.Y() + relative.Z() * relative.Z());
+      const double x_distance = std::abs(relative.X());
+      solid_angle = Disk_SolidAngle(zy_offset, x_distance, fradius);
+    }
+    else {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: Invalid optical detector shape requested - configuration "
+           "error in semi-analytical model, only rectangular, dome or disk "
+           "optical detectors are supported."
+        << "\n";
+    }
+
+    // calculate visibility by geometric acceptance
+    // accounting for solid angle and LAr absorbtion length
+    double visibility_geo =
+      std::exp(-1. * distance / fvuv_absorption_length) * (solid_angle / (4 * CLHEP::pi));
+
+    // apply Gaisser-Hillas correction for Rayleigh scattering distance
+    // and angular dependence offset angle bin
+    const size_t j = (theta / fdelta_angulo_vuv);
+
+    // determine GH parameters, accounting for border effects
+    // radial distance from centre of detector (Y-Z)
+    double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+
+    double pars_ini[4] = {0, 0, 0, 0};
+    double s1 = 0;
+    double s2 = 0;
+    double s3 = 0;
+    // flat PDs
+    if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)) {
+      if (opDet.orientation == 1 && fIsFlatPDCorrLat) { // laterals
+        pars_ini[0] = fGHvuvpars_flat_lateral[0][j];
+        pars_ini[1] = fGHvuvpars_flat_lateral[1][j];
+        pars_ini[2] = fGHvuvpars_flat_lateral[2][j];
+        pars_ini[3] = fGHvuvpars_flat_lateral[3][j];
+        s1 =
+          interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[0], theta, true);
+        s2 =
+          interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[1], theta, true);
+        s3 =
+          interpolate(fborder_corr_angulo_flat_lateral, fborder_corr_flat_lateral[2], theta, true);
+      }
+      else if (opDet.orientation == 0 && fIsFlatPDCorr) { // cathode/anode
+        pars_ini[0] = fGHvuvpars_flat[0][j];
+        pars_ini[1] = fGHvuvpars_flat[1][j];
+        pars_ini[2] = fGHvuvpars_flat[2][j];
+        pars_ini[3] = fGHvuvpars_flat[3][j];
+        s1 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[0], theta, true);
+        s2 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[1], theta, true);
+        s3 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[2], theta, true);
+      }
+      else {
+        throw cet::exception("SemiAnalyticalModel")
+          << "Error: flat optical detectors are found, but parameters are "
+             "missing - configuration error in semi-analytical model."
+          << "\n";
+      }
+    }
+    // dome PDs
+    else if (opDet.type == 1 && fIsDomePDCorr) {
+      pars_ini[0] = fGHvuvpars_dome[0][j];
+      pars_ini[1] = fGHvuvpars_dome[1][j];
+      pars_ini[2] = fGHvuvpars_dome[2][j];
+      pars_ini[3] = fGHvuvpars_dome[3][j];
+      s1 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[0], theta, true);
+      s2 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[1], theta, true);
+      s3 = interpolate(fborder_corr_angulo_dome, fborder_corr_dome[2], theta, true);
+    }
+    else {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: Invalid optical detector shape requested or corrections are "
+           "missing - configuration error in semi-analytical model."
+        << "\n";
+    }
+
+    // add border correction to parameters
+    pars_ini[0] = pars_ini[0] + s1 * r;
+    pars_ini[1] = pars_ini[1] + s2 * r;
+    pars_ini[2] = pars_ini[2] + s3 * r;
+    pars_ini[3] = pars_ini[3];
+
+    // calculate correction
+    double GH_correction = Gaisser_Hillas(distance, pars_ini);
+
+    // apply field cage transparency factor
+    if (fApplyFieldCageTransparency) {
+      if (opDet.orientation == 1)
+        GH_correction = GH_correction * fFieldCageTransparencyLateral;
+      else if (opDet.orientation == 0)
+        GH_correction = GH_correction * fFieldCageTransparencyCathode;
+    }
+
+    // determine corrected visibility of photo-detector
+    return GH_correction * visibility_geo / cosine;
+  }
+
+  //......................................................................
+  // VIS semi-analytical model visibility calculation
+  void SemiAnalyticalModel::detectedReflectedVisibilities(
+    std::vector<double>& ReflDetectedVisibilities,
+    geo::Point_t const& ScintPoint,
+    bool AnodeMode) const
+  {
+    // 1). calculate visibility of VUV photons on
+    // reflective foils via solid angle + Gaisser-Hillas
+    // corrections:
+
+    // get scintpoint coords relative to centre of cathode plane and set plane
+    // dimensions
+    geo::Vector_t ScintPoint_relative;
+    Dims plane_dimensions;
+    double plane_depth;
+    if (AnodeMode) {
+      plane_dimensions = fanode_plane;
+      plane_depth = fanode_plane_depth;
+      ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - fanode_plane_depth),
+                                         std::abs(ScintPoint.Y() - fanode_centre[1]),
+                                         std::abs(ScintPoint.Z() - fanode_centre[2]));
+    }
+    else {
+      plane_dimensions = fcathode_plane;
+      plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
+      ScintPoint_relative.SetCoordinates(std::abs(ScintPoint.X() - plane_depth),
+                                         std::abs(ScintPoint.Y() - fcathode_centre[1]),
+                                         std::abs(ScintPoint.Z() - fcathode_centre[2]));
+    }
+
+    // calculate solid angle of anode/cathode from the scintillation point,
+    // orientation always = 0 (anode/cathode)
+    double solid_angle_cathode = Rectangle_SolidAngle(plane_dimensions, ScintPoint_relative, 0);
+
+    // calculate distance and angle between ScintPoint and hotspot
+    // vast majority of hits in hotspot region directly infront of scintpoint,
+    // therefore consider attenuation for this distance and on axis GH instead of
+    // for the centre coordinate
+    double distance_cathode = std::abs(plane_depth - ScintPoint.X());
+    // calculate hits on cathode plane via geometric acceptance
+    double cathode_visibility_geo = std::exp(-1. * distance_cathode / fvuv_absorption_length) *
+                                    (solid_angle_cathode / (4. * CLHEP::pi));
+
+    // determine Gaisser-Hillas correction including border effects
+    // use flat correction
+    double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    double pars_ini[4] = {0, 0, 0, 0};
+    double s1 = 0;
+    double s2 = 0;
+    double s3 = 0;
+    if (fIsFlatPDCorr) {
+      pars_ini[0] = fGHvuvpars_flat[0][0];
+      pars_ini[1] = fGHvuvpars_flat[1][0];
+      pars_ini[2] = fGHvuvpars_flat[2][0];
+      pars_ini[3] = fGHvuvpars_flat[3][0];
+      s1 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[0], 0, true);
+      s2 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[1], 0, true);
+      s3 = interpolate(fborder_corr_angulo_flat, fborder_corr_flat[2], 0, true);
+    }
+    else {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: flat optical detector VUV correction required for reflected "
+           "semi-analytic hits. - configuration error in semi-analytical model."
+        << "\n";
+    }
+
+    // add border correction
+    pars_ini[0] = pars_ini[0] + s1 * r;
+    pars_ini[1] = pars_ini[1] + s2 * r;
+    pars_ini[2] = pars_ini[2] + s3 * r;
+    pars_ini[3] = pars_ini[3];
+
+    // calculate corrected number of hits
+    double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini);
+    const double cathode_visibility_rec = GH_correction * cathode_visibility_geo;
+
+    // 2). detemine visibility of each PD
+    const geo::Point_t hotspot = {plane_depth, ScintPoint.Y(), ScintPoint.Z()};
+    ReflDetectedVisibilities.resize(fNOpDets);
+    for (size_t const OpDet : util::counter(fNOpDets)) {
+      if (!isOpDetInSameTPC(ScintPoint, fOpDetector[OpDet].center)) {
+        ReflDetectedVisibilities[OpDet] = 0.;
+        continue;
+      }
+
+      ReflDetectedVisibilities[OpDet] =
+        VISVisibility(ScintPoint, fOpDetector[OpDet], cathode_visibility_rec, hotspot, AnodeMode);
+    }
+  }
+
+  double SemiAnalyticalModel::VISVisibility(geo::Point_t const& ScintPoint,
+                                            OpticalDetector const& opDet,
+                                            const double cathode_visibility,
+                                            geo::Point_t const& hotspot,
+                                            bool AnodeMode) const
+  {
+    // set correct plane_depth
+    double plane_depth;
+    if (AnodeMode)
+      plane_depth = fanode_plane_depth;
+    else
+      plane_depth = ScintPoint.X() < 0. ? -fplane_depth : fplane_depth;
+
+    // calculate visibility of the optical
+    // detector from the hotspot using solid angle:
+
+    geo::Vector_t const emission_relative = hotspot - opDet.center;
+
+    // calculate distances and angles for application of corrections
+    // distance from hotspot to optical detector
+    const double distance_vis = emission_relative.R();
+    //  angle between hotspot and optical detector
+    double cosine_vis;
+    if (opDet.orientation == 1) { // lateral
+      cosine_vis = std::abs(emission_relative.Y()) / distance_vis;
+    }
+    else { // anode/cathode (default)
+      cosine_vis = std::abs(emission_relative.X()) / distance_vis;
+    }
+    const double theta_vis = fast_acos(cosine_vis) * 180. / CLHEP::pi;
+
+    // calculate solid angle of optical channel
+    double solid_angle_detector = 0.;
+    // ARAPUCAS/Bars (rectangle)
+    if (opDet.type == 0) {
+      // get hotspot coordinates relative to opDet
+      geo::Vector_t const abs_emission_relative{std::abs(emission_relative.X()),
+                                                std::abs(emission_relative.Y()),
+                                                std::abs(emission_relative.Z())};
+      solid_angle_detector =
+        Rectangle_SolidAngle(Dims{opDet.h, opDet.w}, abs_emission_relative, opDet.orientation);
+    }
+    // PMTS (dome)
+    else if (opDet.type == 1) {
+      solid_angle_detector = Omega_Dome_Model(distance_vis, theta_vis);
+    }
+    // PMTs (disk)
+    else if (opDet.type == 2) {
+      const double zy_offset = std::sqrt(emission_relative.Y() * emission_relative.Y() +
+                                         emission_relative.Z() * emission_relative.Z());
+      const double x_distance = std::abs(emission_relative.X());
+      solid_angle_detector = Disk_SolidAngle(zy_offset, x_distance, fradius);
+    }
+    else {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: Invalid optical detector shape requested - configuration "
+           "error in semi-analytical model, only rectangular, dome or disk "
+           "optical detectors are supported."
+        << "\n";
+    }
+
+    // calculate number of hits via geometeric acceptance
+    double visibility_geo = (solid_angle_detector / (2. * CLHEP::pi)) *
+                            cathode_visibility; // 2*pi due to presence of reflective foils
+
+    // determine correction factor, depending on PD type
+    const size_t k = (theta_vis / fdelta_angulo_vis); // off-set angle bin
+    double r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    double d_c = std::abs(ScintPoint.X() - plane_depth); // distance to cathode
+    double border_correction = 0;
+    // flat PDs
+    if ((opDet.type == 0 || opDet.type == 2) && (fIsFlatPDCorr || fIsFlatPDCorrLat)) {
+      // cathode/anode case
+      if (opDet.orientation == 0 && fIsFlatPDCorr) {
+        border_correction =
+          interpolate2(fvis_distances_x_flat, fvis_distances_r_flat, fvispars_flat, d_c, r, k);
+      }
+      // laterals case
+      else if (opDet.orientation == 1 && fIsFlatPDCorrLat) {
+        border_correction = interpolate2(fvis_distances_x_flat_lateral,
+                                         fvis_distances_r_flat_lateral,
+                                         fvispars_flat_lateral,
+                                         d_c,
+                                         r,
+                                         k);
+      }
+      else {
+        throw cet::exception("SemiAnalyticalModel")
+          << "Error: Invalid optical detector shape requested or corrections "
+             "are missing - configuration error in semi-analytical model."
+          << "\n";
+      }
+    }
+    // dome PDs
+    else if (opDet.type == 1 && fIsDomePDCorr) {
+      border_correction =
+        interpolate2(fvis_distances_x_dome, fvis_distances_r_dome, fvispars_dome, d_c, r, k);
+    }
+    else {
+      throw cet::exception("SemiAnalyticalModel")
+        << "Error: Invalid optical detector shape requested or corrections are "
+           "missing - configuration error in semi-analytical model."
+        << "\n";
+    }
+
+    // apply anode reflectivity factor
+    if (AnodeMode) border_correction *= fAnodeReflectivity;
+
+    // apply field cage transparency factor
+    if (fApplyFieldCageTransparency) {
+      if (opDet.orientation == 1)
+        border_correction *= fFieldCageTransparencyLateral;
+      else if (opDet.orientation == 0)
+        border_correction *= fFieldCageTransparencyCathode;
+    }
+
+    return border_correction * visibility_geo / cosine_vis;
+  }
+
+  //......................................................................
+  // Gaisser-Hillas function definition
+  double SemiAnalyticalModel::Gaisser_Hillas(const double x, const double* par) const
+  {
+    double X_mu_0 = par[3];
+    double Normalization = par[0];
+    double Diff = par[1] - X_mu_0;
+    double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
+    double Exponential = std::exp((par[1] - x) / par[2]);
+
+    return (Normalization * Term * Exponential);
+  }
+
+  //......................................................................
+  // solid angle of circular aperture
+  double SemiAnalyticalModel::Disk_SolidAngle(const double d, const double h, const double b) const
+  {
+    if (b <= 0. || d < 0. || h <= 0.) return 0.;
+    const double leg2 = (b + d) * (b + d);
+    const double aa = std::sqrt(h * h / (h * h + leg2));
+    if (isApproximatelyZero(d)) { return 2. * CLHEP::pi * (1. - aa); }
+    double bb = 2. * std::sqrt(b * d / (h * h + leg2));
+    double cc = 4. * b * d / leg2;
+
+    if (isDefinitelyGreaterThan(d, b)) {
+      try {
+        return 2. * aa *
+               (std::sqrt(1. - cc) * boost::math::ellint_3(bb, cc, noLDoublePromote()) -
+                boost::math::ellint_1(bb, noLDoublePromote()));
+      }
+      catch (std::domain_error& e) {
+        if (isApproximatelyEqual(d, b, 1e-9)) {
+          mf::LogWarning("SemiAnalyticalModel")
+            << "Elliptic Integral in Disk_SolidAngle() given parameters "
+               "outside domain."
+            << "\nbb: " << bb << "\ncc: " << cc << "\nException message: " << e.what()
+            << "\nRelax condition and carry on.";
+          return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
+        }
+        else {
+          mf::LogError("SemiAnalyticalModel")
+            << "Elliptic Integral inside Disk_SolidAngle() given parameters "
+               "outside domain.\n"
+            << "\nbb: " << bb << "\ncc: " << cc << "Exception message: " << e.what();
+          return 0.;
+        }
+      }
+    }
+    if (isDefinitelyLessThan(d, b)) {
+      try {
+        return 2. * CLHEP::pi -
+               2. * aa *
+                 (boost::math::ellint_1(bb, noLDoublePromote()) +
+                  std::sqrt(1. - cc) * boost::math::ellint_3(bb, cc, noLDoublePromote()));
+      }
+      catch (std::domain_error& e) {
+        if (isApproximatelyEqual(d, b, 1e-9)) {
+          mf::LogWarning("SemiAnalyticalModel")
+            << "Elliptic Integral in Disk_SolidAngle() given parameters "
+               "outside domain."
+            << "\nbb: " << bb << "\ncc: " << cc << "\nException message: " << e.what()
+            << "\nRelax condition and carry on.";
+          return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
+        }
+        else {
+          mf::LogError("SemiAnalyticalModel")
+            << "Elliptic Integral inside Disk_SolidAngle() given parameters "
+               "outside domain.\n"
+            << "\nbb: " << bb << "\ncc: " << cc << "Exception message: " << e.what();
+          return 0.;
+        }
+      }
+    }
+    if (isApproximatelyEqual(d, b)) {
+      return CLHEP::pi - 2. * aa * boost::math::ellint_1(bb, noLDoublePromote());
+    }
+    return 0.;
+  }
+
+  //......................................................................
+  // solid angle of rectangular aperture
+  double SemiAnalyticalModel::Rectangle_SolidAngle(const double a,
+                                                   const double b,
+                                                   const double d) const
+  {
+    double aa = a / (2. * d);
+    double bb = b / (2. * d);
+    double aux = (1. + aa * aa + bb * bb) / ((1. + aa * aa) * (1. + bb * bb));
+    return 4. * fast_acos(std::sqrt(aux));
+  }
+
+  double SemiAnalyticalModel::Rectangle_SolidAngle(Dims const& o,
+                                                   geo::Vector_t const& v,
+                                                   double OpDetOrientation) const
+  {
+    // v is the position of the track segment with respect to
+    // the center position of the arapuca window
+
+    // solid angle calculation depends on orientation of PD, set correct distances
+    // to use
+    double d1;
+    double d2;
+    if (OpDetOrientation == 1) {
+      // lateral PD, arapuca plane fixed in y direction
+      d1 = std::abs(v.X());
+      d2 = std::abs(v.Y());
+    }
+    else {
+      // anode/cathode PD, arapuca plane fixed in x direction [default]
+      d1 = std::abs(v.Y());
+      d2 = std::abs(v.X());
+    }
+    // arapuca plane fixed in x direction
+    if (isApproximatelyZero(d1) && isApproximatelyZero(v.Z())) {
+      return Rectangle_SolidAngle(o.h, o.w, d2);
+    }
+    if (isDefinitelyGreaterThan(d1, o.h * .5) &&
+        isDefinitelyGreaterThan(std::abs(v.Z()), o.w * .5)) {
+      double A = d1 - o.h * .5;
+      double B = std::abs(v.Z()) - o.w * .5;
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
+                         .25;
+      return to_return;
+    }
+    if ((d1 <= o.h * .5) && (std::abs(v.Z()) <= o.w * .5)) {
+      double A = -d1 + o.h * .5;
+      double B = -std::abs(v.Z()) + o.w * .5;
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
+                         .25;
+      return to_return;
+    }
+    if (isDefinitelyGreaterThan(d1, o.h * .5) && (std::abs(v.Z()) <= o.w * .5)) {
+      double A = d1 - o.h * .5;
+      double B = -std::abs(v.Z()) + o.w * .5;
+      double to_return = (Rectangle_SolidAngle(2. * (A + o.h), 2. * (o.w - B), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * (o.w - B), d2) +
+                          Rectangle_SolidAngle(2. * (A + o.h), 2. * B, d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
+                         .25;
+      return to_return;
+    }
+    if ((d1 <= o.h * .5) && isDefinitelyGreaterThan(std::abs(v.Z()), o.w * .5)) {
+      double A = -d1 + o.h * .5;
+      double B = std::abs(v.Z()) - o.w * .5;
+      double to_return = (Rectangle_SolidAngle(2. * (o.h - A), 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * (o.h - A), 2. * B, d2) +
+                          Rectangle_SolidAngle(2. * A, 2. * (B + o.w), d2) -
+                          Rectangle_SolidAngle(2. * A, 2. * B, d2)) *
+                         .25;
+      return to_return;
+    }
+
+    return 0.;
+  }
+
+  //......................................................................
+  // solid angle of dome aperture
+  double SemiAnalyticalModel::Omega_Dome_Model(const double distance, const double theta) const
+  {
+    // this function calculates the solid angle of a semi-sphere of radius b,
+    // as a correction to the analytic formula of the on-axix solid angle,
+    // as we move off-axis an angle theta. We have used 9-angular bins
+    // with delta_theta width.
+
+    // par0 = Radius correction close
+    // par1 = Radius correction far
+    // par2 = breaking distance betwween "close" and "far"
+
+    constexpr double par0[9] = {0., 0., 0., 0., 0., 0.597542, 1.00872, 1.46993, 2.04221};
+    constexpr double par1[9] = {
+      0., 0., 0.19569, 0.300449, 0.555598, 0.854939, 1.39166, 2.19141, 2.57732};
+    const double delta_theta = 10.; // TODO: should this be fdelta_angulo_vuv?
+    int j = int(theta / delta_theta);
+    // PMT radius
+    const double b = fradius; // cm
+    // distance form which the model parameters break (empirical value)
+    const double d_break = 5 * b; // par2
+
+    if (distance >= d_break) {
+      double R_apparent_far = b - par1[j];
+      double ratio_square = (R_apparent_far * R_apparent_far) / (distance * distance);
+      return (2 * CLHEP::pi * (1 - std::sqrt(1 - ratio_square)));
+    }
+    else {
+      double R_apparent_close = b - par0[j];
+      double ratio_square = (R_apparent_close * R_apparent_close) / (distance * distance);
+      return (2 * CLHEP::pi * (1 - std::sqrt(1 - ratio_square)));
+    }
+  }
+
+  //......................................................................
+  // checks photo-detector is in same TPC/argon volume as scintillation
+  bool SemiAnalyticalModel::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
+                                             geo::Point_t const& OpDetPoint) const
+  {
+    // method working for SBND, uBooNE, DUNE-HD 1x2x6 and DUNE-VD 1x8x6
+    // will need to be replaced to work in full DUNE geometry, ICARUS geometry
+    // check x coordinate has same sign or is close to zero, otherwise return
+    // false
+    if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10. &&
+        fNTPC == 2) { // TODO: replace with geometry service
+      return false;
+    }
+    return true;
+  }
+
+  std::vector<SemiAnalyticalModel::OpticalDetector> SemiAnalyticalModel::opticalDetectors() const
+  {
+    std::vector<SemiAnalyticalModel::OpticalDetector> opticalDetector;
+    for (size_t const i : util::counter(fNOpDets)) {
+      geo::OpDetGeo const& opDet = fGeom.OpDetGeoFromOpDet(i);
+      geo::Point_t center = opDet.GetCenter();
+      double height;
+      double length;
+      int type;
+      int orientation;
+      if (opDet.isSphere()) { // dome PMTs
+        type = 1;             // dome
+        orientation = 0;      // anode/cathode (default)
+        length = -1;
+        height = -1;
+      }
+      else if (opDet.isBar()) {
+        type = 0; // (X)Arapucas/Bars
+        // determine orientation to get correction OpDet dimensions
+        length = opDet.Length();
+        if (opDet.Width() > opDet.Height()) { // laterals, Y dimension smallest
+          orientation = 1;
+          height = opDet.Width();
+        }
+        else { // anode/cathode (default), X dimension smallest
+          orientation = 0;
+          height = opDet.Height();
+        }
+      }
+      else {
+        type = 2;        // disk PMTs
+        orientation = 0; // anode/cathode (default)
+        length = -1;
+        height = -1;
+      }
+      opticalDetector.emplace_back(
+        SemiAnalyticalModel::OpticalDetector{height, length, center, type, orientation});
+    }
+    return opticalDetector;
+  }
+
+} // namespace phot

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -3,8 +3,10 @@
 
 // SemiAnalyticalModel
 //  - fast optical simulation using semi-analytical model
-//  - contains functions to calculate the number of direct and reflected photons incident
-//    each photo-detector, along with the necessary ultility functions (geometry calculations etc.)
+//  - contains functions to calculate the number of direct and reflected photons
+//  incident
+//    each photo-detector, along with the necessary ultility functions (geometry
+//    calculations etc.)
 //  - full description of model: Eur. Phys. J. C 81, 349 (2021)
 
 // Nov 2021 by P. Green
@@ -27,198 +29,130 @@
 typedef boost::math::policies::policy<boost::math::policies::promote_double<false>>
   noLDoublePromote;
 
-class SemiAnalyticalModel {
+namespace phot {
+  class SemiAnalyticalModel {
 
-public:
-  // constructor
-  SemiAnalyticalModel(fhicl::ParameterSet VUVHits,
-                      fhicl::ParameterSet VISHits,
-                      bool doReflectedLight = false,
-                      bool includeAnodeReflections = false);
+  public:
+    // constructor
+    SemiAnalyticalModel(const fhicl::ParameterSet& VUVHits,
+                        const fhicl::ParameterSet& VISHits,
+                        const bool doReflectedLight = false,
+                        const bool includeAnodeReflections = false);
 
-  // direct / VUV light
-  void detectedDirectVisibilities(std::vector<double>& DetectedVisibilities,
-                                  geo::Point_t const& ScintPoint) const;
+    // direct / VUV light
+    void detectedDirectVisibilities(std::vector<double>& DetectedVisibilities,
+                                    geo::Point_t const& ScintPoint) const;
 
-  // reflected / visible light
-  void detectedReflectedVisibilities(std::vector<double>& ReflDetectedVisibilities,
-                                     geo::Point_t const& ScintPoint,
-                                     bool AnodeMode = false) const;
+    // reflected / visible light
+    void detectedReflectedVisibilities(std::vector<double>& ReflDetectedVisibilities,
+                                       geo::Point_t const& ScintPoint,
+                                       bool AnodeMode = false) const;
 
-private:
-  // parameter and geometry initialization
-  void Initialization();
+  private:
+    int VUVAbsorptionLength() const;
 
-  int VUVAbsorptionLength() const;
+    // structure for rectangular solid angle calculation
+    struct Dims {
+      double h, w; // height, width
+    };
 
-  // structure for rectangular solid angle calculation
-  struct Dims {
-    double h, w; // height, width
+    // structure for optical detector information
+    struct OpticalDetector {
+      double h; // height
+      double w; // width
+      geo::Point_t center;
+      int type;
+      int orientation;
+    };
+
+    // direct light photo-detector visibility calculation
+    double VUVVisibility(geo::Point_t const& ScintPoint, OpticalDetector const& opDet) const;
+
+    // reflected light photo-detector visibility calculation
+    double VISVisibility(geo::Point_t const& ScintPoint,
+                         OpticalDetector const& opDet,
+                         const double cathode_visibility,
+                         geo::Point_t const& hotspot,
+                         bool AnodeMode = false) const;
+
+    // Gaisser-Hillas
+    double Gaisser_Hillas(const double x, const double* par) const;
+
+    // solid angle calculations
+    // rectangular aperture
+    double Rectangle_SolidAngle(const double a, const double b, const double d) const;
+    double Rectangle_SolidAngle(Dims const& o,
+                                geo::Vector_t const& v,
+                                const double OpDetOrientation) const;
+    // circular aperture
+    double Disk_SolidAngle(const double d, const double h, const double b) const;
+    // dome aperture calculation
+    double Omega_Dome_Model(const double distance, const double theta) const;
+
+    // TODO: replace with geometry service
+    bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
+    std::vector<OpticalDetector> opticalDetectors() const;
+
+    // geometry properties
+    geo::GeometryCore const& fGeom;
+    const larg4::ISTPC fISTPC;
+    const int fNTPC;
+    const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
+    const TVector3 fcathode_centre, fanode_centre;
+    double fplane_depth, fanode_plane_depth;
+
+    // photodetector geometry properties
+    const size_t fNOpDets;
+    const std::vector<OpticalDetector> fOpDetector;
+    double fradius;
+    Dims fcathode_plane;
+    Dims fanode_plane;
+
+    const int fvuv_absorption_length;
+
+    // For VUV semi-analytic hits
+    double fdelta_angulo_vuv;
+    // flat PDs
+    bool fIsFlatPDCorr;
+    std::vector<std::vector<double>> fGHvuvpars_flat;
+    std::vector<double> fborder_corr_angulo_flat;
+    std::vector<std::vector<double>> fborder_corr_flat;
+    // lateral PDs
+    bool fIsFlatPDCorrLat;
+    std::vector<std::vector<double>> fGHvuvpars_flat_lateral;
+    std::vector<double> fborder_corr_angulo_flat_lateral;
+    std::vector<std::vector<double>> fborder_corr_flat_lateral;
+
+    // dome PDs
+    bool fIsDomePDCorr;
+    std::vector<std::vector<double>> fGHvuvpars_dome;
+    std::vector<double> fborder_corr_angulo_dome;
+    std::vector<std::vector<double>> fborder_corr_dome;
+    // Field cage scaling
+    bool fApplyFieldCageTransparency;
+    double fFieldCageTransparencyLateral;
+    double fFieldCageTransparencyCathode;
+
+    // For VIS semi-analytic hits
+    const bool fDoReflectedLight;
+    const bool fIncludeAnodeReflections;
+    // correction parameters for VIS Nhits estimation
+    double fdelta_angulo_vis;
+    double fAnodeReflectivity;
+    // flat PDs
+    std::vector<double> fvis_distances_x_flat;
+    std::vector<double> fvis_distances_r_flat;
+    std::vector<std::vector<std::vector<double>>> fvispars_flat;
+    // lateral PDs
+    std::vector<double> fvis_distances_x_flat_lateral;
+    std::vector<double> fvis_distances_r_flat_lateral;
+    std::vector<std::vector<std::vector<double>>> fvispars_flat_lateral;
+    // dome PDs
+    std::vector<double> fvis_distances_x_dome;
+    std::vector<double> fvis_distances_r_dome;
+    std::vector<std::vector<std::vector<double>>> fvispars_dome;
   };
 
-  // structure for optical detector information
-  struct OpticalDetector {
-    double h; // height
-    double w; // width
-    geo::Point_t OpDetPoint;
-    int type;
-    int orientation;
-  };
-
-  // direct light photo-detector visibility calculation
-  double VUVVisibility(geo::Point_t const& ScintPoint, OpticalDetector const& opDet) const;
-
-  // reflected light photo-detector visibility calculation
-  double VISVisibility(geo::Point_t const& ScintPoint,
-                       OpticalDetector const& opDet,
-                       const double cathode_visibility,
-                       geo::Point_t const& hotspot,
-                       bool AnodeMode = false) const;
-
-  // Gaisser-Hillas
-  double Gaisser_Hillas(const double x, const double* par) const;
-
-  // solid angle calculations
-  // rectangular aperture
-  double Rectangle_SolidAngle(const double a, const double b, const double d) const;
-  double Rectangle_SolidAngle(Dims const& o,
-                              geo::Vector_t const& v,
-                              const double OpDetOrientation) const;
-  // circular aperture
-  double Disk_SolidAngle(const double d, const double h, const double b) const;
-  // dome aperture calculation
-  double Omega_Dome_Model(const double distance, const double theta) const;
-
-  // utility functions
-  bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
-
-  double fast_acos(double x) const;
-
-  double interpolate(const std::vector<double>& xData,
-                     const std::vector<double>& yData,
-                     double x,
-                     bool extrapolate,
-                     size_t i = 0) const;
-
-  double interpolate2(const std::vector<double>& xDistances,
-                      const std::vector<double>& rDistances,
-                      const std::vector<std::vector<std::vector<double>>>& parameters,
-                      const double x,
-                      const double r,
-                      const size_t k) const;
-
-  // implements relative method - do not use for comparing with zero
-  // use this most of the time, tolerance needs to be meaningful in your context
-  template <typename TReal>
-  inline constexpr static bool
-  isApproximatelyEqual(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
-  {
-    TReal diff = std::fabs(a - b);
-    if (diff <= tolerance) return true;
-    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
-    return false;
-  }
-
-  // supply tolerance that is meaningful in your context
-  // for example, default tolerance may not work if you are comparing double with
-  // float
-  template <typename TReal>
-  inline constexpr static bool isApproximatelyZero(
-    TReal a,
-    TReal tolerance = std::numeric_limits<TReal>::epsilon())
-  {
-    if (std::fabs(a) <= tolerance) return true;
-    return false;
-  }
-
-  // use this when you want to be on safe side
-  // for example, don't start rover unless signal is above 1
-  template <typename TReal>
-  inline constexpr static bool
-  isDefinitelyLessThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
-  {
-    TReal diff = a - b;
-    if (diff < tolerance) return true;
-    if (diff < std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
-    return false;
-  }
-
-  template <typename TReal>
-  inline constexpr static bool
-  isDefinitelyGreaterThan(TReal a, TReal b, TReal tolerance = std::numeric_limits<TReal>::epsilon())
-  {
-    TReal diff = a - b;
-    if (diff > tolerance) return true;
-    if (diff > std::fmax(std::fabs(a), std::fabs(b)) * tolerance) return true;
-    return false;
-  }
-
-  // fhicl parameter sets
-  const fhicl::ParameterSet fVUVHitsParams;
-  const fhicl::ParameterSet fVISHitsParams;
-
-  // geometry properties
-  const larg4::ISTPC fISTPC;
-  geo::GeometryCore const& fGeom;
-  const int fNTPC;
-  const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
-  const TVector3 fcathode_centre, fanode_centre;
-  double fplane_depth, fanode_plane_depth;
-
-  // photodetector geometry properties
-  const size_t nOpDets;
-  double fradius;
-  Dims fcathode_plane;
-  Dims fanode_plane;
-  std::vector<geo::Point_t> fOpDetCenter;
-  std::vector<int> fOpDetType;
-  std::vector<int> fOpDetOrientation;
-  std::vector<double> fOpDetLength;
-  std::vector<double> fOpDetHeight;
-
-  const int fvuv_absorption_length;
-
-  // For VUV semi-analytic hits
-  double fdelta_angulo_vuv;
-  // flat PDs
-  bool fIsFlatPDCorr;
-  std::vector<std::vector<double>> fGHvuvpars_flat;
-  std::vector<double> fborder_corr_angulo_flat;
-  std::vector<std::vector<double>> fborder_corr_flat;
-  // lateral PDs
-  bool fIsFlatPDCorrLat;
-  std::vector<std::vector<double>> fGHvuvpars_flat_lateral;
-  std::vector<double> fborder_corr_angulo_flat_lateral;
-  std::vector<std::vector<double>> fborder_corr_flat_lateral;
-
-  // dome PDs
-  bool fIsDomePDCorr;
-  std::vector<std::vector<double>> fGHvuvpars_dome;
-  std::vector<double> fborder_corr_angulo_dome;
-  std::vector<std::vector<double>> fborder_corr_dome;
-  // Field cage scaling
-  bool fApplyFieldCageTransparency;
-  double fFieldCageTransparencyLateral;
-  double fFieldCageTransparencyCathode;
-
-  // For VIS semi-analytic hits
-  const bool fDoReflectedLight;
-  const bool fIncludeAnodeReflections;
-  // correction parameters for VIS Nhits estimation
-  double fdelta_angulo_vis;
-  double fAnodeReflectivity;
-  // flat PDs
-  std::vector<double> fvis_distances_x_flat;
-  std::vector<double> fvis_distances_r_flat;
-  std::vector<std::vector<std::vector<double>>> fvispars_flat;
-  // lateral PDs
-  std::vector<double> fvis_distances_x_flat_lateral;
-  std::vector<double> fvis_distances_r_flat_lateral;
-  std::vector<std::vector<std::vector<double>>> fvispars_flat_lateral;
-  // dome PDs
-  std::vector<double> fvis_distances_x_dome;
-  std::vector<double> fvis_distances_r_dome;
-  std::vector<std::vector<std::vector<double>>> fvispars_dome;
-};
+} // namespace phot
 
 #endif


### PR DESCRIPTION
While inspecting the code for bugs I tend to make changes to the code to make tests. I've collected enough of these changes that it makes sense to put them together neatly.

This PR improves performance times and hopefully improves the organisation of the code. The processing time per event doesn't change much, but the initialisation is substantially reduced.

Functionality stays largely the same, but there is is a small change in the time propagation distribution, which is expected. 

Main changes:

- Change from using ROOT RNG to CLHEP::RandGeneral
- Create PhotonPropagationUtils to host functions defined twice elsewhere
- Use references of the fcl parameters, instead of copying the objects
- Move PropagationTimeModel and SemiAnalyticalModel to the `phot` namespace
- Simplify the initialisation and reduce the number of class members, moving several things around and creating some functions to use them during initialisation
- Round scintillation times instead of flooring them
- Stop using TVector3
- Regularise the syntax and clean comments

I'm opening this PR as a draft to accept possible suggestions to improve the code. I've created a CI test, but it hasn't been enabled yet. I'll update this PR with the results from the test once I have them.