### PR TITLE
Adding An Ellipsoidal Model for Recombination

### DIFF
--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -117,8 +117,7 @@ namespace larg4 {
         }
         else {
           double B_ellips = fEllipsModBoxB * dEdx /
-                            (EFieldStep * sqrt(pow(std::sin(phi), 2) +
-                                               (pow(std::cos(phi), 2) / pow(fEllipsModBoxR, 2))));
+                            (EFieldStep * std::hypot(std::sin(phi),  std::cos(phi) / fEllipsModBoxR));
 
           recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
         }

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -108,8 +108,7 @@ namespace larg4 {
                          pow(edep.StartZ() - edep.EndZ(), 2)));
 
         if (phi > std::atan(1) * 2) {
-          double temp_phi = phi;
-          phi = std::atan(1) * 4 - temp_phi;
+          phi = std::atan(1) * 4 - phi;
         }
 
         if (phi != phi) {

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -104,17 +104,16 @@ namespace larg4 {
 
         double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
 
-        if (phi > std::atan(1) * 2) {
-          phi = std::atan(1) * 4 - phi;
-        }
+        if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
 
         if (phi != phi) {
           double Xi = fModBoxB * dEdx / EFieldStep;
           recomb = std::log(fModBoxA + Xi) / Xi;
         }
         else {
-          double B_ellips = fEllipsModBoxB * dEdx /
-                            (EFieldStep * std::hypot(std::sin(phi),  std::cos(phi) / fEllipsModBoxR));
+          double B_ellips =
+            fEllipsModBoxB * dEdx /
+            (EFieldStep * std::hypot(std::sin(phi), std::cos(phi) / fEllipsModBoxR));
 
           recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
         }

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -102,11 +102,9 @@ namespace larg4 {
       }
       else if (fUseEllipsModBoxRecomb) {
 
-        double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
+        double phi = AngleToEFieldAtStep(detProp.Efield(), edep);
 
-        if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
-
-        if (phi != phi) {
+        if (std::isnan(phi)) {
           double Xi = fModBoxB * dEdx / EFieldStep;
           recomb = std::log(fModBoxA + Xi) / Xi;
         }
@@ -173,6 +171,45 @@ namespace larg4 {
 
     auto const eFieldOffsets = fSCE->GetEfieldOffsets(edep.MidPoint());
     return efield * std::hypot(1 + eFieldOffsets.X(), eFieldOffsets.Y(), eFieldOffsets.Z());
+  }
+  //----------------------------------------------------------------------------
+  double ISCalcCorrelated::AngleToEFieldAtStep(double efield, sim::SimEnergyDeposit const& edep)
+  {
+
+    // electric field outside active volume set to zero
+    if (!fISTPC.isScintInActiveVolume(edep.MidPoint())) return 0.;
+
+    TVector3 stepvec(
+      edep.StartX() - edep.EndX(), edep.StartY() - edep.EndY(), edep.StartZ() - edep.EndZ());
+
+    TVector3 elecvec;
+
+    art::ServiceHandle<geo::Geometry const> fGeometry;
+    geo::TPCID tpcid = fGeometry->PositionToTPCID(edep.MidPoint());
+    const geo::TPCGeo& tpcGeo = fGeometry->TPC(tpcid);
+
+    if (tpcGeo.DetectDriftDirection() == 1) elecvec.SetXYZ(1, 0, 0);
+    if (tpcGeo.DetectDriftDirection() == -1) elecvec.SetXYZ(-1, 0, 0);
+    if (tpcGeo.DetectDriftDirection() == 2) elecvec.SetXYZ(0, 1, 0);
+    if (tpcGeo.DetectDriftDirection() == -2) elecvec.SetXYZ(0, -1, 0);
+    if (tpcGeo.DetectDriftDirection() == 3) elecvec.SetXYZ(0, 0, 1);
+    if (tpcGeo.DetectDriftDirection() == -3) elecvec.SetXYZ(0, 0, -1);
+
+    elecvec *= efield;
+
+    // electric field inside active volume
+    if (fSCE->EnableSimEfieldSCE()) {
+      auto const eFieldOffsets = fSCE->GetEfieldOffsets(edep.MidPoint());
+      TVector3 scevec(
+        efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      elecvec += scevec;
+    }
+
+    double angle = std::acos(stepvec.Dot(elecvec) / (stepvec.Mag() * elecvec.Mag()));
+
+    if (angle > TMath::PiOver2()) { angle = abs(TMath::Pi() - angle); }
+
+    return angle;
   }
 
   //----------------------------------------------------------------------------

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -51,7 +51,11 @@ namespace larg4 {
     fRecombk = LArG4PropHandle->Recombk() / detProp.Density(detProp.Temperature());
     fModBoxA = LArG4PropHandle->ModBoxA();
     fModBoxB = LArG4PropHandle->ModBoxB() / detProp.Density(detProp.Temperature());
+    fEllipsModBoxA = LArG4PropHandle->EllipsModBoxA();
+    fEllipsModBoxB = LArG4PropHandle->EllipsModBoxB() / detProp.Density(detProp.Temperature());
+    fEllipsModBoxR = LArG4PropHandle->EllipsModBoxR();
     fUseModBoxRecomb = (bool)LArG4PropHandle->UseModBoxRecomb();
+    fUseEllipsModBoxRecomb = (bool)LArG4PropHandle->UseEllipsModBoxRecomb();
     fUseModLarqlRecomb = (bool)LArG4PropHandle->UseModLarqlRecomb();
     fUseBinomialFlucts = (bool)LArG4PropHandle->UseBinomialFlucts();
     fLarqlChi0A = LArG4PropHandle->LarqlChi0A();
@@ -75,74 +79,94 @@ namespace larg4 {
                                                sim::SimEnergyDeposit const& edep)
   {
 
-    double const energy_deposit = edep.Energy();
-
-    // calculate total quanta (ions + excitons)
-    double num_ions = 0.0; //check if the deposited energy is above ionization threshold
-    if (energy_deposit >= fWion) num_ions = energy_deposit / fWion;
-    double num_quanta = energy_deposit / fWph;
-
-    double ds = edep.StepLength();
-    double dEdx = (ds <= 0.0) ? 0.0 : energy_deposit / ds;
-    dEdx = (dEdx < 1.) ? 1. : dEdx;
-    double EFieldStep = EFieldAtStep(detProp.Efield(), edep);
-    double recomb = 0., num_electrons = 0.;
-
-    //calculate recombination survival fraction value inside, otherwise zero
-    if (EFieldStep > 0.) {
-      // calculate recombination survival fraction
-      // ...using Modified Box model
-      if (fUseModBoxRecomb) {
-        double Xi = fModBoxB * dEdx / EFieldStep;
-        recomb = std::log(fModBoxA + Xi) / Xi;
+      double const energy_deposit = edep.Energy();
+      
+      // calculate total quanta (ions + excitons)
+      double num_ions = 0.0; //check if the deposited energy is above ionization threshold
+      if (energy_deposit >= fWion) num_ions = energy_deposit / fWion;
+      double num_quanta = energy_deposit / fWph;
+      
+      double ds = edep.StepLength();
+      double dEdx = (ds <= 0.0) ? 0.0 : energy_deposit / ds;
+      dEdx = (dEdx < 1.) ? 1. : dEdx;
+      double EFieldStep = EFieldAtStep(detProp.Efield(), edep);
+      double recomb = 0., num_electrons = 0.;
+      
+      //calculate recombination survival fraction value inside, otherwise zero
+      if (EFieldStep > 0.) {
+	// calculate recombination survival fraction
+	// ...using Modified Box model
+	if (fUseModBoxRecomb) {
+	  double Xi = fModBoxB * dEdx / EFieldStep;
+	  recomb = std::log(fModBoxA + Xi) / Xi;
       }
-      // ... or using Birks/Doke
-      else {
-        recomb = fRecombA / (1. + dEdx * fRecombk / EFieldStep);
+	else if (fUseEllipsModBoxRecomb){
+
+	  double phi = std::acos(abs(edep.StartX() - edep.EndX()) / sqrt(pow(edep.StartX() - edep.EndX(), 2) + pow(edep.StartY() - edep.EndY(), 2) + pow(edep.StartZ() - edep.EndZ(), 2)));
+	  
+	  if(phi > std::atan(1)*2){
+	    double temp_phi = phi;
+	    phi = std::atan(1)*4-temp_phi;
+	  }
+	  
+	  if(phi != phi){
+	    double Xi = fModBoxB * dEdx / EFieldStep;
+	    recomb = std::log(fModBoxA + Xi) / Xi;
+	  }	  
+	  else{
+	    double B_ellips = fEllipsModBoxB * dEdx / (EFieldStep * sqrt( pow(std::sin(phi),2) + ( pow(std::cos(phi),2) / pow(fEllipsModBoxR,2)))); 
+
+	    recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
+	    
+	  }
+	}
+	// ... or using Birks/Doke
+	else {
+	  recomb = fRecombA / (1. + dEdx * fRecombk / EFieldStep);
+	}
       }
-    }
+      
+      if (fUseModLarqlRecomb &&
+	  edep.PdgCode() != 1000020040) { //Use corrections from LArQL model (except for alpha)
+	recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF
+      }
 
-    if (fUseModLarqlRecomb &&
-        edep.PdgCode() != 1000020040) { //Use corrections from LArQL model (except for alpha)
-      recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF
-    }
-
-    // Guard against unphysical recombination values
-    if (recomb < 0.) {
-      mf::LogWarning("ISCalcCorrelated")
-        << "Recombination survival fraction is lower than 0.: " << recomb << ", fixing it to 0.";
-      recomb = 0.;
-    }
-    else if (recomb > 1.) {
-      mf::LogWarning("ISCalcCorrelated")
+      // Guard against unphysical recombination values
+      if (recomb < 0.) {
+	mf::LogWarning("ISCalcCorrelated")
+	  << "Recombination survival fraction is lower than 0.: " << recomb << ", fixing it to 0.";
+	recomb = 0.;
+      }
+      else if (recomb > 1.) {
+	mf::LogWarning("ISCalcCorrelated")
         << "Recombination survival fraction is higher than 1.: " << recomb << ", fixing it to 1.";
-      recomb = 1.;
-    }
+	recomb = 1.;
+      }
 
-    // using this recombination, calculate number of ionization electrons
-    if (num_ions > 0.)
-      num_electrons =
-        (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
-
-    // calculate scintillation photons
-    double num_photons = (num_quanta - num_electrons) * fScintPreScale;
-
-    if (edep.PdgCode() == 1000020040) {
-      num_electrons = num_electrons * fQAlpha;
-      num_photons = num_photons * fQAlpha;
-    }
-
+      // using this recombination, calculate number energy_deposit of ionization electrons
+      if (num_ions > 0.)
+      	num_electrons =
+	  (fUseBinomialFlucts) ? fBinomialGen.fire(num_ions, recomb) : (num_ions * recomb);
+      
+      // calculate scintillation photons
+      double num_photons = (num_quanta - num_electrons) * fScintPreScale;
+      
+      if (edep.PdgCode() == 1000020040) {
+	num_electrons = num_electrons * fQAlpha;
+	num_photons = num_photons * fQAlpha;
+      }
+          
     MF_LOG_DEBUG("ISCalcCorrelated")
       << "With " << energy_deposit << " MeV of deposited energy, "
       << "and a recombination of " << recomb << ", \nthere are " << num_electrons
       << " electrons, and " << num_photons << " photons.";
-
+     
     return {energy_deposit, num_electrons, num_photons, GetScintYieldRatio(edep)};
   }
-
+    
   //----------------------------------------------------------------------------
-  double ISCalcCorrelated::EFieldAtStep(double efield, sim::SimEnergyDeposit const& edep)
-  {
+    double ISCalcCorrelated::EFieldAtStep(double efield, sim::SimEnergyDeposit const& edep)
+    {
     // electric field outside active volume set to zero
     if (!fISTPC.isScintInActiveVolume(edep.MidPoint())) return 0.;
 

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -102,10 +102,7 @@ namespace larg4 {
       }
       else if (fUseEllipsModBoxRecomb) {
 
-        double phi =
-          std::acos(abs(edep.StartX() - edep.EndX()) /
-                    sqrt(pow(edep.StartX() - edep.EndX(), 2) + pow(edep.StartY() - edep.EndY(), 2) +
-                         pow(edep.StartZ() - edep.EndZ(), 2)));
+        double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
 
         if (phi > std::atan(1) * 2) {
           phi = std::atan(1) * 4 - phi;

--- a/larsim/IonizationScintillation/ISCalcCorrelated.h
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.h
@@ -38,6 +38,7 @@ namespace larg4 {
     double EFieldAtStep(double efield,
                         sim::SimEnergyDeposit const& edep)
       override; //value of field with any corrections for this step
+    double AngleToEFieldAtStep(double efield, sim::SimEnergyDeposit const& edep);
     ISCalcData CalcIonAndScint(detinfo::DetectorPropertiesData const& detProp,
                                sim::SimEnergyDeposit const& edep) override;
 

--- a/larsim/IonizationScintillation/ISCalcCorrelated.h
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.h
@@ -54,6 +54,9 @@ namespace larg4 {
     double fRecombk;         ///< from LArG4Parameters service
     double fModBoxA;         ///< from LArG4Parameters service
     double fModBoxB;         ///< from LArG4Parameters service
+    double fEllipsModBoxA;   ///< from LArG4Parameters service
+    double fEllipsModBoxB;   ///< from LArG4Parameters service
+    double fEllipsModBoxR;   ///< from LArG4Parameters service
     double fLarqlChi0A;      ///< from LArG4Parameters service
     double fLarqlChi0B;      ///< from LArG4Parameters service
     double fLarqlChi0C;      ///< from LArG4Parameters service
@@ -62,6 +65,7 @@ namespace larg4 {
     double fLarqlBeta;       ///< from LArG4Parameters service
     double fQAlpha;          ///< from LArG4Parameters service
     bool fUseModBoxRecomb;   ///< from LArG4Parameters service
+    bool fUseEllipsModBoxRecomb; ///< from LArG4Parameters service
     bool fUseModLarqlRecomb; ///< from LArG4Parameters service
     bool fUseBinomialFlucts; ///< from LArG4Parameters service
 

--- a/larsim/IonizationScintillation/ISCalcCorrelated.h
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.h
@@ -46,28 +46,28 @@ namespace larg4 {
     const spacecharge::SpaceCharge* fSCE;
     CLHEP::RandBinomial fBinomialGen;
 
-    double fGeVToElectrons;  ///< from LArG4Parameters service
-    double fWion;            ///< W_ion (23.6 eV) == 1/fGeVToElectrons
-    double fWph;             ///< from LArG4Parameters service
-    double fScintPreScale;   ///< scintillation pre-scaling factor from LArProperties service
-    double fRecombA;         ///< from LArG4Parameters service
-    double fRecombk;         ///< from LArG4Parameters service
-    double fModBoxA;         ///< from LArG4Parameters service
-    double fModBoxB;         ///< from LArG4Parameters service
-    double fEllipsModBoxA;   ///< from LArG4Parameters service
-    double fEllipsModBoxB;   ///< from LArG4Parameters service
-    double fEllipsModBoxR;   ///< from LArG4Parameters service
-    double fLarqlChi0A;      ///< from LArG4Parameters service
-    double fLarqlChi0B;      ///< from LArG4Parameters service
-    double fLarqlChi0C;      ///< from LArG4Parameters service
-    double fLarqlChi0D;      ///< from LArG4Parameters service
-    double fLarqlAlpha;      ///< from LArG4Parameters service
-    double fLarqlBeta;       ///< from LArG4Parameters service
-    double fQAlpha;          ///< from LArG4Parameters service
-    bool fUseModBoxRecomb;   ///< from LArG4Parameters service
+    double fGeVToElectrons;      ///< from LArG4Parameters service
+    double fWion;                ///< W_ion (23.6 eV) == 1/fGeVToElectrons
+    double fWph;                 ///< from LArG4Parameters service
+    double fScintPreScale;       ///< scintillation pre-scaling factor from LArProperties service
+    double fRecombA;             ///< from LArG4Parameters service
+    double fRecombk;             ///< from LArG4Parameters service
+    double fModBoxA;             ///< from LArG4Parameters service
+    double fModBoxB;             ///< from LArG4Parameters service
+    double fEllipsModBoxA;       ///< from LArG4Parameters service
+    double fEllipsModBoxB;       ///< from LArG4Parameters service
+    double fEllipsModBoxR;       ///< from LArG4Parameters service
+    double fLarqlChi0A;          ///< from LArG4Parameters service
+    double fLarqlChi0B;          ///< from LArG4Parameters service
+    double fLarqlChi0C;          ///< from LArG4Parameters service
+    double fLarqlChi0D;          ///< from LArG4Parameters service
+    double fLarqlAlpha;          ///< from LArG4Parameters service
+    double fLarqlBeta;           ///< from LArG4Parameters service
+    double fQAlpha;              ///< from LArG4Parameters service
+    bool fUseModBoxRecomb;       ///< from LArG4Parameters service
     bool fUseEllipsModBoxRecomb; ///< from LArG4Parameters service
-    bool fUseModLarqlRecomb; ///< from LArG4Parameters service
-    bool fUseBinomialFlucts; ///< from LArG4Parameters service
+    bool fUseModLarqlRecomb;     ///< from LArG4Parameters service
+    bool fUseBinomialFlucts;     ///< from LArG4Parameters service
 
     double EscapingEFraction(
       double const dEdx) const; //LArQL chi0 function = fraction of escaping electrons

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
@@ -71,7 +71,7 @@ namespace larg4 {
     fLarqlBeta = lgpHandle->LarqlBeta();
     fUseModBoxRecomb = lgpHandle->UseModBoxRecomb();
     fUseEllipsModBoxRecomb = (bool)lgpHandle->UseEllipsModBoxRecomb();
-    
+
     fUseModLarqlRecomb = lgpHandle->UseModLarqlRecomb();
 
     // determine the step size using the voxel sizes
@@ -133,27 +133,25 @@ namespace larg4 {
         recomb = 0;
     }
     else if (fUseEllipsModBoxRecomb) {
-      
+
       double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
-      
+
       if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
-      
+
       if (phi != phi) {
-	double Xi = fModBoxB * dEdx / EFieldStep;
-	recomb = std::log(fModBoxA + Xi) / Xi;
+        double Xi = fModBoxB * dEdx / EFieldStep;
+        recomb = std::log(fModBoxA + Xi) / Xi;
       }
       else {
-	double B_ellips =
-	  fEllipsModBoxB * dEdx /
-	  (EFieldStep * std::hypot(std::sin(phi), std::cos(phi) / fEllipsModBoxR));
-	
-	recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
+        double B_ellips = fEllipsModBoxB * dEdx /
+                          (EFieldStep * std::hypot(std::sin(phi), std::cos(phi) / fEllipsModBoxR));
+
+        recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
       }
     }
     else {
       recomb = fRecombA / (1. + dEdx * fRecombk / EFieldStep);
     }
-
 
     if (fUseModLarqlRecomb) { //Use corrections from LArQL model
       recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
@@ -134,7 +134,7 @@ namespace larg4 {
     }
     else if (fUseEllipsModBoxRecomb) {
 
-      double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
+      double phi = std::acos(abs(step->GetPreStepPoint()->GetPosition().x() - step->GetPostStepPoint()->GetPosition().x()) / step->GetStepLength());
 
       if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
 

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
@@ -134,7 +134,9 @@ namespace larg4 {
     }
     else if (fUseEllipsModBoxRecomb) {
 
-      double phi = std::acos(abs(step->GetPreStepPoint()->GetPosition().x() - step->GetPostStepPoint()->GetPosition().x()) / step->GetStepLength());
+      double phi = std::acos(abs(step->GetPreStepPoint()->GetPosition().x() -
+                                 step->GetPostStepPoint()->GetPosition().x()) /
+                             step->GetStepLength());
 
       if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
 

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.cxx
@@ -60,6 +60,9 @@ namespace larg4 {
     fRecombk = lgpHandle->Recombk() / density;
     fModBoxA = lgpHandle->ModBoxA();
     fModBoxB = lgpHandle->ModBoxB() / density;
+    fEllipsModBoxA = lgpHandle->EllipsModBoxA();
+    fEllipsModBoxB = lgpHandle->EllipsModBoxB() / detProp.Density(detProp.Temperature());
+    fEllipsModBoxR = lgpHandle->EllipsModBoxR();
     fLarqlChi0A = lgpHandle->LarqlChi0A();
     fLarqlChi0B = lgpHandle->LarqlChi0B();
     fLarqlChi0C = lgpHandle->LarqlChi0C();
@@ -67,6 +70,8 @@ namespace larg4 {
     fLarqlAlpha = lgpHandle->LarqlAlpha();
     fLarqlBeta = lgpHandle->LarqlBeta();
     fUseModBoxRecomb = lgpHandle->UseModBoxRecomb();
+    fUseEllipsModBoxRecomb = (bool)lgpHandle->UseEllipsModBoxRecomb();
+    
     fUseModLarqlRecomb = lgpHandle->UseModLarqlRecomb();
 
     // determine the step size using the voxel sizes
@@ -127,9 +132,28 @@ namespace larg4 {
       else
         recomb = 0;
     }
+    else if (fUseEllipsModBoxRecomb) {
+      
+      double phi = std::acos(abs(edep.StartX() - edep.EndX()) / edep.StepLength());
+      
+      if (phi > std::atan(1) * 2) { phi = std::atan(1) * 4 - phi; }
+      
+      if (phi != phi) {
+	double Xi = fModBoxB * dEdx / EFieldStep;
+	recomb = std::log(fModBoxA + Xi) / Xi;
+      }
+      else {
+	double B_ellips =
+	  fEllipsModBoxB * dEdx /
+	  (EFieldStep * std::hypot(std::sin(phi), std::cos(phi) / fEllipsModBoxR));
+	
+	recomb = std::log(fEllipsModBoxA + B_ellips) / B_ellips;
+      }
+    }
     else {
       recomb = fRecombA / (1. + dEdx * fRecombk / EFieldStep);
     }
+
 
     if (fUseModLarqlRecomb) { //Use corrections from LArQL model
       recomb += EscapingEFraction(dEdx) * FieldCorrection(EFieldStep, dEdx); //Correction for low EF

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.h
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.h
@@ -51,6 +51,10 @@ namespace larg4 {
     double fLarqlChi0D;      ///< from LArG4Parameters service
     double fLarqlAlpha;      ///< from LArG4Parameters service
     double fLarqlBeta;       ///< from LArG4Parameters service
+    double fEllipsModBoxA;   ///< from LArG4Parameters service
+    double fEllipsModBoxB;   ///< from LArG4Parameters service
+    double fEllipsModBoxR;   ///< from LArG4Parameters service
+    bool fUseEllipsModBoxRecomb; ///< from LArG4Parameters service
     bool fUseModBoxRecomb;   ///< from LArG4Parameters service
     bool fUseModLarqlRecomb; ///< from LArG4Parameters service
 

--- a/larsim/LegacyLArG4/ISCalculationCorrelated.h
+++ b/larsim/LegacyLArG4/ISCalculationCorrelated.h
@@ -36,27 +36,27 @@ namespace larg4 {
     double StepSizeLimit() const { return fStepSize; }
 
   private:
-    double fStepSize;        ///< maximum step to take
-    double fEfield;          ///< value of electric field from LArProperties service
-    double fWion;            ///< W_ion (23.6 eV) == 1/fGeVToElectrons
-    double fWph;             ///< W_ph (19.5 eV)
-    double fScintPreScale;   ///< scintillation pre-scale from LArProperties service
-    double fRecombA;         ///< from LArG4Parameters service
-    double fRecombk;         ///< from LArG4Parameters service
-    double fModBoxA;         ///< from LArG4Parameters service
-    double fModBoxB;         ///< from LArG4Parameters service
-    double fLarqlChi0A;      ///< from LArG4Parameters service
-    double fLarqlChi0B;      ///< from LArG4Parameters service
-    double fLarqlChi0C;      ///< from LArG4Parameters service
-    double fLarqlChi0D;      ///< from LArG4Parameters service
-    double fLarqlAlpha;      ///< from LArG4Parameters service
-    double fLarqlBeta;       ///< from LArG4Parameters service
-    double fEllipsModBoxA;   ///< from LArG4Parameters service
-    double fEllipsModBoxB;   ///< from LArG4Parameters service
-    double fEllipsModBoxR;   ///< from LArG4Parameters service
+    double fStepSize;            ///< maximum step to take
+    double fEfield;              ///< value of electric field from LArProperties service
+    double fWion;                ///< W_ion (23.6 eV) == 1/fGeVToElectrons
+    double fWph;                 ///< W_ph (19.5 eV)
+    double fScintPreScale;       ///< scintillation pre-scale from LArProperties service
+    double fRecombA;             ///< from LArG4Parameters service
+    double fRecombk;             ///< from LArG4Parameters service
+    double fModBoxA;             ///< from LArG4Parameters service
+    double fModBoxB;             ///< from LArG4Parameters service
+    double fLarqlChi0A;          ///< from LArG4Parameters service
+    double fLarqlChi0B;          ///< from LArG4Parameters service
+    double fLarqlChi0C;          ///< from LArG4Parameters service
+    double fLarqlChi0D;          ///< from LArG4Parameters service
+    double fLarqlAlpha;          ///< from LArG4Parameters service
+    double fLarqlBeta;           ///< from LArG4Parameters service
+    double fEllipsModBoxA;       ///< from LArG4Parameters service
+    double fEllipsModBoxB;       ///< from LArG4Parameters service
+    double fEllipsModBoxR;       ///< from LArG4Parameters service
     bool fUseEllipsModBoxRecomb; ///< from LArG4Parameters service
-    bool fUseModBoxRecomb;   ///< from LArG4Parameters service
-    bool fUseModLarqlRecomb; ///< from LArG4Parameters service
+    bool fUseModBoxRecomb;       ///< from LArG4Parameters service
+    bool fUseModLarqlRecomb;     ///< from LArG4Parameters service
 
     double EscapingEFraction(
       double const dEdx); //LArQL chi0 function = fraction of escaping electrons

--- a/larsim/Simulation/LArG4Parameters.cc
+++ b/larsim/Simulation/LArG4Parameters.cc
@@ -46,6 +46,9 @@ namespace sim {
     , fRecombk{pset.get<double>("Recombk", util::kRecombk)}
     , fModBoxA{pset.get<double>("ModBoxA", util::kModBoxA)}
     , fModBoxB{pset.get<double>("ModBoxB", util::kModBoxB)}
+    , fEllipsModBoxA{pset.get<double>("EllipsModBoxA")}
+    , fEllipsModBoxB{pset.get<double>("EllipsModBoxB")}
+    , fEllipsModBoxR{pset.get<double>("EllipsModBoxR")}
     , fLarqlChi0A{pset.get<double>("LarqlChi0A")}
     , fLarqlChi0B{pset.get<double>("LarqlChi0B")}
     , fLarqlChi0C{pset.get<double>("LarqlChi0C")}
@@ -55,6 +58,7 @@ namespace sim {
     , fWph{pset.get<double>("Wph")}
     , fQAlpha{pset.get<double>("QAlpha")}
     , fUseModBoxRecomb{pset.get<bool>("UseModBoxRecomb")}
+    , fUseEllipsModBoxRecomb{pset.get<bool>("UseEllipsModBoxRecomb")}
     , fUseModLarqlRecomb{pset.get<bool>("UseModLarqlRecomb")}
     , fUseBinomialFlucts{pset.get<bool>("UseBinomialFlucts", true)}
     , fIonAndScintCalculator{pset.get<std::string>("IonAndScintCalculator", "Separate")}

--- a/larsim/Simulation/LArG4Parameters.h
+++ b/larsim/Simulation/LArG4Parameters.h
@@ -55,7 +55,7 @@ namespace sim {
     double Wph() const { return fWph; }
     double QAlpha() const { return fQAlpha; }
     bool UseModBoxRecomb() const { return fUseModBoxRecomb; }
-    bool UseEllipsModBoxRecomb() const {return fUseEllipsModBoxRecomb; }
+    bool UseEllipsModBoxRecomb() const { return fUseEllipsModBoxRecomb; }
     bool UseModLarqlRecomb() const { return fUseModLarqlRecomb; }
     bool UseBinomialFlucts() const { return fUseBinomialFlucts; }
     double GeVToElectrons() const { return util::kGeVToElectrons; }
@@ -117,24 +117,25 @@ namespace sim {
     bool const fDisableWireplanes;     ///< Turn of LAr sensitivity and remove charge
                                        ///< drift simulation - use for running pure optical sims
     std::vector<unsigned short int> const
-      fSkipWireSignalInTPCs;       ///< selective disabling of drift simulation
-    double const fRecombA;         ///< Possibly override the RecombA parameter
-    double const fRecombk;         ///< Possibly override the Recombk parameter
-    double const fModBoxA;         ///< Possibly override the ModBoxA parameter
-    double const fModBoxB;         ///< Possibly override the ModBoxB parameter
-    double const fEllipsModBoxA;         ///< Possibly override the EllipsModBoxA parameter
-    double const fEllipsModBoxB;         ///< Possibly override the EllipsModBoxB parameter
-    double const fEllipsModBoxR;         ///< Possibly override the EllipsModBoxR parameter
-    double const fLarqlChi0A;      ///< Possibly override the LarqlChi0A parameter
-    double const fLarqlChi0B;      ///< Possibly override the LarqlChi0B parameter
-    double const fLarqlChi0C;      ///< Possibly override the LarqlChi0C parameter
-    double const fLarqlChi0D;      ///< Possibly override the LarqlChi0D parameter
-    double const fLarqlAlpha;      ///< Possibly override the LarqlAlpha parameter
-    double const fLarqlBeta;       ///< Possibly override the LarqlBeta parameter
-    double const fWph;             ///< Possibly override the Wph parameter
-    double const fQAlpha;          ///< Possibly override the QAlpha parameter
-    bool const fUseModBoxRecomb;   ///< Use Modified Box model recombination instead of Birks
-    bool const fUseEllipsModBoxRecomb;   ///< Use Ellipsoid Modified Box model recombination instead of Birks
+      fSkipWireSignalInTPCs;     ///< selective disabling of drift simulation
+    double const fRecombA;       ///< Possibly override the RecombA parameter
+    double const fRecombk;       ///< Possibly override the Recombk parameter
+    double const fModBoxA;       ///< Possibly override the ModBoxA parameter
+    double const fModBoxB;       ///< Possibly override the ModBoxB parameter
+    double const fEllipsModBoxA; ///< Possibly override the EllipsModBoxA parameter
+    double const fEllipsModBoxB; ///< Possibly override the EllipsModBoxB parameter
+    double const fEllipsModBoxR; ///< Possibly override the EllipsModBoxR parameter
+    double const fLarqlChi0A;    ///< Possibly override the LarqlChi0A parameter
+    double const fLarqlChi0B;    ///< Possibly override the LarqlChi0B parameter
+    double const fLarqlChi0C;    ///< Possibly override the LarqlChi0C parameter
+    double const fLarqlChi0D;    ///< Possibly override the LarqlChi0D parameter
+    double const fLarqlAlpha;    ///< Possibly override the LarqlAlpha parameter
+    double const fLarqlBeta;     ///< Possibly override the LarqlBeta parameter
+    double const fWph;           ///< Possibly override the Wph parameter
+    double const fQAlpha;        ///< Possibly override the QAlpha parameter
+    bool const fUseModBoxRecomb; ///< Use Modified Box model recombination instead of Birks
+    bool const
+      fUseEllipsModBoxRecomb; ///< Use Ellipsoid Modified Box model recombination instead of Birks
     bool const fUseModLarqlRecomb; ///< Use LArQL model recombination correction (dependence on EF)
     bool const fUseBinomialFlucts; ///< Use binomial fluctuations in correlated method
     std::string const

--- a/larsim/Simulation/LArG4Parameters.h
+++ b/larsim/Simulation/LArG4Parameters.h
@@ -43,6 +43,9 @@ namespace sim {
     double Recombk() const { return fRecombk; }
     double ModBoxA() const { return fModBoxA; }
     double ModBoxB() const { return fModBoxB; }
+    double EllipsModBoxA() const { return fEllipsModBoxA; }
+    double EllipsModBoxB() const { return fEllipsModBoxB; }
+    double EllipsModBoxR() const { return fEllipsModBoxR; }
     double LarqlChi0A() const { return fLarqlChi0A; }
     double LarqlChi0B() const { return fLarqlChi0B; }
     double LarqlChi0C() const { return fLarqlChi0C; }
@@ -52,6 +55,7 @@ namespace sim {
     double Wph() const { return fWph; }
     double QAlpha() const { return fQAlpha; }
     bool UseModBoxRecomb() const { return fUseModBoxRecomb; }
+    bool UseEllipsModBoxRecomb() const {return fUseEllipsModBoxRecomb; }
     bool UseModLarqlRecomb() const { return fUseModLarqlRecomb; }
     bool UseBinomialFlucts() const { return fUseBinomialFlucts; }
     double GeVToElectrons() const { return util::kGeVToElectrons; }
@@ -118,6 +122,9 @@ namespace sim {
     double const fRecombk;         ///< Possibly override the Recombk parameter
     double const fModBoxA;         ///< Possibly override the ModBoxA parameter
     double const fModBoxB;         ///< Possibly override the ModBoxB parameter
+    double const fEllipsModBoxA;         ///< Possibly override the EllipsModBoxA parameter
+    double const fEllipsModBoxB;         ///< Possibly override the EllipsModBoxB parameter
+    double const fEllipsModBoxR;         ///< Possibly override the EllipsModBoxR parameter
     double const fLarqlChi0A;      ///< Possibly override the LarqlChi0A parameter
     double const fLarqlChi0B;      ///< Possibly override the LarqlChi0B parameter
     double const fLarqlChi0C;      ///< Possibly override the LarqlChi0C parameter
@@ -127,6 +134,7 @@ namespace sim {
     double const fWph;             ///< Possibly override the Wph parameter
     double const fQAlpha;          ///< Possibly override the QAlpha parameter
     bool const fUseModBoxRecomb;   ///< Use Modified Box model recombination instead of Birks
+    bool const fUseEllipsModBoxRecomb;   ///< Use Ellipsoid Modified Box model recombination instead of Birks
     bool const fUseModLarqlRecomb; ///< Use LArQL model recombination correction (dependence on EF)
     bool const fUseBinomialFlucts; ///< Use binomial fluctuations in correlated method
     std::string const

--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -23,10 +23,10 @@ standard_largeantparameters:
  CosmogenicXSMNBiasOn:     0 # 0 is off. 1 works. 2 still in development.
  CosmogenicXSMNBiasFactor: 1 # Not more than 5-ish cuz of numerical instabilities.
  DisableWireplanes:        false #if set true, charge drift simulation does not run - used for optical sim jobs OR just when you don't wanna drift the e's.
- SkipWireSignalInTPCs:     []     # put here TPC id's which should not receive ionization electrons - used to simulate TPC geom volumes which are actually dead LAr volumes in protoDUNE
- UseModBoxRecomb:          true   # use Modified Box recombination instead of Birks
- UseEllipsModBoxRecomb:    false    # use Ellipsoid Modified Box recomination instead of Birks
- UseModLarqlRecomb:        true   # use LArQL recombination corrections (dependence on EF)
+ SkipWireSignalInTPCs:     []    # put here TPC id's which should not receive ionization electrons - used to simulate TPC geom volumes which are actually dead LAr volumes in protoDUNE
+ UseModBoxRecomb:          true  # use Modified Box recombination instead of Birks
+ UseEllipsModBoxRecomb:    false # use Ellipsoid Modified Box recomination instead of Birks
+ UseModLarqlRecomb:        false # use LArQL recombination corrections (dependence on EF)
 
  #* Recombination factor coefficients come from Nucl.Instrum.Meth.A523:275-286,2004
  #* * @f$ dE/dx @f$ is given by the voxel energy deposition, but have to convert it to MeV/cm from GeV/voxel width

--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -25,7 +25,8 @@ standard_largeantparameters:
  DisableWireplanes:        false #if set true, charge drift simulation does not run - used for optical sim jobs OR just when you don't wanna drift the e's.
  SkipWireSignalInTPCs:     []     # put here TPC id's which should not receive ionization electrons - used to simulate TPC geom volumes which are actually dead LAr volumes in protoDUNE
  UseModBoxRecomb:          true   # use Modified Box recombination instead of Birks
- UseModLarqlRecomb:        false   # use LArQL recombination corrections (dependence on EF)
+ UseEllipsModBoxRecomb:    false    # use Ellipsoid Modified Box recomination instead of Birks
+ UseModLarqlRecomb:        true   # use LArQL recombination corrections (dependence on EF)
 
  #* Recombination factor coefficients come from Nucl.Instrum.Meth.A523:275-286,2004
  #* * @f$ dE/dx @f$ is given by the voxel energy deposition, but have to convert it to MeV/cm from GeV/voxel width
@@ -42,6 +43,14 @@ standard_largeantparameters:
  #* * `kModBoxB` needs to be scaled with the electric field.
  ModBoxA: 0.930
  ModBoxB: 0.212
+
+ #* Recombination factor coefficients come from Gray Putnam 
+ #* * @f$ dE/dx @f$ is given by the voxel energy deposition, but have to convert it to MeV/cm from GeV/voxel width
+ #* * electric field: @f$ E @f$ in kV/cm
+ #* * `EllipsModBoxB` needs to be scaled with the electric field.
+ EllipsModBoxA: 0.906 # +/- 0.008 
+ EllipsModBoxB: 0.203 # +/- 0.008
+ EllipsModBoxR: 1.25  # +/- 0.02
 
  #* Recombination factor coefficients for LArQL
  #* https://doi.org/10.1088/1748-0221/17/07/C07009


### PR DESCRIPTION
This PR adds a simulation of an ellipsoidal model for recombination which creates an angular dependence for the recombination model. This is based on this paper https://iopscience.iop.org/article/10.1088/1748-0221/12/12/P12002/pdf and developed further by Gray Putnam (UChicago). 