### PR TITLE
Bug Fix; Adding a check that the TPCID is valid in ISCalcCorrelated 

### DIFF
--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -170,7 +170,9 @@ namespace larg4 {
 
     art::ServiceHandle<geo::Geometry const> fGeometry;
     geo::TPCID tpcid = fGeometry->PositionToTPCID(edep.MidPoint());
+    if (!bool(tpcid)) return 0.;
     const geo::TPCGeo& tpcGeo = fGeometry->TPC(tpcid);
+
 
     if (tpcGeo.DetectDriftDirection() == 1) elecvec.SetXYZ(1, 0, 0);
     if (tpcGeo.DetectDriftDirection() == -1) elecvec.SetXYZ(-1, 0, 0);
@@ -223,6 +225,7 @@ namespace larg4 {
 
     art::ServiceHandle<geo::Geometry const> fGeometry;
     geo::TPCID tpcid = fGeometry->PositionToTPCID(edep.MidPoint());
+    if (!bool(tpcid)) return 0.;
     const geo::TPCGeo& tpcGeo = fGeometry->TPC(tpcid);
 
     if (tpcGeo.DetectDriftDirection() == 1) elecvec.SetXYZ(1, 0, 0);

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -173,7 +173,6 @@ namespace larg4 {
     if (!bool(tpcid)) return 0.;
     const geo::TPCGeo& tpcGeo = fGeometry->TPC(tpcid);
 
-
     if (tpcGeo.DetectDriftDirection() == 1) elecvec.SetXYZ(1, 0, 0);
     if (tpcGeo.DetectDriftDirection() == -1) elecvec.SetXYZ(-1, 0, 0);
     if (tpcGeo.DetectDriftDirection() == 2) elecvec.SetXYZ(0, 1, 0);


### PR DESCRIPTION
DUNE-VD informed me that they use `ISCalcCorrelated` to simulate light outside the TPC volume, this was a use case I did not expect. This causes `ISCalcCorrelated` to crash because there was no check that the TPCID is valid. This PR adds this check and enables the DUNE-VD simulation to work.