### PR TITLE
Adding alpha quenching to the Correlated IonAndScint method

### DIFF
--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -59,8 +59,8 @@ namespace larg4 {
     fLarqlChi0C = LArG4PropHandle->LarqlChi0C();
     fLarqlChi0D = LArG4PropHandle->LarqlChi0D();
     fLarqlAlpha = LArG4PropHandle->LarqlAlpha();
-    fLarqlBeta  = LArG4PropHandle->LarqlBeta();
-    fQAlpha     = LArG4PropHandle->QAlpha();
+    fLarqlBeta = LArG4PropHandle->LarqlBeta();
+    fQAlpha = LArG4PropHandle->QAlpha();
     fGeVToElectrons = LArG4PropHandle->GeVToElectrons();
 
     // ionization work function
@@ -78,8 +78,8 @@ namespace larg4 {
     double const energy_deposit = edep.Energy();
 
     // calculate total quanta (ions + excitons)
-    double num_ions=0.0; //check if the deposited energy is above ionization threshold
-    if(energy_deposit>=fWion) num_ions = energy_deposit / fWion;
+    double num_ions = 0.0; //check if the deposited energy is above ionization threshold
+    if (energy_deposit >= fWion) num_ions = energy_deposit / fWion;
     double num_quanta = energy_deposit / fWph;
 
     double ds = edep.StepLength();
@@ -102,7 +102,8 @@ namespace larg4 {
       }
     }
 
-    if (fUseModLarqlRecomb && edep.PdgCode()!=1000020040) { //Use corrections from LArQL model (except for alpha)
+    if (fUseModLarqlRecomb &&
+        edep.PdgCode() != 1000020040) { //Use corrections from LArQL model (except for alpha)
       recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF
     }
 
@@ -119,16 +120,17 @@ namespace larg4 {
     }
 
     // using this recombination, calculate number of ionization electrons
-    if(num_ions>0.) num_electrons =
-      (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
+    if (num_ions > 0.)
+      num_electrons =
+        (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
 
-    if(edep.PdgCode()==1000020040){
-      num_electrons = num_electrons*fQAlpha;
-      num_photons = num_photons*fQAlpha;
-      }
+    if (edep.PdgCode() == 1000020040) {
+      num_electrons = num_electrons * fQAlpha;
+      num_photons = num_photons * fQAlpha;
+    }
 
     MF_LOG_DEBUG("ISCalcCorrelated")
       << "With " << energy_deposit << " MeV of deposited energy, "

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -77,14 +77,15 @@ namespace larg4 {
     double const energy_deposit = edep.Energy();
 
     // calculate total quanta (ions + excitons)
-    double num_ions = energy_deposit / fWion;
+    double num_ions=0.0; //check if the deposited energy is above ionization threshold
+    if(energy_deposit>=fWion) num_ions = energy_deposit / fWion;
     double num_quanta = energy_deposit / fWph;
 
     double ds = edep.StepLength();
     double dEdx = (ds <= 0.0) ? 0.0 : energy_deposit / ds;
     dEdx = (dEdx < 1.) ? 1. : dEdx;
     double EFieldStep = EFieldAtStep(detProp.Efield(), edep);
-    double recomb = 0.;
+    double recomb = 0., num_electrons = 0.;
 
     //calculate recombination survival fraction value inside, otherwise zero
     if (EFieldStep > 0.) {
@@ -117,8 +118,8 @@ namespace larg4 {
     }
 
     // using this recombination, calculate number of ionization electrons
-    double num_electrons =
-      (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
+    if(num_ions>0.) num_electrons =
+      (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);    
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -59,7 +59,8 @@ namespace larg4 {
     fLarqlChi0C = LArG4PropHandle->LarqlChi0C();
     fLarqlChi0D = LArG4PropHandle->LarqlChi0D();
     fLarqlAlpha = LArG4PropHandle->LarqlAlpha();
-    fLarqlBeta = LArG4PropHandle->LarqlBeta();
+    fLarqlBeta  = LArG4PropHandle->LarqlBeta();
+    fQAlpha     = LArG4PropHandle->QAlpha();
     fGeVToElectrons = LArG4PropHandle->GeVToElectrons();
 
     // ionization work function
@@ -101,7 +102,7 @@ namespace larg4 {
       }
     }
 
-    if (fUseModLarqlRecomb) { //Use corrections from LArQL model
+    if (fUseModLarqlRecomb && edep.PdgCode()!=1000020040) { //Use corrections from LArQL model (except for alpha)
       recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF
     }
 
@@ -119,10 +120,15 @@ namespace larg4 {
 
     // using this recombination, calculate number of ionization electrons
     if(num_ions>0.) num_electrons =
-      (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);    
+      (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
+
+    if(edep.PdgCode()==1000020040){
+      num_electrons = num_electrons*fQAlpha;
+      num_photons = (num_quanta - num_electrons) * fScintPreScale*fQAlpha;
+      }
 
     MF_LOG_DEBUG("ISCalcCorrelated")
       << "With " << energy_deposit << " MeV of deposited energy, "

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -127,7 +127,7 @@ namespace larg4 {
 
     if(edep.PdgCode()==1000020040){
       num_electrons = num_electrons*fQAlpha;
-      num_photons = (num_quanta - num_electrons) * fScintPreScale*fQAlpha;
+      num_photons = num_photons*fQAlpha;
       }
 
     MF_LOG_DEBUG("ISCalcCorrelated")

--- a/larsim/IonizationScintillation/ISCalcCorrelated.h
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.h
@@ -60,6 +60,7 @@ namespace larg4 {
     double fLarqlChi0D;      ///< from LArG4Parameters service
     double fLarqlAlpha;      ///< from LArG4Parameters service
     double fLarqlBeta;       ///< from LArG4Parameters service
+    double fQAlpha;          ///< from LArG4Parameters service
     bool fUseModBoxRecomb;   ///< from LArG4Parameters service
     bool fUseModLarqlRecomb; ///< from LArG4Parameters service
     bool fUseBinomialFlucts; ///< from LArG4Parameters service

--- a/larsim/Simulation/LArG4Parameters.cc
+++ b/larsim/Simulation/LArG4Parameters.cc
@@ -53,6 +53,7 @@ namespace sim {
     , fLarqlAlpha{pset.get<double>("LarqlAlpha")}
     , fLarqlBeta{pset.get<double>("LarqlBeta")}
     , fWph{pset.get<double>("Wph")}
+    , fQAlpha{pset.get<double>("QAlpha")}
     , fUseModBoxRecomb{pset.get<bool>("UseModBoxRecomb")}
     , fUseModLarqlRecomb{pset.get<bool>("UseModLarqlRecomb")}
     , fUseBinomialFlucts{pset.get<bool>("UseBinomialFlucts", true)}

--- a/larsim/Simulation/LArG4Parameters.h
+++ b/larsim/Simulation/LArG4Parameters.h
@@ -50,6 +50,7 @@ namespace sim {
     double LarqlAlpha() const { return fLarqlAlpha; }
     double LarqlBeta() const { return fLarqlBeta; }
     double Wph() const { return fWph; }
+    double QAlpha() const { return fQAlpha; }
     bool UseModBoxRecomb() const { return fUseModBoxRecomb; }
     bool UseModLarqlRecomb() const { return fUseModLarqlRecomb; }
     bool UseBinomialFlucts() const { return fUseBinomialFlucts; }
@@ -124,6 +125,7 @@ namespace sim {
     double const fLarqlAlpha;      ///< Possibly override the LarqlAlpha parameter
     double const fLarqlBeta;       ///< Possibly override the LarqlBeta parameter
     double const fWph;             ///< Possibly override the Wph parameter
+    double const fQAlpha;          ///< Possibly override the QAlpha parameter
     bool const fUseModBoxRecomb;   ///< Use Modified Box model recombination instead of Birks
     bool const fUseModLarqlRecomb; ///< Use LArQL model recombination correction (dependence on EF)
     bool const fUseBinomialFlucts; ///< Use binomial fluctuations in correlated method

--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -43,7 +43,8 @@ standard_largeantparameters:
  ModBoxA: 0.930
  ModBoxB: 0.212
 
- #* Recombination factor coefficients for LArQL can be found in https://cdcvs.fnal.gov/redmine/projects/larsoft/wiki/LArQL_algorithm
+ #* Recombination factor coefficients for LArQL
+ #* https://doi.org/10.1088/1748-0221/17/07/C07009
  #* * @f$ dE/dx @f$ is given by the energy deposition in MeV/cm
  #* * electric field: @f$ E @f$ in kV/cm
  LarqlChi0A: 0.00338427
@@ -52,6 +53,10 @@ standard_largeantparameters:
  LarqlChi0D: 0.000129379
  LarqlAlpha: 0.0372
  LarqlBeta: 0.0124
+
+  #* alpha particle quenching factor
+  #* Doke et al. Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538
+ QAlpha: 0.72
 
   #* ion+excitation work function in eV
   #* https://doi.org/10.1016/0168-9002(90)90011-T


### PR DESCRIPTION
The DUNE low energy group requested a separate treatment for the alpha particle when calculating the ionization and scintillation obtained from it. Alpha particles produce a reduced scintillation signal compared to electrons of the same energy, an effect known as quenching due to high excitation density. To address this, the modification of the charge yield added by LArQL (escaping electrons and electric field corrections) was removed for the alpha particle. In this way, alpha LY will not depend on the electric field (it has a small dependence on the EF but the _opposite_ one that is currently being calculated by LArQL). A fhicl parameter, the quenching factor, QAlpha, was introduced with default value of 0.72 following Doke et al. 2002. With this value, the alpha LY is ~36000 ph/MeV. This factor affects both light and charge.
References: A Hitachi, A Yunoki, T Doke, T Takahashi - PRA 35, 3956 (1987); Doke et al. Jpn. J. Appl. Phys. v. 41 (2002) pt. 1, 3A
A small correction to the method was also added: binomial sample on the number of electrons generated is only called if the deposited energy is higher than the ionization threshold.