### PR TITLE
Add in option to skip TrackID Offsets to MergeSimSources

### DIFF
--- a/larsim/MergeSimSources/MergeSimSources.cxx
+++ b/larsim/MergeSimSources/MergeSimSources.cxx
@@ -63,7 +63,7 @@ void sim::MergeSimSourcesUtility::MergeMCParticles(
 void sim::MergeSimSourcesUtility::MergeSimChannels(std::vector<sim::SimChannel>& merged_vector,
                                                    const std::vector<sim::SimChannel>& input_vector,
                                                    size_t source_index,
-						   bool skip_trackIDs)
+                                                   bool skip_trackIDs)
 {
   if (source_index >= fG4TrackIDOffsets.size())
     std::runtime_error("ERROR in MergeSimSourcesUtility: Source index out of range!");
@@ -90,8 +90,7 @@ void sim::MergeSimSourcesUtility::MergeSimChannels(std::vector<sim::SimChannel>&
       range_trackID.second = std::abs(thisrange.second);
   }
 
-  if(!skip_trackIDs)
-    UpdateG4TrackIDRange(range_trackID, source_index);
+  if (!skip_trackIDs) UpdateG4TrackIDRange(range_trackID, source_index);
 }
 
 void sim::MergeSimSourcesUtility::MergeAuxDetSimChannels(

--- a/larsim/MergeSimSources/MergeSimSources.cxx
+++ b/larsim/MergeSimSources/MergeSimSources.cxx
@@ -62,7 +62,8 @@ void sim::MergeSimSourcesUtility::MergeMCParticles(
 
 void sim::MergeSimSourcesUtility::MergeSimChannels(std::vector<sim::SimChannel>& merged_vector,
                                                    const std::vector<sim::SimChannel>& input_vector,
-                                                   size_t source_index)
+                                                   size_t source_index,
+						   bool skip_trackIDs)
 {
   if (source_index >= fG4TrackIDOffsets.size())
     std::runtime_error("ERROR in MergeSimSourcesUtility: Source index out of range!");
@@ -89,7 +90,8 @@ void sim::MergeSimSourcesUtility::MergeSimChannels(std::vector<sim::SimChannel>&
       range_trackID.second = std::abs(thisrange.second);
   }
 
-  UpdateG4TrackIDRange(range_trackID, source_index);
+  if(!skip_trackIDs)
+    UpdateG4TrackIDRange(range_trackID, source_index);
 }
 
 void sim::MergeSimSourcesUtility::MergeAuxDetSimChannels(

--- a/larsim/MergeSimSources/MergeSimSources.h
+++ b/larsim/MergeSimSources/MergeSimSources.h
@@ -39,7 +39,8 @@ namespace sim {
 
     void MergeSimChannels(std::vector<sim::SimChannel>&,
                           const std::vector<sim::SimChannel>&,
-                          size_t);
+                          size_t,
+			  bool);
 
     void MergeAuxDetSimChannels(std::vector<sim::AuxDetSimChannel>&,
                                 const std::vector<sim::AuxDetSimChannel>&,

--- a/larsim/MergeSimSources/MergeSimSources.h
+++ b/larsim/MergeSimSources/MergeSimSources.h
@@ -40,7 +40,7 @@ namespace sim {
     void MergeSimChannels(std::vector<sim::SimChannel>&,
                           const std::vector<sim::SimChannel>&,
                           size_t,
-			  bool);
+                          bool);
 
     void MergeAuxDetSimChannels(std::vector<sim::AuxDetSimChannel>&,
                                 const std::vector<sim::AuxDetSimChannel>&,

--- a/larsim/MergeSimSources/MergeSimSources_module.cc
+++ b/larsim/MergeSimSources/MergeSimSources_module.cc
@@ -320,7 +320,7 @@ void sim::MergeSimSources::produce(art::Event& e)
     }
 
     if (fFillSimChannels) {
-      auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);      
+      auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);
       MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, fSkipTrackIDOffsets);
 
       /*

--- a/larsim/MergeSimSources/MergeSimSources_module.cc
+++ b/larsim/MergeSimSources/MergeSimSources_module.cc
@@ -83,6 +83,12 @@ public:
       true // default
     };
 
+    fhicl::Atom<bool> SkipTrackIDOffsets{
+      fhicl::Name{"SkipTrackIDOffsets"},
+      fhicl::Comment{"skip the application of trackID offsets"},
+      false // default
+    };
+
     fhicl::Atom<bool> FillAuxDetSimChannels{
       fhicl::Name{"FillAuxDetSimChannels"},
       fhicl::Comment{"whether to merge AuxDetSimChannels"},
@@ -134,6 +140,7 @@ private:
   bool const fFillMCParticles;
   bool const fFillSimPhotons;
   bool const fFillSimChannels;
+  bool const fSkipTrackIDOffsets;
   bool const fFillAuxDetSimChannels;
   bool const fFillSimEnergyDeposits;
   std::vector<std::string> const fEnergyDepositionInstances;
@@ -175,6 +182,7 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
   , fFillMCParticles(params().FillMCParticles())
   , fFillSimPhotons(params().FillSimPhotons())
   , fFillSimChannels(params().FillSimChannels())
+  , fSkipTrackIDOffsets(params().SkipTrackIDOffsets())
   , fFillAuxDetSimChannels(params().FillAuxDetSimChannels())
   , fFillSimEnergyDeposits(
       getOptionalValue(params().FillSimEnergyDeposits)
@@ -185,7 +193,7 @@ sim::MergeSimSources::MergeSimSources(Parameters const& params)
   , fFillParticleAncestryMaps(params().FillParticleAncestryMaps())
 {
 
-  if (fInputSourcesLabels.size() != fTrackIDOffsets.size()) {
+  if (fSkipTrackIDOffsets == false && fInputSourcesLabels.size() != fTrackIDOffsets.size()) {
     throw art::Exception(art::errors::Configuration)
       << "Unequal input vector sizes: InputSourcesLabels and TrackIDOffsets.\n";
   }
@@ -312,8 +320,19 @@ void sim::MergeSimSources::produce(art::Event& e)
     }
 
     if (fFillSimChannels) {
-      auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);
-      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source);
+      auto const& input_scCol = e.getProduct<std::vector<sim::SimChannel>>(input_label);      
+      MergeUtility.MergeSimChannels(*scCol, input_scCol, i_source, fSkipTrackIDOffsets);
+
+      /*
+      for (auto& simChannel : *scCol) {
+	auto& tdcIDEMap = simChannel.TDCIDEMap();
+	std::map<int, std::vector<sim::IDE>> sortedTDCIDEMap;
+	for (auto& entry : tdcIDEMap) {
+	  sortedTDCIDEMap[entry.first] = std::move(entry.second);
+	}
+	simChannel.SetTDCIDEMap(std::move(sortedTDCIDEMap));
+      }
+      */
     }
 
     if (fFillAuxDetSimChannels) {


### PR DESCRIPTION
This feature enables the intransparency simulation in ICARUS.