### PR TITLE
Handle extremely large times that have undefined behaviour when being converted from double to int

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -261,7 +261,7 @@ namespace phot {
                 // calculate the time at which each photon is seen
                 double dtime = edepi.StartT() + fScintTime->fastScintTime();
                 if (fIncludePropTime) dtime += transport_time[i];
-                int time = static_cast<int>(std::round(dtime));
+                int time(dtime > static_cast<double>(std::numeric_limits<int>::max()) ? std::numeric_limits<int>::max() : static_cast<int>(std::round(dtime)));
                 if (Reflected)
                   ++ref_phlitcol[channel].DetectedPhotons[time];
                 else
@@ -274,7 +274,7 @@ namespace phot {
                 // calculate the time at which each photon is seen
                 double dtime = edepi.StartT() + fScintTime->slowScintTime();
                 if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
-                int time = static_cast<int>(std::round(dtime));
+                int time(dtime > static_cast<double>(std::numeric_limits<int>::max()) ? std::numeric_limits<int>::max() : static_cast<int>(std::round(dtime)));
                 if (Reflected)
                   ++ref_phlitcol[channel].DetectedPhotons[time];
                 else


### PR DESCRIPTION
SimPhotonsLite class stores time as an int (its used as the key in a map)
It's possible that long lived Ar isotopes decay many hours after an event's simulation time.  This decay time (as a double/float) is larger than the maximum value of an int.  Converting these extreme values to an int wraps the time to the most extreme negative int.

This PR enforces that the large time becomes a max int.