### PR TITLE
Add an automatic voxelisation option to PhotonVisibilityService

### DIFF
--- a/larsim/PhotonPropagation/PhotonVisibilityService.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.cc
@@ -315,14 +315,13 @@ namespace phot {
 
       // Find the TPC volume, following example from
       // https://github.com/LArSoft/larsim/blob/05378155a2a07551fa5757d0449ffb30476d5cf9/larsim/LegacyLArG4/OpFastScintillation.cxx#L2149-L2165
-      geo::BoxBoundedGeo cryoVolume{ geom->Cryostat().BoundingBox() };
-      geo::BoxBoundedGeo tpcVolume{ geom->Cryostat().TPC(0).ActiveBoundingBox() };
-      for ( geo::CryostatGeo const& cryo : geom->Iterate<geo::CryostatGeo>() ) {
+      geo::BoxBoundedGeo cryoVolume{geom->Cryostat().BoundingBox()};
+      geo::BoxBoundedGeo tpcVolume{geom->Cryostat().TPC(0).ActiveBoundingBox()};
+      for (geo::CryostatGeo const& cryo : geom->Iterate<geo::CryostatGeo>()) {
 
-        cryoVolume.ExtendToInclude( cryo.BoundingBox() );
-        for ( geo::TPCGeo const& TPC : cryo.IterateTPCs() )
-        {
-          tpcVolume.ExtendToInclude( TPC.ActiveBoundingBox() );
+        cryoVolume.ExtendToInclude(cryo.BoundingBox());
+        for (geo::TPCGeo const& TPC : cryo.IterateTPCs()) {
+          tpcVolume.ExtendToInclude(TPC.ActiveBoundingBox());
         }
       }
 
@@ -330,46 +329,67 @@ namespace phot {
       if (fUseAutomaticVoxels) {
 
         std::string logString = "Automatic voxelisation x-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinX(), tpcVolume.MaxX(), cryoVolume.MinX(), cryoVolume.MaxX(), fNx, fXmin, fXmax );
+        findVoxelSuggestion(logString,
+                            tpcVolume.MinX(),
+                            tpcVolume.MaxX(),
+                            cryoVolume.MinX(),
+                            cryoVolume.MaxX(),
+                            fNx,
+                            fXmin,
+                            fXmax);
         logString += "Automatic voxelisation y-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinY(), tpcVolume.MaxY(), cryoVolume.MinY(), cryoVolume.MaxY(), fNy, fYmin, fYmax );
+        findVoxelSuggestion(logString,
+                            tpcVolume.MinY(),
+                            tpcVolume.MaxY(),
+                            cryoVolume.MinY(),
+                            cryoVolume.MaxY(),
+                            fNy,
+                            fYmin,
+                            fYmax);
         logString += "Automatic voxelisation z-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinZ(), tpcVolume.MaxZ(), cryoVolume.MinZ(), cryoVolume.MaxZ(), fNz, fZmin, fZmax );
+        findVoxelSuggestion(logString,
+                            tpcVolume.MinZ(),
+                            tpcVolume.MaxZ(),
+                            cryoVolume.MinZ(),
+                            cryoVolume.MaxZ(),
+                            fNz,
+                            fZmin,
+                            fZmax);
         mf::LogInfo("PhotonVisibilityService") << logString;
       }
 
       fVoxelDef = sim::PhotonVoxelDef(fXmin, fXmax, fNx, fYmin, fYmax, fNy, fZmin, fZmax, fNz);
 
       // Output lists of voxels within the TPC and outside it
-      if ( fSaveTPCVoxels != "" || fSaveOtherVoxels != "" ) {
+      if (fSaveTPCVoxels != "" || fSaveOtherVoxels != "") {
 
         unsigned int const totalVoxels = fVoxelDef.GetNVoxels();
-        std::vector< unsigned int > tpcVoxels, otherVoxels;
-        tpcVoxels.reserve( totalVoxels );
-        otherVoxels.reserve( totalVoxels );
-        for ( unsigned int voxelID = 0; voxelID < totalVoxels; ++voxelID ) {
+        std::vector<unsigned int> tpcVoxels, otherVoxels;
+        tpcVoxels.reserve(totalVoxels);
+        otherVoxels.reserve(totalVoxels);
+        for (unsigned int voxelID = 0; voxelID < totalVoxels; ++voxelID) {
 
-          auto const voxelCenter = fVoxelDef.GetPhotonVoxel( voxelID ).GetCenter();
-          if ( tpcVolume.ContainsPosition( voxelCenter ) ) {
-            tpcVoxels.push_back( voxelID );
-          }
+          auto const voxelCenter = fVoxelDef.GetPhotonVoxel(voxelID).GetCenter();
+          if (tpcVolume.ContainsPosition(voxelCenter)) { tpcVoxels.push_back(voxelID); }
           else {
-            otherVoxels.push_back( voxelID );
+            otherVoxels.push_back(voxelID);
           }
         }
-        std::string logString = "Voxels within TPC: " + std::to_string( tpcVoxels.size() );
-        if ( fSaveTPCVoxels != "" ) logString += " saved to file\n\t" + fSaveTPCVoxels;
-        logString += "\nVoxels outside TPC: " + std::to_string( otherVoxels.size() );
-        if ( fSaveOtherVoxels != "" ) logString += " saved to file\n\t" + fSaveOtherVoxels;
+        std::string logString = "Voxels within TPC: " + std::to_string(tpcVoxels.size());
+        if (fSaveTPCVoxels != "") logString += " saved to file\n\t" + fSaveTPCVoxels;
+        logString += "\nVoxels outside TPC: " + std::to_string(otherVoxels.size());
+        if (fSaveOtherVoxels != "") logString += " saved to file\n\t" + fSaveOtherVoxels;
         mf::LogInfo("PhotonVisibilityService") << logString << std::endl;
 
-        if ( fSaveTPCVoxels != "" ) {
-          std::ofstream outputFile = std::ofstream( fSaveTPCVoxels );
-          for ( auto voxel : tpcVoxels ) outputFile <<  std::to_string( voxel ) + "\n";
+        if (fSaveTPCVoxels != "") {
+          std::ofstream outputFile = std::ofstream(fSaveTPCVoxels);
+          for (auto voxel : tpcVoxels)
+            outputFile << std::to_string(voxel) + "\n";
         }
-        if ( fSaveOtherVoxels != "" ) {
-          std::ofstream outputFile = std::ofstream( fSaveOtherVoxels );
-          for ( auto voxel : otherVoxels ) outputFile <<  std::to_string( voxel ) + "\n";
+        if (fSaveOtherVoxels != "") {
+          std::ofstream outputFile = std::ofstream(fSaveOtherVoxels);
+          for (auto voxel : otherVoxels)
+            outputFile << std::to_string(voxel) + "\n";
         }
       }
     }
@@ -896,60 +916,88 @@ namespace phot {
     return fMapping->detectorToLibrary(p);
   }
 
-  void PhotonVisibilityService::findVoxelSuggestion( std::string& logString,
-                                                     float tpcMin, float tpcMax, float cryoMin, float cryoMax,
-                                                     int& nVoxels, float& voxelMin, float& voxelMax,
-                                                     float voxelSizeGoal ) const
+  void PhotonVisibilityService::findVoxelSuggestion(std::string& logString,
+                                                    float tpcMin,
+                                                    float tpcMax,
+                                                    float cryoMin,
+                                                    float cryoMax,
+                                                    int& nVoxels,
+                                                    float& voxelMin,
+                                                    float& voxelMax,
+                                                    float voxelSizeGoal) const
   {
     // Scan the "jog" parameter, which adds an integer amount of voxels within the TPC
     int bestJog = 0;
     float bestResult = 1000;
     std::string dummyString = "";
-    for ( int jog = -10; jog <= 10; ++jog )
-    {
+    for (int jog = -10; jog <= 10; ++jog) {
       dummyString = "";
-      float result = testVoxelSuggestion( dummyString,
-                                          tpcMin, tpcMax, cryoMin, cryoMax,
-                                          nVoxels, voxelMin, voxelMax,
-                                          voxelSizeGoal, jog );
-      if ( result < bestResult )
-      {
+      float result = testVoxelSuggestion(dummyString,
+                                         tpcMin,
+                                         tpcMax,
+                                         cryoMin,
+                                         cryoMax,
+                                         nVoxels,
+                                         voxelMin,
+                                         voxelMax,
+                                         voxelSizeGoal,
+                                         jog);
+      if (result < bestResult) {
         bestResult = result;
         bestJog = jog;
       }
     }
 
     // Print the best result (and update the outputs)
-    testVoxelSuggestion( logString,
-                         tpcMin, tpcMax, cryoMin, cryoMax,
-                         nVoxels, voxelMin, voxelMax,
-                         voxelSizeGoal, bestJog );
+    testVoxelSuggestion(logString,
+                        tpcMin,
+                        tpcMax,
+                        cryoMin,
+                        cryoMax,
+                        nVoxels,
+                        voxelMin,
+                        voxelMax,
+                        voxelSizeGoal,
+                        bestJog);
   }
 
-  float PhotonVisibilityService::testVoxelSuggestion( std::string& logString,
-                                                      float tpcMin, float tpcMax, float cryoMin, float cryoMax,
-                                                      int& nVoxels, float& voxelMin, float& voxelMax,
-                                                      float voxelSizeGoal, int jog ) const
+  float PhotonVisibilityService::testVoxelSuggestion(std::string& logString,
+                                                     float tpcMin,
+                                                     float tpcMax,
+                                                     float cryoMin,
+                                                     float cryoMax,
+                                                     int& nVoxels,
+                                                     float& voxelMin,
+                                                     float& voxelMax,
+                                                     float voxelSizeGoal,
+                                                     int jog) const
   {
     // Examine TPC to establish voxel size
     float tpcSize = tpcMax - tpcMin;
-    int tpcVoxelNumber = ceil( tpcSize / voxelSizeGoal ) + jog; // units are cm
+    int tpcVoxelNumber = ceil(tpcSize / voxelSizeGoal) + jog; // units are cm
     float voxelSize = tpcSize / tpcVoxelNumber;
     float cryoSize = cryoMax - cryoMin;
-    logString += "\tTPC size " + std::to_string( tpcSize ) + "cm requires " + std::to_string( tpcVoxelNumber ) + " voxels of size " + std::to_string( voxelSize ) + "cm\n";
+    logString += "\tTPC size " + std::to_string(tpcSize) + "cm requires " +
+                 std::to_string(tpcVoxelNumber) + " voxels of size " + std::to_string(voxelSize) +
+                 "cm\n";
 
     // Extend voxel grid to full cryostat
     voxelMin = tpcMin;
-    while ( voxelMin > cryoMin ) voxelMin -= voxelSize;
+    while (voxelMin > cryoMin)
+      voxelMin -= voxelSize;
     voxelMax = tpcMax;
-    while ( voxelMax < cryoMax ) voxelMax += voxelSize;
+    while (voxelMax < cryoMax)
+      voxelMax += voxelSize;
     float cryoVoxelNumberGuess = cryoSize / voxelSize;
-    nVoxels = round( ( voxelMax - voxelMin ) / voxelSize );
-    logString += "\tCryostat boundaries " + std::to_string( cryoMin ) + " to " + std::to_string( cryoMax ) + "cm would use " + std::to_string( cryoVoxelNumberGuess ) + " voxels\n";
-    logString += "\tCryostat voxel range " + std::to_string( voxelMin ) + " to " + std::to_string( voxelMax ) + "cm uses " + std::to_string( nVoxels ) + " voxels\n";
-    float voxelDelta = fabs( nVoxels - cryoVoxelNumberGuess );
+    nVoxels = round((voxelMax - voxelMin) / voxelSize);
+    logString += "\tCryostat boundaries " + std::to_string(cryoMin) + " to " +
+                 std::to_string(cryoMax) + "cm would use " + std::to_string(cryoVoxelNumberGuess) +
+                 " voxels\n";
+    logString += "\tCryostat voxel range " + std::to_string(voxelMin) + " to " +
+                 std::to_string(voxelMax) + "cm uses " + std::to_string(nVoxels) + " voxels\n";
+    float voxelDelta = fabs(nVoxels - cryoVoxelNumberGuess);
     return voxelDelta;
   }
 
-    /// @}
+  /// @}
 } // namespace

--- a/larsim/PhotonPropagation/PhotonVisibilityService.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.cc
@@ -934,16 +934,8 @@ namespace phot {
     int bestJog = 0;
     float bestResult = 1000;
     for (int jog = -10; jog <= 10; ++jog) {
-      float result = testVoxelSuggestion(tpcMin,
-                                         tpcMax,
-                                         cryoMin,
-                                         cryoMax,
-                                         nVoxels,
-                                         voxelMin,
-                                         voxelMax,
-                                         voxelSizeGoal,
-                                         jog,
-                                         nullptr); // No logging string
+      float result = testVoxelSuggestion(
+        tpcMin, tpcMax, cryoMin, cryoMax, nVoxels, voxelMin, voxelMax, voxelSizeGoal, jog);
       if (result < bestResult) {
         bestResult = result;
         bestJog = jog;

--- a/larsim/PhotonPropagation/PhotonVisibilityService.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.cc
@@ -329,32 +329,36 @@ namespace phot {
       if (fUseAutomaticVoxels) {
 
         std::string logString = "Automatic voxelisation x-dimension\n";
-        findVoxelSuggestion(logString,
-                            tpcVolume.MinX(),
+        float voxelSizeGoal = 10.0; // 10cm standard choice
+        findVoxelSuggestion(tpcVolume.MinX(),
                             tpcVolume.MaxX(),
                             cryoVolume.MinX(),
                             cryoVolume.MaxX(),
                             fNx,
                             fXmin,
-                            fXmax);
+                            fXmax,
+                            voxelSizeGoal,
+                            &logString);
         logString += "Automatic voxelisation y-dimension\n";
-        findVoxelSuggestion(logString,
-                            tpcVolume.MinY(),
+        findVoxelSuggestion(tpcVolume.MinY(),
                             tpcVolume.MaxY(),
                             cryoVolume.MinY(),
                             cryoVolume.MaxY(),
                             fNy,
                             fYmin,
-                            fYmax);
+                            fYmax,
+                            voxelSizeGoal,
+                            &logString);
         logString += "Automatic voxelisation z-dimension\n";
-        findVoxelSuggestion(logString,
-                            tpcVolume.MinZ(),
+        findVoxelSuggestion(tpcVolume.MinZ(),
                             tpcVolume.MaxZ(),
                             cryoVolume.MinZ(),
                             cryoVolume.MaxZ(),
                             fNz,
                             fZmin,
-                            fZmax);
+                            fZmax,
+                            voxelSizeGoal,
+                            &logString);
         mf::LogInfo("PhotonVisibilityService") << logString;
       }
 
@@ -986,13 +990,13 @@ namespace phot {
     float cryoVoxelNumberGuess = cryoSize / voxelSize;
     nVoxels = round((voxelMax - voxelMin) / voxelSize);
 
-    if ( logString ) {
+    if (logString) {
       *logString += "\tTPC size " + std::to_string(tpcSize) + "cm requires " +
-                    std::to_string(tpcVoxelNumber) + " voxels of size " + std::to_string(voxelSize) +
-                    "cm\n";
+                    std::to_string(tpcVoxelNumber) + " voxels of size " +
+                    std::to_string(voxelSize) + "cm\n";
       *logString += "\tCryostat boundaries " + std::to_string(cryoMin) + " to " +
-                    std::to_string(cryoMax) + "cm would use " + std::to_string(cryoVoxelNumberGuess) +
-                    " voxels\n";
+                    std::to_string(cryoMax) + "cm would use " +
+                    std::to_string(cryoVoxelNumberGuess) + " voxels\n";
       *logString += "\tCryostat voxel range " + std::to_string(voxelMin) + " to " +
                     std::to_string(voxelMax) + "cm uses " + std::to_string(nVoxels) + " voxels\n";
     }

--- a/larsim/PhotonPropagation/PhotonVisibilityService.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.cc
@@ -44,6 +44,7 @@
 #include "TF1.h"
 
 // C/C++ standard libraries
+#include <fstream>
 
 namespace phot {
 
@@ -81,6 +82,9 @@ namespace phot {
     , fNy(0)
     , fNz(0)
     , fUseCryoBoundary(false)
+    , fUseAutomaticVoxels(false)
+    , fSaveTPCVoxels()
+    , fSaveOtherVoxels()
     , fLibraryBuildJob(false)
     , fDoNotLoadLibrary(false)
     , fParameterization(false)
@@ -274,6 +278,9 @@ namespace phot {
     fUseCryoBoundary = p.get<bool>("UseCryoBoundary", false);
     fInterpolate = p.get<bool>("Interpolate", false);
     fReflectOverZeroX = p.get<bool>("ReflectOverZeroX", false);
+    fUseAutomaticVoxels = p.get<bool>("UseAutomaticVoxels", false);
+    fSaveTPCVoxels = p.get<std::string>("TPCVoxelListFile", "");
+    fSaveOtherVoxels = p.get<std::string>("OtherVoxelListFile", "");
 
     fParPropTime = p.get<bool>("ParametrisedTimePropagation", false);
     fParPropTime_npar = p.get<size_t>("ParametrisedTimePropagationNParameters", 0);
@@ -306,7 +313,65 @@ namespace phot {
       fNy = p.get<int>("NY");
       fNz = p.get<int>("NZ");
 
+      // Find the TPC volume, following example from
+      // https://github.com/LArSoft/larsim/blob/05378155a2a07551fa5757d0449ffb30476d5cf9/larsim/LegacyLArG4/OpFastScintillation.cxx#L2149-L2165
+      geo::BoxBoundedGeo tpcVolume{geom->Cryostat().TPC(0).ActiveBoundingBox()};
+      for (geo::CryostatGeo const& cryo : geom->Iterate<geo::CryostatGeo>()) {
+
+        int i = 0;
+        for (geo::TPCGeo const& TPC : cryo.IterateTPCs())
+        {
+          tpcVolume.ExtendToInclude(TPC.ActiveBoundingBox());
+          ++i;
+        }
+      }
+
+      // Try to make ~10cm voxels, fit TPC exactly, then fit cryostat approximately
+      if (fUseAutomaticVoxels) {
+
+        std::string logString = "Automatic voxelisation x-dimension\n";
+        findVoxelSuggestion( logString, tpcVolume.MinX(), tpcVolume.MaxX(), geom->Cryostat().Boundaries().MinX(), geom->Cryostat().Boundaries().MaxX(), fNx, fXmin, fXmax );
+        logString += "Automatic voxelisation y-dimension\n";
+        findVoxelSuggestion( logString, tpcVolume.MinY(), tpcVolume.MaxY(), geom->Cryostat().Boundaries().MinY(), geom->Cryostat().Boundaries().MaxY(), fNy, fYmin, fYmax );
+        logString += "Automatic voxelisation z-dimension\n";
+        findVoxelSuggestion( logString, tpcVolume.MinZ(), tpcVolume.MaxZ(), geom->Cryostat().Boundaries().MinZ(), geom->Cryostat().Boundaries().MaxZ(), fNz, fZmin, fZmax );
+        mf::LogInfo("PhotonVisibilityService") << logString;
+      }
+
       fVoxelDef = sim::PhotonVoxelDef(fXmin, fXmax, fNx, fYmin, fYmax, fNy, fZmin, fZmax, fNz);
+
+      // Output lists of voxels within the TPC and outside it
+      if ( fSaveTPCVoxels != "" || fSaveOtherVoxels != "" ) {
+
+        unsigned int const totalVoxels = fVoxelDef.GetNVoxels();
+        std::vector< unsigned int > tpcVoxels, otherVoxels;
+        tpcVoxels.reserve( totalVoxels );
+        otherVoxels.reserve( totalVoxels );
+        for ( unsigned int voxelID = 0; voxelID < totalVoxels; ++voxelID ) {
+
+          auto const voxelCenter = fVoxelDef.GetPhotonVoxel( voxelID ).GetCenter();
+          if ( tpcVolume.ContainsPosition( voxelCenter ) ) {
+            tpcVoxels.push_back( voxelID );
+          }
+          else {
+            otherVoxels.push_back( voxelID );
+          }
+        }
+        std::string logString = "Voxels within TPC: " + std::to_string( tpcVoxels.size() );
+        if ( fSaveTPCVoxels != "" ) logString += " saved to file\n\t" + fSaveTPCVoxels;
+        logString += "\nVoxels outside TPC: " + std::to_string( otherVoxels.size() );
+        if ( fSaveOtherVoxels != "" ) logString += " saved to file\n\t" + fSaveOtherVoxels;
+        mf::LogInfo("PhotonVisibilityService") << logString << std::endl;
+
+        if ( fSaveTPCVoxels != "" ) {
+          std::ofstream outputFile = std::ofstream( fSaveTPCVoxels );
+          for ( auto voxel : tpcVoxels ) outputFile <<  std::to_string( voxel ) + "\n";
+        }
+        if ( fSaveOtherVoxels != "" ) {
+          std::ofstream outputFile = std::ofstream( fSaveOtherVoxels );
+          for ( auto voxel : otherVoxels ) outputFile <<  std::to_string( voxel ) + "\n";
+        }
+      }
     }
 
     if (fIncludePropTime) {
@@ -831,4 +896,60 @@ namespace phot {
     return fMapping->detectorToLibrary(p);
   }
 
+  void PhotonVisibilityService::findVoxelSuggestion( std::string& logString,
+                                                     float tpcMin, float tpcMax, float cryoMin, float cryoMax,
+                                                     int& nVoxels, float& voxelMin, float& voxelMax,
+                                                     float voxelSizeGoal ) const
+  {
+    // Scan the "jog" parameter, which adds an integer amount of voxels within the TPC
+    int bestJog = 0;
+    float bestResult = 1000;
+    std::string dummyString = "";
+    for ( int jog = -10; jog <= 10; ++jog )
+    {
+      dummyString = "";
+      float result = testVoxelSuggestion( dummyString,
+                                          tpcMin, tpcMax, cryoMin, cryoMax,
+                                          nVoxels, voxelMin, voxelMax,
+                                          voxelSizeGoal, jog );
+      if ( result < bestResult )
+      {
+        bestResult = result;
+        bestJog = jog;
+      }
+    }
+
+    // Print the best result (and update the outputs)
+    testVoxelSuggestion( logString,
+                         tpcMin, tpcMax, cryoMin, cryoMax,
+                         nVoxels, voxelMin, voxelMax,
+                         voxelSizeGoal, bestJog );
+  }
+
+  float PhotonVisibilityService::testVoxelSuggestion( std::string& logString,
+                                                      float tpcMin, float tpcMax, float cryoMin, float cryoMax,
+                                                      int& nVoxels, float& voxelMin, float& voxelMax,
+                                                      float voxelSizeGoal, int jog ) const
+  {
+    // Examine TPC to establish voxel size
+    float tpcSize = tpcMax - tpcMin;
+    int tpcVoxelNumber = ceil( tpcSize / voxelSizeGoal ) + jog; // units are cm
+    float voxelSize = tpcSize / tpcVoxelNumber;
+    float cryoSize = cryoMax - cryoMin;
+    logString += "\tTPC size " + std::to_string( tpcSize ) + "cm requires " + std::to_string( tpcVoxelNumber ) + " voxels of size " + std::to_string( voxelSize ) + "cm\n";
+
+    // Extend voxel grid to full cryostat
+    voxelMin = tpcMin;
+    while ( voxelMin > cryoMin ) voxelMin -= voxelSize;
+    voxelMax = tpcMax;
+    while ( voxelMax < cryoMax ) voxelMax += voxelSize;
+    float cryoVoxelNumberGuess = cryoSize / voxelSize;
+    nVoxels = round( ( voxelMax - voxelMin ) / voxelSize );
+    logString += "\tCryostat boundaries " + std::to_string( cryoMin ) + " to " + std::to_string( cryoMax ) + "cm would use " + std::to_string( cryoVoxelNumberGuess ) + " voxels\n";
+    logString += "\tCryostat voxel range " + std::to_string( voxelMin ) + " to " + std::to_string( voxelMax ) + "cm uses " + std::to_string( nVoxels ) + " voxels\n";
+    float voxelDelta = fabs( nVoxels - cryoVoxelNumberGuess );
+    return voxelDelta;
+  }
+
+    /// @}
 } // namespace

--- a/larsim/PhotonPropagation/PhotonVisibilityService.cc
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.cc
@@ -315,14 +315,14 @@ namespace phot {
 
       // Find the TPC volume, following example from
       // https://github.com/LArSoft/larsim/blob/05378155a2a07551fa5757d0449ffb30476d5cf9/larsim/LegacyLArG4/OpFastScintillation.cxx#L2149-L2165
-      geo::BoxBoundedGeo tpcVolume{geom->Cryostat().TPC(0).ActiveBoundingBox()};
-      for (geo::CryostatGeo const& cryo : geom->Iterate<geo::CryostatGeo>()) {
+      geo::BoxBoundedGeo cryoVolume{ geom->Cryostat().BoundingBox() };
+      geo::BoxBoundedGeo tpcVolume{ geom->Cryostat().TPC(0).ActiveBoundingBox() };
+      for ( geo::CryostatGeo const& cryo : geom->Iterate<geo::CryostatGeo>() ) {
 
-        int i = 0;
-        for (geo::TPCGeo const& TPC : cryo.IterateTPCs())
+        cryoVolume.ExtendToInclude( cryo.BoundingBox() );
+        for ( geo::TPCGeo const& TPC : cryo.IterateTPCs() )
         {
-          tpcVolume.ExtendToInclude(TPC.ActiveBoundingBox());
-          ++i;
+          tpcVolume.ExtendToInclude( TPC.ActiveBoundingBox() );
         }
       }
 
@@ -330,11 +330,11 @@ namespace phot {
       if (fUseAutomaticVoxels) {
 
         std::string logString = "Automatic voxelisation x-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinX(), tpcVolume.MaxX(), geom->Cryostat().Boundaries().MinX(), geom->Cryostat().Boundaries().MaxX(), fNx, fXmin, fXmax );
+        findVoxelSuggestion( logString, tpcVolume.MinX(), tpcVolume.MaxX(), cryoVolume.MinX(), cryoVolume.MaxX(), fNx, fXmin, fXmax );
         logString += "Automatic voxelisation y-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinY(), tpcVolume.MaxY(), geom->Cryostat().Boundaries().MinY(), geom->Cryostat().Boundaries().MaxY(), fNy, fYmin, fYmax );
+        findVoxelSuggestion( logString, tpcVolume.MinY(), tpcVolume.MaxY(), cryoVolume.MinY(), cryoVolume.MaxY(), fNy, fYmin, fYmax );
         logString += "Automatic voxelisation z-dimension\n";
-        findVoxelSuggestion( logString, tpcVolume.MinZ(), tpcVolume.MaxZ(), geom->Cryostat().Boundaries().MinZ(), geom->Cryostat().Boundaries().MaxZ(), fNz, fZmin, fZmax );
+        findVoxelSuggestion( logString, tpcVolume.MinZ(), tpcVolume.MaxZ(), cryoVolume.MinZ(), cryoVolume.MaxZ(), fNz, fZmin, fZmax );
         mf::LogInfo("PhotonVisibilityService") << logString;
       }
 

--- a/larsim/PhotonPropagation/PhotonVisibilityService.h
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.h
@@ -300,15 +300,26 @@ namespace phot {
 
     MappedFunctions_t doGetTimingTF1(geo::Point_t const& p) const;
 
-    void findVoxelSuggestion( std::string& logString,
-                              float tpcMin, float tpcMax, float cryoMin, float cryoMax,
-                              int& nVoxels, float& voxelMin, float& voxelMax,
-                              float voxelSizeGoal=10.0 ) const;
+    void findVoxelSuggestion(std::string& logString,
+                             float tpcMin,
+                             float tpcMax,
+                             float cryoMin,
+                             float cryoMax,
+                             int& nVoxels,
+                             float& voxelMin,
+                             float& voxelMax,
+                             float voxelSizeGoal = 10.0) const;
 
-    float testVoxelSuggestion( std::string& logString,
-                               float tpcMin, float tpcMax, float cryoMin, float cryoMax,
-                               int& nVoxels, float& voxelMin, float& voxelMax,
-                               float voxelSizeGoal=10.0, int jog=0 ) const;
+    float testVoxelSuggestion(std::string& logString,
+                              float tpcMin,
+                              float tpcMax,
+                              float cryoMin,
+                              float cryoMax,
+                              int& nVoxels,
+                              float& voxelMin,
+                              float& voxelMax,
+                              float voxelSizeGoal = 10.0,
+                              int jog = 0) const;
 
     /// @}
     // --- END Implementation functions ----------------------------------------

--- a/larsim/PhotonPropagation/PhotonVisibilityService.h
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.h
@@ -308,7 +308,7 @@ namespace phot {
                              float& voxelMin,
                              float& voxelMax,
                              float voxelSizeGoal,
-                             std::string* logString) const;
+                             std::string* logString = nullptr) const;
 
     float testVoxelSuggestion(float tpcMin,
                               float tpcMax,
@@ -319,7 +319,7 @@ namespace phot {
                               float& voxelMax,
                               float voxelSizeGoal,
                               int jog,
-                              std::string* logString) const;
+                              std::string* logString = nullptr) const;
 
     /// @}
     // --- END Implementation functions ----------------------------------------

--- a/larsim/PhotonPropagation/PhotonVisibilityService.h
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.h
@@ -180,6 +180,8 @@ namespace phot {
     int fNx, fNy, fNz;
 
     bool fUseCryoBoundary;
+    bool fUseAutomaticVoxels;
+    std::string fSaveTPCVoxels, fSaveOtherVoxels;
 
     bool fLibraryBuildJob;
     bool fDoNotLoadLibrary;
@@ -297,6 +299,16 @@ namespace phot {
     MappedParams_t doGetTimingPar(geo::Point_t const& p) const;
 
     MappedFunctions_t doGetTimingTF1(geo::Point_t const& p) const;
+
+    void findVoxelSuggestion( std::string& logString,
+                              float tpcMin, float tpcMax, float cryoMin, float cryoMax,
+                              int& nVoxels, float& voxelMin, float& voxelMax,
+                              float voxelSizeGoal=10.0 ) const;
+
+    float testVoxelSuggestion( std::string& logString,
+                               float tpcMin, float tpcMax, float cryoMin, float cryoMax,
+                               int& nVoxels, float& voxelMin, float& voxelMax,
+                               float voxelSizeGoal=10.0, int jog=0 ) const;
 
     /// @}
     // --- END Implementation functions ----------------------------------------

--- a/larsim/PhotonPropagation/PhotonVisibilityService.h
+++ b/larsim/PhotonPropagation/PhotonVisibilityService.h
@@ -300,26 +300,26 @@ namespace phot {
 
     MappedFunctions_t doGetTimingTF1(geo::Point_t const& p) const;
 
-    void findVoxelSuggestion(std::string& logString,
-                             float tpcMin,
+    void findVoxelSuggestion(float tpcMin,
                              float tpcMax,
                              float cryoMin,
                              float cryoMax,
                              int& nVoxels,
                              float& voxelMin,
                              float& voxelMax,
-                             float voxelSizeGoal = 10.0) const;
+                             float voxelSizeGoal,
+                             std::string* logString) const;
 
-    float testVoxelSuggestion(std::string& logString,
-                              float tpcMin,
+    float testVoxelSuggestion(float tpcMin,
                               float tpcMax,
                               float cryoMin,
                               float cryoMax,
                               int& nVoxels,
                               float& voxelMin,
                               float& voxelMax,
-                              float voxelSizeGoal = 10.0,
-                              int jog = 0) const;
+                              float voxelSizeGoal,
+                              int jog,
+                              std::string* logString) const;
 
     /// @}
     // --- END Implementation functions ----------------------------------------


### PR DESCRIPTION
Added an automatic voxelisation option, fitting exactly to the TPC boundaries and then optimising for the cryostat

Also added the option to save lists of voxel IDs within the TPC and outside, to allow efficient generation of photon library.

NB, this seems to require a rebuild of larana, specificially due to
https://github.com/LArSoft/larana/blob/b6abb28a9515bb5a8193e6aa2fd131a2ee0ecd8e/larana/OpticalDetector/SimPhotonCounter_module.cc#L192
This seems like a problem with the build system, but maybe I'm missing something obvious.