### PR TITLE
Added track ID offsets to handle ancestory of merged MCTruths

### DIFF
--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -55,7 +55,7 @@ namespace sim {
     unsigned int result = this->at(part_index)._mother;
 
     //Is a primary particle. Account for possible track ID offsets
-    for (auto const& offset : _trackIDOffsets) { 
+    for (auto const& offset : _trackIDOffsets) {
       if (result == offset) return this->at(part_index)._track_id;
     }
 
@@ -85,7 +85,7 @@ namespace sim {
     if (result == this->at(part_index)._track_id) return result;
 
     //Is a primary particle. Account for possible track ID offsets
-    for (auto const& offset : _trackIDOffsets) { 
+    for (auto const& offset : _trackIDOffsets) {
       if (result == offset) return this->at(part_index)._track_id;
     }
 

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -23,6 +23,7 @@ namespace sim {
     , _y_min{std::numeric_limits<double>::max()}
     , _z_max{std::numeric_limits<double>::min()}
     , _z_min{std::numeric_limits<double>::max()}
+    , _trackIDOffsets{pset.get<std::vector<unsigned int>>("TrackIDOffsets", {0})}
   {
     this->clear();
     _track_index.clear();
@@ -53,7 +54,10 @@ namespace sim {
 
     unsigned int result = this->at(part_index)._mother;
 
-    if (!result) return this->at(part_index)._track_id;
+    //Is a primary particle. Account for possible track ID offsets
+    for (auto const& offset : _trackIDOffsets) { 
+      if (result == offset) return this->at(part_index)._track_id;
+    }
 
     if (TrackToParticleIndex(result) != ::sim::kINVALID_UINT) return result;
 
@@ -80,7 +84,10 @@ namespace sim {
 
     if (result == this->at(part_index)._track_id) return result;
 
-    if (!result) return this->at(part_index)._track_id;
+    //Is a primary particle. Account for possible track ID offsets
+    for (auto const& offset : _trackIDOffsets) { 
+      if (result == offset) return this->at(part_index)._track_id;
+    }
 
     auto mother_index = TrackToParticleIndex(result);
 

--- a/larsim/MCSTReco/MCRecoPart.h
+++ b/larsim/MCSTReco/MCRecoPart.h
@@ -147,6 +147,7 @@ namespace sim {
     double _y_min; //!< y-min of volume box used to determine whether to save track information
     double _z_max; //!< z-max of volume box used to determine whether to save track information
     double _z_min; //!< z-min of volume box used to determine whether to save track information
+    std::vector<unsigned int> _trackIDOffsets; //!< Track ID offsets for different MCTruths
 
   }; // class MCRecoPart
 


### PR DESCRIPTION
Bug fix for setting ancestory based on trackIDs being 0 for mothers. Need to account for offsets as seen [here](https://github.com/SBNSoftware/sbndcode/issues/401).