### PR TITLE
Replace fast_acos with faster code using better fit

### DIFF
--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -146,6 +146,9 @@ cet_build_plugin(PhotonLibraryAnalyzer art::EDAnalyzer
   ROOT::Hist
 )
 
+add_executable(test_fast_acos test_fast_acos.cc)
+target_link_libraries(test_fast_acos PRIVATE larsim::PhotonPropagation)
+
 add_subdirectory(LibraryBuildTools)
 
 install_headers()

--- a/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
+++ b/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
@@ -8,23 +8,37 @@
 namespace phot {
 
   //......................................................................
-  // fast approximation to acos, from C. Hastings, Jr., "Approximations for Digital Computers", Princeton University Press, 1955.
- double fast_acos(double xin) {
-   double const x = std::abs(xin);
-   double const a0 =  1.5707288;
-   double const a1 = -0.2121144;
-   double const a2 =  0.0742610;
-   double const a3 = -0.0187293;
-   double ret = a3;
-   ret *= x;
-   ret += a2;
-   ret *= x;
-   ret += a1;
-   ret *= x;
-   ret += a0;
-   ret *= std::sqrt(1.0-x);
-   if (xin >= 0) return ret;
-   return M_PI - ret;
+  // fast approximation to acos, This implementation foillows the functional
+  // form from C. Hastings, Jr., "Approximations for Digital Computers",
+  // Princeton University Press, 1955.
+  // This differs from that version by using a new fit to the same functional
+  // form, but done in double precision. The resulting parameters differ, and
+  // result in the same calculation speed but yield a better approximation.
+  //
+  // The functional form for the fit is:
+  //    acos(x) = sqrt(1-x) * a0 * (x + a1 * (x + a2 * (x + a3)))
+  // The fit done is *not* a least squares fit.
+  // It is a fit that minimizes the value of the maximum absolute deviation
+  // between the fitted function and the C math library's implementation of
+  // acos(double).
+  //
+  double fast_acos(double xin)
+  {
+    double const a3 = -2.08730442907856008e-02;
+    double const a2 =  7.68769404161671888e-02;
+    double const a1 = -2.12871094165645952e-01;
+    double const a0 =  1.57075835365209659e+00;
+    double const x = std::abs(xin);
+    double ret = a3;
+    ret *= x;
+    ret += a2;
+    ret *= x;
+    ret += a1;
+    ret *= x;
+    ret += a0;
+    ret *= std::sqrt(1.0-x);
+    if (xin >= 0) return ret;
+    return M_PI - ret;
   }
 
   //......................................................................

--- a/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
+++ b/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
@@ -25,9 +25,9 @@ namespace phot {
   double fast_acos(double xin)
   {
     double const a3 = -2.08730442907856008e-02;
-    double const a2 =  7.68769404161671888e-02;
+    double const a2 = 7.68769404161671888e-02;
     double const a1 = -2.12871094165645952e-01;
-    double const a0 =  1.57075835365209659e+00;
+    double const a0 = 1.57075835365209659e+00;
     double const x = std::abs(xin);
     double ret = a3;
     ret *= x;
@@ -36,7 +36,7 @@ namespace phot {
     ret += a1;
     ret *= x;
     ret += a0;
-    ret *= std::sqrt(1.0-x);
+    ret *= std::sqrt(1.0 - x);
     if (xin >= 0) return ret;
     return M_PI - ret;
   }

--- a/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
+++ b/larsim/PhotonPropagation/PhotonPropagationUtils.cxx
@@ -3,25 +3,28 @@
 // Utility functions
 ////////////////////////////////////////////////////////////////////////
 #include "larsim/PhotonPropagation/PhotonPropagationUtils.h"
+#include <cmath>
 
 namespace phot {
 
   //......................................................................
-  double fast_acos(double x)
-  {
-    double negate = double(x < 0.);
-    x = std::abs(x);
-    x -= double(x > 1.) * (x - 1.); // <- equivalent to min(1.,x), but faster
-    double ret = -0.0187293;
-    ret = ret * x;
-    ret = ret + 0.0742610;
-    ret = ret * x;
-    ret = ret - 0.2121144;
-    ret = ret * x;
-    ret = ret + 1.5707288;
-    ret = ret * std::sqrt(1. - x);
-    ret = ret - 2. * negate * ret;
-    return negate * 3.14159265358979 + ret;
+  // fast approximation to acos, from C. Hastings, Jr., "Approximations for Digital Computers", Princeton University Press, 1955.
+ double fast_acos(double xin) {
+   double const x = std::abs(xin);
+   double const a0 =  1.5707288;
+   double const a1 = -0.2121144;
+   double const a2 =  0.0742610;
+   double const a3 = -0.0187293;
+   double ret = a3;
+   ret *= x;
+   ret += a2;
+   ret *= x;
+   ret += a1;
+   ret *= x;
+   ret += a0;
+   ret *= std::sqrt(1.0-x);
+   if (xin >= 0) return ret;
+   return M_PI - ret;
   }
 
   //......................................................................

--- a/larsim/PhotonPropagation/test_fast_acos.cc
+++ b/larsim/PhotonPropagation/test_fast_acos.cc
@@ -1,0 +1,21 @@
+#include "larsim/PhotonPropagation/PhotonPropagationUtils.h"
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+
+
+using phot::fast_acos;
+
+int main()
+{
+  std::cout << "fast\tstd\n";
+  std::cout << std::setprecision(17);
+  for (int i = 0; i <= 100; ++i)
+  {
+    double x = static_cast<double>(i)/100.0;
+    double f_x = fast_acos(x);
+    double y_x = std::acos(x);
+    std::cout << f_x << '\t' << y_x << '\n';
+  }
+}

--- a/larsim/PhotonPropagation/test_fast_acos.cc
+++ b/larsim/PhotonPropagation/test_fast_acos.cc
@@ -4,16 +4,14 @@
 #include <iomanip>
 #include <iostream>
 
-
 using phot::fast_acos;
 
 int main()
 {
   std::cout << "fast\tstd\n";
   std::cout << std::setprecision(17);
-  for (int i = 0; i <= 100; ++i)
-  {
-    double x = static_cast<double>(i)/100.0;
+  for (int i = 0; i <= 100; ++i) {
+    double x = static_cast<double>(i) / 100.0;
     double f_x = fast_acos(x);
     double y_x = std::acos(x);
     std::cout << f_x << '\t' << y_x << '\n';


### PR DESCRIPTION
This PR will replace the `fast_acos` function with a  slightly more precise approximation that is faster.
This work was presented at the March 5, 2024 LArSoft Coordination meeting: https://indico.fnal.gov/event/63641/.
