### PR TITLE
Corrected for SCE convention and generalized

### DIFF
--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -166,11 +166,52 @@ namespace larg4 {
     // electric field outside active volume set to zero
     if (!fISTPC.isScintInActiveVolume(edep.MidPoint())) return 0.;
 
-    // electric field inside active volume
-    if (!fSCE->EnableSimEfieldSCE()) return efield;
+    TVector3 elecvec;
 
-    auto const eFieldOffsets = fSCE->GetEfieldOffsets(edep.MidPoint());
-    return efield * std::hypot(1 + eFieldOffsets.X(), eFieldOffsets.Y(), eFieldOffsets.Z());
+    art::ServiceHandle<geo::Geometry const> fGeometry;
+    geo::TPCID tpcid = fGeometry->PositionToTPCID(edep.MidPoint());
+    const geo::TPCGeo& tpcGeo = fGeometry->TPC(tpcid);
+
+    if (tpcGeo.DetectDriftDirection() == 1) elecvec.SetXYZ(1, 0, 0);
+    if (tpcGeo.DetectDriftDirection() == -1) elecvec.SetXYZ(-1, 0, 0);
+    if (tpcGeo.DetectDriftDirection() == 2) elecvec.SetXYZ(0, 1, 0);
+    if (tpcGeo.DetectDriftDirection() == -2) elecvec.SetXYZ(0, -1, 0);
+    if (tpcGeo.DetectDriftDirection() == 3) elecvec.SetXYZ(0, 0, 1);
+    if (tpcGeo.DetectDriftDirection() == -3) elecvec.SetXYZ(0, 0, -1);
+
+    elecvec *= efield;
+
+    if (fSCE->EnableSimEfieldSCE()) {
+      auto const eFieldOffsets = fSCE->GetEfieldOffsets(edep.MidPoint());
+      TVector3 scevec;
+
+      if (tpcGeo.DetectDriftDirection() == 1)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -1)
+        scevec.SetXYZ(
+          -1 * efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == 2)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -2)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), -1 * efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == 3)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -3)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), -1 * efield * eFieldOffsets.Z());
+
+      elecvec += scevec;
+
+      std::cout << "New : " << elecvec.Mag() << " old : "
+                << efield * std::hypot(1 + eFieldOffsets.X(), eFieldOffsets.Y(), eFieldOffsets.Z())
+                << " at X: " << edep.StartX() << std::endl;
+    }
+
+    return elecvec.Mag();
   }
   //----------------------------------------------------------------------------
   double ISCalcCorrelated::AngleToEFieldAtStep(double efield, sim::SimEnergyDeposit const& edep)
@@ -200,8 +241,28 @@ namespace larg4 {
     // electric field inside active volume
     if (fSCE->EnableSimEfieldSCE()) {
       auto const eFieldOffsets = fSCE->GetEfieldOffsets(edep.MidPoint());
-      TVector3 scevec(
-        efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+
+      TVector3 scevec;
+
+      if (tpcGeo.DetectDriftDirection() == 1)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -1)
+        scevec.SetXYZ(
+          -1 * efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == 2)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -2)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), -1 * efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == 3)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), efield * eFieldOffsets.Z());
+      if (tpcGeo.DetectDriftDirection() == -3)
+        scevec.SetXYZ(
+          efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), -1 * efield * eFieldOffsets.Z());
+
       elecvec += scevec;
     }
 

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -205,10 +205,6 @@ namespace larg4 {
           efield * eFieldOffsets.X(), efield * eFieldOffsets.Y(), -1 * efield * eFieldOffsets.Z());
 
       elecvec += scevec;
-
-      std::cout << "New : " << elecvec.Mag() << " old : "
-                << efield * std::hypot(1 + eFieldOffsets.X(), eFieldOffsets.Y(), eFieldOffsets.Z())
-                << " at X: " << edep.StartX() << std::endl;
     }
 
     return elecvec.Mag();


### PR DESCRIPTION
This generalizes the `EFieldAtStep` function and corrects a typo I had in the convention for the direction of SCE electric field offsets. 

What looks like a bug in the correlated ionization and scintillation simulation seems to have the space-charge E-field distortion added incorrectly to the E field.

This PR changes default behavior in DUNE's Monte Carlo simulation, and should be reviewed by simulation experts.

The PR has been tested with ICARUS but it affects any detector with an E field that points in any direction other than +X.