### PR TITLE
SingleGen: random engine initialized via NuRandomService

### DIFF
--- a/larsim/EventGenerator/SingleGen_module.cc
+++ b/larsim/EventGenerator/SingleGen_module.cc
@@ -447,7 +447,11 @@ namespace evgen {
     , fHistFileName(config().HistogramFile())
     , fPHist(config().PHist())
     , fThetaXzYzHist(config().ThetaXzYzHist())
-    , fEngine(createEngine(0))
+    /// @todo Remove `registerAndSeedEngine()` dummy template type
+    ///       when [`nurandom` #28424 bug](https://cdcvs.fnal.gov/redmine/issues/28424) is solved
+    , fEngine(
+        art::ServiceHandle<rndm::NuRandomService>()->registerAndSeedEngine<void>(createEngine(0),
+                                                                                 config().Seed))
   {
     setup();
     rndm::NuRandomService::seed_t seed;


### PR DESCRIPTION
This solves [Redmine issue #28411](https://cdcvs.fnal.gov/redmine/issues/28411), but it contains a workaround for [`nurandom` issue #28424](https://cdcvs.fnal.gov/redmine/issues/28424).