### PR TITLE
Fix ParentIDMap in LArG4 for OrigTrackID

### DIFF
--- a/larsim/LegacyLArG4/ParticleListAction.cxx
+++ b/larsim/LegacyLArG4/ParticleListAction.cxx
@@ -76,6 +76,7 @@ namespace larg4 {
     if (fparticleList) fparticleList->clear();
     if (fdroppedParticleList) fdroppedParticleList->clear();
     fParentIDMap.clear();
+    fParentIDMap_OrigTrackID.clear();
     fCurrentTrackID = sim::NoParticleId;
     fCurrentOrigTrackID = sim::NoParticleId;
     fCurrentPdgCode = 0;


### PR DESCRIPTION
In `ParticleListAction` within LArG4, the ParentIDMap was not being reset for each new event for OrigTrackID (the recently added field to keep track of dropped EM shower daughters even when `KeepEMShowerDaughters` is `false`). This is a one line fix, but quite urgently needed by Icarus. Thank you!!