### PR TITLE
Updates to semi-analytical light simulation for DUNE 10kt simulation

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -302,8 +302,9 @@ namespace phot {
 
     // determine drift distance
     fDriftDistance = fGeom.TPC().DriftDistance();
-    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)  
-    if (fNTPC > 1 && fDriftDistance < 50) fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
+    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)
+    if (fNTPC > 1 && fDriftDistance < 50)
+      fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
 
     mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR Initialization finish.\n"
                                 << "Simulate using semi-analytic model for number of hits."
@@ -434,7 +435,7 @@ namespace phot {
           if (!((ndetected_fast > 0 && fDoFastComponent) ||
                 (ndetected_slow > 0 && fDoSlowComponent)))
             continue;
-          
+
           // calculate propagation time, does not matter whether fast or slow photon
           std::vector<double> transport_time;
           if (fIncludePropTime) {
@@ -586,19 +587,20 @@ namespace phot {
                                       geo::Point_t const& OpDetPoint) const
   {
     // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service 
+    // temporary method, needs to be replaced with geometry service
     // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-    
+
     // special case for SBND = 2 TPCs
     // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10.) { 
-       return false;
+    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
+        std::abs(OpDetPoint.X()) > 10.) {
+      return false;
     }
-    
+
     // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance 
-    if (fNTPC == 300 && std::abs( ScintPoint.X() - OpDetPoint.X() ) > fDriftDistance ) {
-       return false;
+    // check whether distance in drift direction > 1 drift distance
+    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
+      return false;
     }
     // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
 

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -161,6 +161,7 @@ namespace phot {
     const size_t fNOpChannels;
     const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
     const int fNTPC;
+    double fDriftDistance;
     const std::vector<geo::Point_t> fOpDetCenter;
 
     // Module behavior
@@ -298,6 +299,12 @@ namespace phot {
         produces<std::vector<sim::SimPhotons>>("Reflected");
       }
     }
+
+    // determine drift distance
+    fDriftDistance = fGeom.TPC().DriftDistance();
+    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)  
+    if (fNTPC > 1 && fDriftDistance < 50) fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
+
     mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR Initialization finish.\n"
                                 << "Simulate using semi-analytic model for number of hits."
                                 << std::endl;
@@ -427,7 +434,7 @@ namespace phot {
           if (!((ndetected_fast > 0 && fDoFastComponent) ||
                 (ndetected_slow > 0 && fDoSlowComponent)))
             continue;
-
+          
           // calculate propagation time, does not matter whether fast or slow photon
           std::vector<double> transport_time;
           if (fIncludePropTime) {
@@ -579,12 +586,22 @@ namespace phot {
                                       geo::Point_t const& OpDetPoint) const
   {
     // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method working for SBND, uBooNE, DUNE 1x2x6; to be replaced to work in full DUNE geometry
+    // temporary method, needs to be replaced with geometry service 
+    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
+    
+    // special case for SBND = 2 TPCs
     // check x coordinate has same sign or is close to zero
-    if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10. &&
-        fNTPC == 2) { // TODO: replace with geometry service method
-      return false;
+    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10.) { 
+       return false;
     }
+    
+    // special case for DUNE-HD 10kt = 300 TPCs
+    // check whether distance in drift direction > 1 drift distance 
+    if (fNTPC == 300 && std::abs( ScintPoint.X() - OpDetPoint.X() ) > fDriftDistance ) {
+       return false;
+    }
+    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
+
     return true;
   }
 

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -63,7 +63,9 @@ namespace phot {
     fApplyFieldCageTransparency = VUVHitsParams.get<bool>("ApplyFieldCageTransparency", false);
     fFieldCageTransparencyLateral = VUVHitsParams.get<double>("FieldCageTransparencyLateral", 1.0);
     fFieldCageTransparencyCathode = VUVHitsParams.get<double>("FieldCageTransparencyCathode", 1.0);
-    fMaxPDDistance = VUVHitsParams.get<double>("MaxPDDistance", 1000); // max distance between scintillation and PD to evaluate light, default 10m
+    fMaxPDDistance = VUVHitsParams.get<double>(
+      "MaxPDDistance",
+      1000); // max distance between scintillation and PD to evaluate light, default 10m
 
     if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
       throw cet::exception("SemiAnalyticalModel")
@@ -145,8 +147,9 @@ namespace phot {
 
     // determine drift distance
     fDriftDistance = fGeom.TPC().DriftDistance();
-    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)  
-    if (fNTPC > 1 && fDriftDistance < 50) fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
+    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)
+    if (fNTPC > 1 && fDriftDistance < 50)
+      fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
 
     // set absorption length
     fvuv_absorption_length = VUVAbsorptionLength();
@@ -201,7 +204,6 @@ namespace phot {
       }
 
       DetectedVisibilities[OpDet] = VUVVisibility(ScintPoint, fOpDetector[OpDet]);
-
     }
   }
 
@@ -325,11 +327,11 @@ namespace phot {
 
     // calculate correction
     double GH_correction = Gaisser_Hillas(distance, pars_ini);
-   
+
     // check sensible GH correction values, GH correction should never be large
     // catches occasional issues caused by overflow
-    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0; 
-   
+    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0;
+
     // determine corrected visibility of photo-detector
     return GH_correction * visibility_geo / cosine;
   }
@@ -409,11 +411,11 @@ namespace phot {
 
     // calculate corrected number of hits
     double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini);
-    
+
     // check sensible GH correction values, GH correction should never be large
     // catches occasional issues caused by overflow
-    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0; 
-    
+    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0;
+
     const double cathode_visibility_rec = GH_correction * cathode_visibility_geo;
 
     // 2). detemine visibility of each PD
@@ -560,7 +562,7 @@ namespace phot {
     double Diff = par[1] - X_mu_0;
     double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
     double Exponential = std::exp((par[1] - x) / par[2]);
-    
+
     return (Normalization * Term * Exponential);
   }
 
@@ -758,23 +760,24 @@ namespace phot {
                                              geo::Point_t const& OpDetPoint) const
   {
     // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service 
+    // temporary method, needs to be replaced with geometry service
     // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-    
+
     // special case for SBND = 2 TPCs
     // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10.) {
-       return false;
+    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
+        std::abs(OpDetPoint.X()) > 10.) {
+      return false;
     }
-    
+
     // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance 
-    if (fNTPC == 300 && std::abs( ScintPoint.X() - OpDetPoint.X() ) > fDriftDistance ) {
-       return false;
+    // check whether distance in drift direction > 1 drift distance
+    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
+      return false;
     }
 
     // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
-    
+
     return true;
   }
 

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -9,6 +9,7 @@
 #include "larcorealg/Geometry/CryostatGeo.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/OpDetGeo.h"
+
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 
 // support libraries
@@ -62,6 +63,7 @@ namespace phot {
     fApplyFieldCageTransparency = VUVHitsParams.get<bool>("ApplyFieldCageTransparency", false);
     fFieldCageTransparencyLateral = VUVHitsParams.get<double>("FieldCageTransparencyLateral", 1.0);
     fFieldCageTransparencyCathode = VUVHitsParams.get<double>("FieldCageTransparencyCathode", 1.0);
+    fMaxPDDistance = VUVHitsParams.get<double>("MaxPDDistance", 1000); // max distance between scintillation and PD to evaluate light, default 10m
 
     if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
       throw cet::exception("SemiAnalyticalModel")
@@ -141,6 +143,11 @@ namespace phot {
       fanode_plane_depth = fanode_centre[0];
     }
 
+    // determine drift distance
+    fDriftDistance = fGeom.TPC().DriftDistance();
+    // for multiple TPCs, use second TPC to skip small volume at edges of detector (DUNE)  
+    if (fNTPC > 1 && fDriftDistance < 50) fDriftDistance = fGeom.TPC(geo::TPCID{0, 1}).DriftDistance();
+
     // set absorption length
     fvuv_absorption_length = VUVAbsorptionLength();
     mf::LogInfo("SemiAnalyticalModel")
@@ -180,13 +187,21 @@ namespace phot {
   {
     DetectedVisibilities.resize(fNOpDets);
     for (size_t const OpDet : util::counter(fNOpDets)) {
+      // check OpDet in same drift volume
       if (!isOpDetInSameTPC(ScintPoint, fOpDetector[OpDet].center)) {
+        DetectedVisibilities[OpDet] = 0.;
+        continue;
+      }
+      // check distance smaller than maximum distance
+      geo::Vector_t const relative = ScintPoint - fOpDetector[OpDet].center;
+      const double distance = relative.R();
+      if (distance > fMaxPDDistance) {
         DetectedVisibilities[OpDet] = 0.;
         continue;
       }
 
       DetectedVisibilities[OpDet] = VUVVisibility(ScintPoint, fOpDetector[OpDet]);
-      ;
+
     }
   }
 
@@ -310,7 +325,11 @@ namespace phot {
 
     // calculate correction
     double GH_correction = Gaisser_Hillas(distance, pars_ini);
-
+   
+    // check sensible GH correction values, GH correction should never be large
+    // catches occasional issues caused by overflow
+    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0; 
+   
     // determine corrected visibility of photo-detector
     return GH_correction * visibility_geo / cosine;
   }
@@ -390,6 +409,11 @@ namespace phot {
 
     // calculate corrected number of hits
     double GH_correction = Gaisser_Hillas(distance_cathode, pars_ini);
+    
+    // check sensible GH correction values, GH correction should never be large
+    // catches occasional issues caused by overflow
+    if (!std::isfinite(GH_correction) || GH_correction < 0 || GH_correction > 10) GH_correction = 0; 
+    
     const double cathode_visibility_rec = GH_correction * cathode_visibility_geo;
 
     // 2). detemine visibility of each PD
@@ -536,7 +560,7 @@ namespace phot {
     double Diff = par[1] - X_mu_0;
     double Term = std::pow((x - X_mu_0) / Diff, Diff / par[2]);
     double Exponential = std::exp((par[1] - x) / par[2]);
-
+    
     return (Normalization * Term * Exponential);
   }
 
@@ -709,7 +733,7 @@ namespace phot {
     constexpr double par0[9] = {0., 0., 0., 0., 0., 0.597542, 1.00872, 1.46993, 2.04221};
     constexpr double par1[9] = {
       0., 0., 0.19569, 0.300449, 0.555598, 0.854939, 1.39166, 2.19141, 2.57732};
-    const double delta_theta = 10.; // TODO: should this be fdelta_angulo_vuv?
+    const double delta_theta = 10.;
     int j = int(theta / delta_theta);
     // PMT radius
     const double b = fradius; // cm
@@ -733,14 +757,24 @@ namespace phot {
   bool SemiAnalyticalModel::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
                                              geo::Point_t const& OpDetPoint) const
   {
-    // method working for SBND, uBooNE, DUNE-HD 1x2x6 and DUNE-VD 1x8x6
-    // will need to be replaced to work in full DUNE geometry, ICARUS geometry
-    // check x coordinate has same sign or is close to zero, otherwise return
-    // false
-    if (((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10. &&
-        fNTPC == 2) { // TODO: replace with geometry service
-      return false;
+    // check optical channel is in same TPC as scintillation light, if not doesn't see light
+    // temporary method, needs to be replaced with geometry service 
+    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
+    
+    // special case for SBND = 2 TPCs
+    // check x coordinate has same sign or is close to zero
+    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) && std::abs(OpDetPoint.X()) > 10.) {
+       return false;
     }
+    
+    // special case for DUNE-HD 10kt = 300 TPCs
+    // check whether distance in drift direction > 1 drift distance 
+    if (fNTPC == 300 && std::abs( ScintPoint.X() - OpDetPoint.X() ) > fDriftDistance ) {
+       return false;
+    }
+
+    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
+    
     return true;
   }
 

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -91,7 +91,6 @@ namespace phot {
     // dome aperture calculation
     double Omega_Dome_Model(const double distance, const double theta) const;
 
-    // TODO: replace with geometry service
     bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
     std::vector<OpticalDetector> opticalDetectors() const;
 
@@ -103,6 +102,7 @@ namespace phot {
     const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
     const TVector3 fcathode_centre, fanode_centre;
     double fplane_depth, fanode_plane_depth;
+    double fDriftDistance;
 
     // photodetector geometry properties
     const size_t fNOpDets;
@@ -156,6 +156,9 @@ namespace phot {
     // absorption length
     const bool fUseXeAbsorption;
     double fvuv_absorption_length;
+
+    // maximum distance
+    double fMaxPDDistance;
   };
 
 } // namespace phot


### PR DESCRIPTION
Adds two minor updates to semi-analytical light simulation to enable it to work in DUNE 10kt simulation (HD):

1. Adds temporary solution for identifying which photon detectors are visible depending on where the light emission occurs given the multiple optically isolated volumes in the DUNE 10kt geometry. Longer term, this is to be updated with a potential geometry service implementation currently under discussion.
2. Adds maximum distance between photon detectors and light emission to evaluate semi-analytical model, configured via fhicl parameter. Negligible light seen from very large distances, so calculations unnecessary -- leads to significant speed up in large geometries. 

This has been tested in DUNE validation system and sample of O(10k) test events successfully produced with 10kt geometry.  