### PR TITLE
Fix geometry service call that expects an exception it is never going to get

### DIFF
--- a/larsim/ElectronDrift/SimDriftElectrons_module.cc
+++ b/larsim/ElectronDrift/SimDriftElectrons_module.cc
@@ -273,24 +273,18 @@ namespace detsim {
       // cryostat and tpc. If somehow the step is outside a tpc
       // (e.g., cosmic rays in rock) just move on to the next one.
       unsigned int cryostat = 0;
-      try {
-        cryostat = fGeometry->PositionToCryostatID(mp).Cryostat;
-      }
-      catch (cet::exception& e) {
+      cryostat = fGeometry->PositionToCryostatID(mp).Cryostat;
+      if (cryostat == geo::CryostatID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a cryostat\n"
-                                            << e;
+                                            << "cannot be found in a cryostat\n";
         continue;
       }
 
       geo::TPCID tpcid;
-      try {
-        tpcid = fGeometry->PositionToTPCID(mp);
-      }
-      catch (cet::exception& e) {
+      tpcid = fGeometry->PositionToTPCID(mp);
+      if (tpcid.TPC == geo::TPCID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a TPC\n"
-                                            << e;
+                                            << "cannot be found in a TPC\n";
         continue;
       }
 

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -168,8 +168,8 @@ namespace sim {
       }
 
       unsigned int tpc = 0;
-      tpcid = geom->PositionToTPCID(mp).TPC;
-      if (tpcid == geo::TPCID::getInvalidID()) {
+      tpc = geom->PositionToTPCID(mp).TPC;
+      if (tpc == geo::TPCID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
                                             << "cannot be found in a TPC\n";
         continue;

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -160,7 +160,7 @@ namespace sim {
       // cryostat and tpc. If somehow the step is outside a tpc
       // (e.g., cosmic rays in rock) just move on to the next one.
       unsigned int cryostat = 0;
-      cryostat = fGeometry->PositionToCryostatID(mp).Cryostat;
+      cryostat = geom->PositionToCryostatID(mp).Cryostat;
       if (cryostat == geo::CryostatID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
                                             << "cannot be found in a cryostat\n";
@@ -168,7 +168,7 @@ namespace sim {
       }
 
       unsigned int tpc = 0;
-      tpcid = fGeometry->PositionToTPCID(mp).TPC;
+      tpcid = geom->PositionToTPCID(mp).TPC;
       if (tpcid == geo::TPCID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
                                             << "cannot be found in a TPC\n";

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -160,25 +160,21 @@ namespace sim {
       // cryostat and tpc. If somehow the step is outside a tpc
       // (e.g., cosmic rays in rock) just move on to the next one.
       unsigned int cryostat = 0;
-      try {
-        geom->PositionToCryostatID(mp);
-      }
-      catch (cet::exception& e) {
+      cryostat = fGeometry->PositionToCryostatID(mp).Cryostat;
+      if (cryostat == geo::CryostatID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a cryostat\n"
-                                            << e;
+                                            << "cannot be found in a cryostat\n";
         continue;
       }
+
       unsigned int tpc = 0;
-      try {
-        geom->PositionToTPCID(mp);
-      }
-      catch (cet::exception& e) {
+      tpcid = fGeometry->PositionToTPCID(mp).TPC;
+      if (tpcid == geo::TPCID::getInvalidID()) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a TPC\n"
-                                            << e;
+                                            << "cannot be found in a TPC\n";
         continue;
       }
+
       geo::TPCID const tpcid{cryostat, tpc};
 
       //Define charge drift direction: driftcoordinate (x, y or z) and driftsign (positive or negative). Also define coordinates perpendicular to drift direction.


### PR DESCRIPTION
I tried to use the electron drift module to make simchannels from simenergydeposits and found I would get an error complaining about an invalid cryostatID. It is caused by code calling `fGeom->PositionTo{Cryostat,TPC}ID(pos)` expecting an exception if the position is outside the necessary volume. I suppose this was true at some point in the geometry service's past but is no longer true. Instead we need to check if this method returns an invalid ID to know if position is not in a TPC or Cyrostat boundary.

I  found the same code in MCRecoEdep.cxx where I fixed it there also. 