### PR TITLE
Adding option to MUSUN generator to rotate coordinate system

### DIFF
--- a/larsim/EventGenerator/MuonPropagation/MUSUN.fcl
+++ b/larsim/EventGenerator/MuonPropagation/MUSUN.fcl
@@ -9,9 +9,9 @@ standard_MUSUN:
  PDG:                    -13        # PdG codes of particles to make
  ChargeRatio:            1.38       # Ratio of particle/anti-particle
                                     # For one particle type set equal to 0.
-                                    
- # Directory where ROOT pdf file is. If not using one of the standard configurations 
- # you will !!NEED!! to change this to your own directory!!!  
+
+ # Directory where ROOT pdf file is. If not using one of the standard configurations
+ # you will !!NEED!! to change this to your own directory!!!
  InputDir:               "/dune/data/users/warburton/MUSUN/"
  InputFile1:             "muint-dune4850-mr-new.dat" # Table of muon intensities for theta and phi
  InputFile2:             "musp-dune4850-mr-new.dat"  # Binary file of energies for theta and depths
@@ -19,19 +19,19 @@ standard_MUSUN:
 
  CavernAngle:            7          # Angle of the detector from the East to South.
  RockDensity:            2.70       # Default rock density is 2.70 g cm-3. If this is
- 			 	    # changed then the three input files need to be 
+ 			 	    # changed then the three input files need to be
 				    # remade. If there is a desire for this contact
 				    # Vitaly Kudryavtsev at V.Kudryavtsev@shef.ac.uk
 
  Emin:                   1.   	    # Minimum Kinetic Energy GeV
  Emax:                   1000000.   # Maximum Kinetic Energy GeV
- 
- Thetamin:               0.         # Minimum angle, must be more than or equal to 0. 
- Thetamax:               90.        # Maximum angle, must be less than or equal to 90	
 
- Phimin:                 0.         # Minimum angle, must be more than or equal to 0. 
+ Thetamin:               0.         # Minimum angle, must be more than or equal to 0.
+ Thetamax:               90.        # Maximum angle, must be less than or equal to 90
+
+ Phimin:                 0.         # Minimum angle, must be more than or equal to 0.
  Phimax:                 360.       # Maximum angle, must be less than or equal to 360
-	
+
  # You have to change all these dimensions if you change the size of the
  # parallelepiped. The dimensions are given in cm.
  # Ideally want the surface on which the muons are sampled to be extended by 5 m
@@ -58,7 +58,7 @@ standard_MUSUN:
  #	-y: 3920.75
  #	+y: 3679.25
  #	-z: 6578
- #	+z: 1022 
+ #	+z: 1022
 
  igflag:                 1         # If want muons sampled from parallelepiped, not a sphere.
  Xmin:                   -1477.    # Minumum X position cm
@@ -68,17 +68,22 @@ standard_MUSUN:
  Zmin:                   -1083.    # Minumum Z position cm
  Zmax:                   6639.     # Maximum Z position cm
 
-#   Vitaly's Fortran code for LBNE uses these positions. 
+# detector rotation, default is the nominal HD FD
+ DetRotX:               0.         # rotation around X axis, clockwise
+ DetRotY:               0.         # rotation around Y axis, clockwise
+ DetRotZ:               0.         # rotation around Z axis, clockwise
+
+#   Vitaly's Fortran code for LBNE uses these positions.
 # Xmin:                   -1500.    # Minumum X position cm
 # Xmax:                   1500.     # Maximum X position cm
 # Ymin:                   -1400.    # Minumum Y position cm
 # Ymax:                   1600.     # Maximum Y position cm
 # Zmin:                   -3500.    # Minumum Z position cm
 # Zmax:                   3500.     # Maximum Z position cm
- 
+
  T0:                     0.         # starting time
  SigmaT:                 0.         # variation in the starting time
- TDist:                  0          # 0 - uniform, 1 - gaussian 
+ TDist:                  0          # 0 - uniform, 1 - gaussian
 }
 
 END_PROLOG

--- a/larsim/EventGenerator/MuonPropagation/MUSUN.fcl
+++ b/larsim/EventGenerator/MuonPropagation/MUSUN.fcl
@@ -61,6 +61,7 @@ standard_MUSUN:
  #	+z: 1022
 
  igflag:                 1         # If want muons sampled from parallelepiped, not a sphere.
+ # Dimensions for DUNE Far Detector - includes 5 m of rock around the detector
  Xmin:                   -1477.    # Minumum X position cm
  Xmax:                   1477.     # Maximum X position cm
  Ymin:                   -1288.    # Minumum Y position cm
@@ -68,10 +69,16 @@ standard_MUSUN:
  Zmin:                   -1083.    # Minumum Z position cm
  Zmax:                   6639.     # Maximum Z position cm
 
-# detector rotation, default is the nominal HD FD
+# detector rotation, default is the nominal DUNE HD FD
  DetRotX:               0.         # rotation around X axis, clockwise
  DetRotY:               0.         # rotation around Y axis, clockwise
  DetRotZ:               0.         # rotation around Z axis, clockwise
+
+# For DUNE FD VD, where X is vertical, rotate Z by 90 deg.
+# DetRotX:               0.         # rotation around X axis, clockwise
+# DetRotY:               0.         # rotation around Y axis, clockwise
+# DetRotZ:              90.         # rotation around Z axis, clockwise
+
 
 #   Vitaly's Fortran code for LBNE uses these positions.
 # Xmin:                   -1500.    # Minumum X position cm

--- a/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
+++ b/larsim/EventGenerator/MuonPropagation/MUSUN_module.cc
@@ -254,10 +254,12 @@ namespace evgen {
 
     /// Rotation of the detector w.r.t. DUNE HD FD nominal coordinate system - Z: beam direction; Y: vertical; X: drift; right-handed
     /// Rotation performed in the order - first around X, then around new Y, and then around new Z
-    double fDetRotX; ///< How much the detector should be rotated around X axis (rotates the coordinate system clockwise))
-    double fDetRotY; ///< How much the detector should be rotated around Y axis (rotates the coordinate system clockwise))
-    double fDetRotZ; ///< How much the detector should be rotated around Z axis (rotates the coordinate system clockwise))
-
+    double
+      fDetRotX; ///< How much the detector should be rotated around X axis (rotates the coordinate system clockwise))
+    double
+      fDetRotY; ///< How much the detector should be rotated around Y axis (rotates the coordinate system clockwise))
+    double
+      fDetRotZ; ///< How much the detector should be rotated around Z axis (rotates the coordinate system clockwise))
 
     double fT0;     ///< Central t position (ns) in world coordinates
     double fSigmaT; ///< Variation in t position (ns)
@@ -372,15 +374,12 @@ namespace evgen {
   void MUSUN::beginJob()
   {
 
-    fDetRotX = fDetRotX * M_PI/180.;
-    fDetRotY = fDetRotY * M_PI/180.;
-    fDetRotZ = fDetRotZ * M_PI/180.;
+    fDetRotX = fDetRotX * M_PI / 180.;
+    fDetRotY = fDetRotY * M_PI / 180.;
+    fDetRotZ = fDetRotZ * M_PI / 180.;
 
-    MF_LOG_WARNING("MUSUN")<<"Rotation: X = "<<fDetRotX
-			<<", Y = "<<fDetRotY
-			<<", Z = "<<fDetRotZ
-			<<std::endl;
-
+    MF_LOG_WARNING("MUSUN") << "Rotation: X = " << fDetRotX << ", Y = " << fDetRotY
+                            << ", Z = " << fDetRotZ << std::endl;
 
     // Make the Histograms....
     art::ServiceHandle<art::TFileService const> tfs;
@@ -615,7 +614,6 @@ namespace evgen {
     pvec.RotateY(-fDetRotY);
     pvec.RotateZ(-fDetRotZ);
 
-
     //  Muon coordinates
     double sh1 = s_hor * cos(theta);
     double sv1 = s_ver1 * sin(theta) * fabs(cos(phi));
@@ -650,7 +648,6 @@ namespace evgen {
     pos.RotateX(-fDetRotX);
     pos.RotateY(-fDetRotY);
     pos.RotateZ(-fDetRotZ);
-
 
     //  Parameters written to the file muons_surf_v2_test*.dat
     //      nmu - muon sequential number


### PR DESCRIPTION
This adds configurables  to MUSUN generator so that users can rotate the coordinate system to match the detector coordinate system.

By default, MUSUN assumes the standard DUNE Far Detector Horizontal Drift coordinate system, with Z in beam direction, Y vertical, and X in the horizontal drift direction. In order to be able to generate muons within Vertical Drift geometry which assumes X to be vertical, MUSUN's internal coordinate system needs to be rotated accordingly.

Example of how to configure this rotation for DUNE FD VD is included in comments within MUSUN.fcl.

This modification was tested long time ago, within DUNE Calibration Working Group, where cosmic muon sample was generated for the VD geometry.