### PR TITLE
Update MCReco to use MCParticle instead of MCParticleLite

### DIFF
--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -160,21 +160,25 @@ namespace sim {
       // cryostat and tpc. If somehow the step is outside a tpc
       // (e.g., cosmic rays in rock) just move on to the next one.
       unsigned int cryostat = 0;
-      cryostat = geom->PositionToCryostatID(mp).Cryostat;
-      if (cryostat == geo::CryostatID::getInvalidID()) {
+      try {
+        geom->PositionToCryostatID(mp);
+      }
+      catch (cet::exception& e) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a cryostat\n";
+                                            << "cannot be found in a cryostat\n"
+                                            << e;
         continue;
       }
-
       unsigned int tpc = 0;
-      tpc = geom->PositionToTPCID(mp).TPC;
-      if (tpc == geo::TPCID::getInvalidID()) {
+      try {
+        geom->PositionToTPCID(mp);
+      }
+      catch (cet::exception& e) {
         mf::LogWarning("SimDriftElectrons") << "step " // << energyDeposit << "\n"
-                                            << "cannot be found in a TPC\n";
+                                            << "cannot be found in a TPC\n"
+                                            << e;
         continue;
       }
-
       geo::TPCID const tpcid{cryostat, tpc};
 
       //Define charge drift direction: driftcoordinate (x, y or z) and driftsign (positive or negative). Also define coordinates perpendicular to drift direction.

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -132,7 +132,7 @@ namespace sim {
   //--------------------------------------------------------------------------------------------
   void MCRecoPart::AddParticles(const std::vector<simb::MCParticle>& mcp_v,
                                 const std::vector<simb::Origin_t>& orig_v,
-                                const std::vector<sim::MCParticleLite>& mcmp_v)
+                                const std::vector<simb::MCParticle>& mcmp_v)
   //--------------------------------------------------------------------------------------------
   {
     if (orig_v.size() != mcp_v.size())
@@ -193,7 +193,7 @@ namespace sim {
     // Now loop over dropped particles
     for (auto const& mcmp : mcmp_v) {
 
-      _track_index.try_emplace(mcmp.TrackID(), this->size());
+      _track_index.try_emplace(mcmp.TrackId(), this->size());
 
       this->push_back(sim::MCMiniPart(mcmp));
 

--- a/larsim/MCSTReco/MCRecoPart.h
+++ b/larsim/MCSTReco/MCRecoPart.h
@@ -7,7 +7,7 @@ namespace fhicl {
 }
 
 // LArSoft
-#include "lardataobj/MCBase/MCLimits.h"       // kINVALID_X
+#include "lardataobj/MCBase/MCLimits.h" // kINVALID_X
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
 

--- a/larsim/MCSTReco/MCRecoPart.h
+++ b/larsim/MCSTReco/MCRecoPart.h
@@ -8,7 +8,6 @@ namespace fhicl {
 
 // LArSoft
 #include "lardataobj/MCBase/MCLimits.h"       // kINVALID_X
-#include "lardataobj/MCBase/MCParticleLite.h" // sim::MCParticleLite
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "nusimdata/SimulationBase/MCTruth.h" // simb::Origin_t
 
@@ -87,19 +86,6 @@ namespace sim {
       _end_vtx = p.EndPosition();
       _end_mom = 1.e3 * p.EndMomentum(); // idem as above
     }
-
-    MCMiniPart(const sim::MCParticleLite& p)
-    {
-      Reset();
-      _track_id = p.TrackID();
-      _pdgcode = p.PdgCode();
-      _mother = p.Mother();
-      _process = p.Process();
-      _start_vtx = p.StartVtx();
-      _start_mom = 1.e3 * p.StartMom(); // Change units to (MeV, cm, us)
-      _end_vtx = p.EndVtx();
-      _end_mom = 1.e3 * p.EndMom(); // idem as above
-    }
   };
 
   class MCRecoPart : public std::vector<sim::MCMiniPart> {
@@ -113,7 +99,7 @@ namespace sim {
 
     void AddParticles(const std::vector<simb::MCParticle>& mcp_v,
                       const std::vector<simb::Origin_t>& orig_v,
-                      const std::vector<sim::MCParticleLite>& mcmp_v = {});
+                      const std::vector<simb::MCParticle>& mcmp_v = {});
 
     unsigned int AncestorTrackID(const unsigned int part_index);
 

--- a/larsim/MCSTReco/MCReco_module.cc
+++ b/larsim/MCSTReco/MCReco_module.cc
@@ -37,7 +37,7 @@ public:
 private:
   // Declare member data here.
   art::InputTag fMCParticleLabel;
-  art::InputTag fMCParticleLiteLabel;
+  art::InputTag fMCParticleDroppedLabel;
   art::InputTag fSimChannelLabel;
   bool fUseSimEnergyDeposit;
   bool fUseSimEnergyDepositLite;
@@ -65,11 +65,11 @@ MCReco::MCReco(fhicl::ParameterSet const& pset)
                                     << "\nUse 'MCParticleLabel' and 'SimChannelLabel' instead.";
 
     fMCParticleLabel = pset.get<art::InputTag>("G4ModName", "largeant");
-    fMCParticleLiteLabel = pset.get<art::InputTag>("G4ModName", "largeant");
+    fMCParticleDroppedLabel = pset.get<art::InputTag>("G4ModName", "largeantdropped");
     fSimChannelLabel = pset.get<art::InputTag>("G4ModName", "largeant");
   }
   else {
-    fMCParticleLiteLabel = pset.get<art::InputTag>("MCParticleLiteLabel", "largeant");
+    fMCParticleDroppedLabel = pset.get<art::InputTag>("MCParticleDroppedLabel", "largeantdropped");
   }
 
   fUseSimEnergyDeposit = pset.get<bool>("UseSimEnergyDeposit", false);
@@ -115,7 +115,7 @@ void MCReco::produce(art::Event& evt)
 
   if (fIncludeDroppedParticles) {
     auto const& mcmp_array =
-      *evt.getValidHandle<std::vector<sim::MCParticleLite>>(fMCParticleLiteLabel);
+      *evt.getValidHandle<std::vector<simb::MCParticle>>(fMCParticleDroppedLabel);
     fPart.AddParticles(mcp_array, orig_array, mcmp_array);
   } // end if fIncludeDroppedParticles
   else {


### PR DESCRIPTION
MCParticleLite is no longer used to store dropped particles in the refactored larg4 [PR](https://github.com/LArSoft/larg4/pull/52). So we now use MCParticle to be consumed.