### PR TITLE
Save MotherTrackID in the SimPhotons

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -449,6 +449,7 @@ namespace phot {
             sim::OnePhoton photon;
             photon.SetInSD = false;
             photon.InitialPosition = edepi.End();
+            photon.MotherTrackID = edepi.TrackID();
             if (Reflected)
               photon.Energy = 2.9 * CLHEP::eV; // 430 nm
             else

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -298,6 +298,7 @@ namespace phot {
             sim::OnePhoton photon;
             photon.SetInSD = false;
             photon.InitialPosition = edepi.End();
+	    photon.MotherTrackID = edepi.TrackID();
             if (Reflected)
               photon.Energy = 2.9 * CLHEP::eV; // 430 nm
             else

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -298,7 +298,7 @@ namespace phot {
             sim::OnePhoton photon;
             photon.SetInSD = false;
             photon.InitialPosition = edepi.End();
-	    photon.MotherTrackID = edepi.TrackID();
+            photon.MotherTrackID = edepi.TrackID();
             if (Reflected)
               photon.Energy = 2.9 * CLHEP::eV; // 430 nm
             else


### PR DESCRIPTION
Running the light simulation with`SimPhotons` we found the `MotherTrackID` attribute was not being filled. This PR fixes this.