### PR TITLE
MCRecoEdep fixes [1/2]

### DIFF
--- a/larsim/MCDumpers/DumpMCParticles_module.cc
+++ b/larsim/MCDumpers/DumpMCParticles_module.cc
@@ -56,6 +56,22 @@ namespace {
       "DumpMCParticles" /* default value */
     };
 
+    fhicl::Atom<bool> PrintStepPositions{
+      Name("PrintStepPositions"),
+      Comment("prints the position and time of each trajectory point"),
+      true
+    };
+    fhicl::Atom<bool> PrintStepMomenta{
+      Name("PrintStepMomenta"),
+      Comment("prints the momentum at each trajectory point"),
+      false
+    };
+    fhicl::Atom<bool> PrintStepEnergies{
+      Name("PrintStepEnergies"),
+      Comment("prints the total energy at each trajectory point"),
+      false
+    };
+
     fhicl::Atom<unsigned int> PointsPerLine{
       Name("PointsPerLine"),
       Comment("trajectory points printed per line (default: 2; 0 = skip them)"),
@@ -118,6 +134,9 @@ private:
   art::InputTag fInputParticles;    ///< name of MCParticle's data product
   art::InputTag fParticleTruthInfo; ///< name of MCParticle assns data product
   std::string fOutputCategory;      ///< name of the stream for output
+  bool fPrintStepPositions;         ///< whether to print trajectory coordinates
+  bool fPrintStepMomenta;           ///< whether to print momentum along trajectory
+  bool fPrintStepEnergies;          ///< whether to print energy along trajectory
   unsigned int fPointsPerLine;      ///< trajectory points per output line
 
   unsigned int fNEvents = 0U; ///< Count of processed events.
@@ -194,6 +213,9 @@ sim::DumpMCParticles::DumpMCParticles(Parameters const& config)
   : EDAnalyzer(config)
   , fInputParticles(config().InputParticles())
   , fOutputCategory(config().OutputCategory())
+  , fPrintStepPositions(config().PrintStepPositions())
+  , fPrintStepMomenta(config().PrintStepMomenta())
+  , fPrintStepEnergies(config().PrintStepEnergies())
   , fPointsPerLine(config().PointsPerLine())
 {
   if (!config().ParticleTruthInfo(fParticleTruthInfo)) fParticleTruthInfo = fInputParticles;
@@ -228,7 +250,9 @@ void sim::DumpMCParticles::DumpMCParticle(Stream&& out,
   if ((nPoints > 0) && (fPointsPerLine > 0)) {
     out << ":";
     sim::dump::DumpMCParticleTrajectory(
-      std::forward<Stream>(out), particle.Trajectory(), fPointsPerLine, indent + "  ");
+      std::forward<Stream>(out), particle.Trajectory(), fPointsPerLine, indent + "  ",
+      fPrintStepPositions, fPrintStepMomenta, fPrintStepEnergies
+      );
   } // if has points
 
 } // sim::DumpMCParticles::DumpMCParticle()

--- a/larsim/MCDumpers/DumpMCParticles_module.cc
+++ b/larsim/MCDumpers/DumpMCParticles_module.cc
@@ -59,18 +59,15 @@ namespace {
     fhicl::Atom<bool> PrintStepPositions{
       Name("PrintStepPositions"),
       Comment("prints the position and time of each trajectory point"),
-      true
-    };
-    fhicl::Atom<bool> PrintStepMomenta{
-      Name("PrintStepMomenta"),
-      Comment("prints the momentum at each trajectory point"),
-      false
-    };
-    fhicl::Atom<bool> PrintStepEnergies{
-      Name("PrintStepEnergies"),
-      Comment("prints the total energy at each trajectory point"),
-      false
-    };
+      true};
+
+    fhicl::Atom<bool> PrintStepMomenta{Name("PrintStepMomenta"),
+                                       Comment("prints the momentum at each trajectory point"),
+                                       false};
+
+    fhicl::Atom<bool> PrintStepEnergies{Name("PrintStepEnergies"),
+                                        Comment("prints the total energy at each trajectory point"),
+                                        false};
 
     fhicl::Atom<unsigned int> PointsPerLine{
       Name("PointsPerLine"),
@@ -249,10 +246,13 @@ void sim::DumpMCParticles::DumpMCParticle(Stream&& out,
   const unsigned int nPoints = particle.NumberTrajectoryPoints();
   if ((nPoints > 0) && (fPointsPerLine > 0)) {
     out << ":";
-    sim::dump::DumpMCParticleTrajectory(
-      std::forward<Stream>(out), particle.Trajectory(), fPointsPerLine, indent + "  ",
-      fPrintStepPositions, fPrintStepMomenta, fPrintStepEnergies
-      );
+    sim::dump::DumpMCParticleTrajectory(std::forward<Stream>(out),
+                                        particle.Trajectory(),
+                                        fPointsPerLine,
+                                        indent + "  ",
+                                        fPrintStepPositions,
+                                        fPrintStepMomenta,
+                                        fPrintStepEnergies);
   } // if has points
 
 } // sim::DumpMCParticles::DumpMCParticle()

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -141,6 +141,9 @@ namespace sim {
 
     if (_debug_mode)
       std::cout << "Processing " << sedArray.size() << " energy deposits..." << std::endl;
+    
+    geo::TPCGeo const* TPC = nullptr; // the TPC where the last deposit was seen
+    
     // Loop over channels
     for (size_t i = 0; i < sedArray.size(); ++i) {
 
@@ -162,7 +165,8 @@ namespace sim {
       // From the position in world coordinates, determine the cryostat and tpc. If
       // somehow the step is outside a tpc (e.g., cosmic rays in rock) just move on to the
       // next one.
-      geo::TPCGeo const* TPC = geom->PositionToTPCptr(mp);
+      
+      if (!TPC || !TPC->ContainsPosition(mp)) TPC = geom->PositionToTPCptr(mp);
       if (!TPC) {
         mf::LogWarning("SimDriftElectrons") << "step at " << mp << " is not within any TPC.";
         continue;

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -146,6 +146,11 @@ namespace sim {
 
       // Get data to loop over
       auto const& sed = sedArray[i];
+      
+      mf::LogVerbatim log{ "MakeMCEdep" }; // FIXME DEBUG
+      log << "EDep=" << sed.Energy() << " Q=" << sed.NumElectrons()
+        << " at " << sed.MidPoint() << " t=" << sed.Time()
+        << " PDGID=" << sed.PdgCode() << " ID=" << sed.TrackID();
 
       // David Caratelli: much of the code below is taken from the module:
       // https://cdcvs.fnal.gov/redmine/projects/larsim/repository/revisions/develop/entry/larsim/ElectronDrift/SimDriftElectrons_module.cc
@@ -225,12 +230,17 @@ namespace sim {
           // This particle energy deposition is never recorded so far. Create a new Edep
           __GetEdepArray__(real_track_id)
             .emplace_back(pos, pid, pindex.size(), sed.Energy(), charge, channel_id);
+          log << "\n  plane #" << channel_id << " => pos=" << mp << " plane " << pid
+            << " (#" << channel_id << "/" << pindex.size() << ")"
+            " Q=" << charge << " E=" << sed.Energy();
         }
         else {
           // Append charge to the relevant edep (@ hit_index)
           MCEdep& edep = __GetEdepArray__(real_track_id).at(hit_index);
           edep.deps[channel_id].charge += charge;
           edep.deps[channel_id].energy += sed.Energy();
+          log << "\n  plane #" << channel_id << " => Q=" << edep.deps[channel_id].charge
+            << " E=" << edep.deps[channel_id].energy;
         }
       } // end looping over planes
     }   // end looping over SimEnergyDeposits

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -147,10 +147,6 @@ namespace sim {
     // Loop over energy depositions
     for (sim::SimEnergyDeposit const& sed : sedArray) {
 
-      mf::LogVerbatim log{"MakeMCEdep"}; // FIXME DEBUG
-      log << "EDep=" << sed.Energy() << " Q=" << sed.NumElectrons() << " at " << sed.MidPoint()
-          << " t=" << sed.Time() << " PDGID=" << sed.PdgCode() << " ID=" << sed.TrackID();
-
       // David Caratelli: much of the code below is taken from the module:
       // https://cdcvs.fnal.gov/redmine/projects/larsim/repository/revisions/develop/entry/larsim/ElectronDrift/SimDriftElectrons_module.cc
 
@@ -202,15 +198,12 @@ namespace sim {
         if (hit_index < 0) {
           // This particle energy deposition is never recorded so far. Create a new Edep
           trackEDeps.emplace_back(pos, planeid, pindex.size(), sed.Energy(), charge, planeNumber);
-          log << "\n  plane #" << planeNumber << " => pos=" << mp << " plane " << planeid << " (#"
-              << planeNumber << "/" << pindex.size() << ") Q=" << charge << " E=" << sed.Energy();
         }
         else {
           // Append charge to the relevant edep (@ hit_index)
           MCEdep::deposit& dep = trackEDeps.at(hit_index).deps[planeNumber];
           dep.charge += charge;
           dep.energy += sed.Energy();
-          log << "\n  plane #" << planeNumber << " => Q=" << dep.charge << " E=" << dep.energy;
         }
       } // end looping over planes in TPC
     }   // end looping over SimEnergyDeposits

--- a/larsim/MCSTReco/MCRecoEdep.cxx
+++ b/larsim/MCSTReco/MCRecoEdep.cxx
@@ -8,6 +8,7 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcore/Geometry/Geometry.h"
 #include "larcore/Geometry/WireReadout.h"
 #include "larcorealg/Geometry/GeometryCore.h"
@@ -17,6 +18,7 @@
 #include "MCRecoEdep.h"
 
 #include <iostream>
+#include <numeric> // std::iota()
 #include <map>
 #include <utility>
 #include <vector>
@@ -24,16 +26,13 @@
 namespace sim {
 
   namespace details {
-    std::map<geo::PlaneID, size_t> createPlaneIndexMap()
+    geo::PlaneDataContainer<std::size_t> createPlaneIndexMap()
     {
-      auto const& wireReadoutGeom = art::ServiceHandle<geo::WireReadout const>()->Get();
-      std::map<geo::PlaneID, size_t> m;
-      size_t i = 0;
-      for (auto const& pid : wireReadoutGeom.Iterate<geo::PlaneID>()) {
-        m[pid] = i;
-        i++;
-      }
-      return m;
+      geo::WireReadoutGeom const& wireReadout = art::ServiceHandle<geo::WireReadout const>()->Get();
+      geo::GeometryCore const& geom = *lar::providerFrom<geo::Geometry>();
+      geo::PlaneDataContainer<std::size_t> planeIndices{ geom.Ncryostats(), geom.MaxTPCs(), wireReadout.MaxPlanes() };
+      std::iota(planeIndices.begin(), planeIndices.end(), 0);
+      return planeIndices;
     }
   }
 
@@ -137,19 +136,16 @@ namespace sim {
     // Key map to identify a unique particle energy deposition point
     std::map<std::pair<UniquePosition, unsigned int>, int> hit_index_m;
 
-    auto pindex = details::createPlaneIndexMap();
+    geo::PlaneDataContainer<std::size_t> const pindex = details::createPlaneIndexMap();
 
     if (_debug_mode)
       std::cout << "Processing " << sedArray.size() << " energy deposits..." << std::endl;
     
     geo::TPCGeo const* TPC = nullptr; // the TPC where the last deposit was seen
     
-    // Loop over channels
-    for (size_t i = 0; i < sedArray.size(); ++i) {
+    // Loop over energy depositions
+    for (sim::SimEnergyDeposit const& sed: sedArray) {
 
-      // Get data to loop over
-      auto const& sed = sedArray[i];
-      
       mf::LogVerbatim log{ "MakeMCEdep" }; // FIXME DEBUG
       log << "EDep=" << sed.Energy() << " Q=" << sed.NumElectrons()
         << " at " << sed.MidPoint() << " t=" << sed.Time()
@@ -158,27 +154,23 @@ namespace sim {
       // David Caratelli: much of the code below is taken from the module:
       // https://cdcvs.fnal.gov/redmine/projects/larsim/repository/revisions/develop/entry/larsim/ElectronDrift/SimDriftElectrons_module.cc
 
-      // given this SimEnergyDeposit, find the TPC channel information "xyz" is the
-      // position of the energy deposit in world coordinates. Note that the units of
-      // distance in sim::SimEnergyDeposit are supposed to be cm.
       auto const mp = sed.MidPoint();
       // From the position in world coordinates, determine the cryostat and tpc. If
       // somehow the step is outside a tpc (e.g., cosmic rays in rock) just move on to the
       // next one.
-      
+      // Try first with the TPC from the previous point, if any; if it fails, go hunting
       if (!TPC || !TPC->ContainsPosition(mp)) TPC = geom->PositionToTPCptr(mp);
       if (!TPC) {
-        mf::LogWarning("SimDriftElectrons") << "step at " << mp << " is not within any TPC.";
+        // mf::LogWarning("SimDriftElectrons") << "step at " << mp << " is not within any TPC.";
+        // ... e.g. in the cathode
         continue;
       }
-      
-      // Define charge drift direction: driftcoordinate (x, y or z) and driftsign
-      // (positive or negative). Also define coordinates perpendicular to drift direction.
 
       // make a collection of electrons for each plane
       for (geo::PlaneGeo const& plane: wireReadoutGeom.Iterate<geo::PlaneGeo>(TPC->ID())) {
 
-        // require containment on the plane
+        // require containment on the plane;
+        // it may fail also if the TPC volume is bigger than the active one
         if (!plane.isProjectionOnPlane(mp)) {
           geo::PlaneGeo::WidthDepthProjection_t const deltaProj
             = plane.DeltaFromPlane(plane.PointWidthDepthProjection(mp));
@@ -187,48 +179,48 @@ namespace sim {
           continue;
         }
         geo::PlaneID const planeid = plane.ID();
+
+        // for each track ID, we keep a list of "hits" (depositions at the exact same location);
+        // each hit tracks the energy and charge per plane (via a plane index);
+        // note which wire/channel senses the charge does not make any difference
+        // and all the planes in the TPC get the same charge contributions (barred geometric acceptance).
+        // So: __GetEdepArray__[trackID][hitIndex].deps[planeIndex].energy/charge
+        int const track_id = std::abs(sed.TrackID());
+        UniquePosition const pos{mp};
+        std::vector<sim::MCEdep>& trackEDeps = __GetEdepArray__(track_id);
+        std::pair const key{pos, track_id};
         
-        // grab the nearest wire
-        int track_id = sed.TrackID();
-
-        if (track_id < 0) track_id = track_id * (-1);
-        unsigned int real_track_id = track_id;
-
-        UniquePosition pos(mp.X(), mp.Y(), mp.Z());
-
+        // find the index of the hit the energy belongs to (possibly a new one):
         int hit_index = -1;
-        auto key = std::make_pair(pos, real_track_id);
-        auto hit_index_track_iter = hit_index_m.find(key);
+        auto const hit_index_track_iter = hit_index_m.find(key);
         if (hit_index_track_iter == hit_index_m.end()) {
-          int new_hit_index = __GetEdepArray__(real_track_id).size();
-          hit_index_m[key] = new_hit_index;
+          hit_index_m[key] = trackEDeps.size();
         }
         else {
-          hit_index = (*hit_index_track_iter).second;
+          hit_index = hit_index_track_iter->second;
         }
-        auto const planeNumber = pindex[planeid];
-        double charge = sed.NumElectrons();
+        size_t const planeNumber = pindex[planeid];
+        double const charge = sed.NumElectrons();
         if (hit_index < 0) {
           // This particle energy deposition is never recorded so far. Create a new Edep
-          __GetEdepArray__(real_track_id)
-            .emplace_back(pos, planeid, pindex.size(), sed.Energy(), charge, planeNumber);
+          trackEDeps.emplace_back(pos, planeid, pindex.size(), sed.Energy(), charge, planeNumber);
           log << "\n  plane #" << planeNumber << " => pos=" << mp << " plane " << planeid
             << " (#" << planeNumber << "/" << pindex.size() << ")"
             " Q=" << charge << " E=" << sed.Energy();
         }
         else {
           // Append charge to the relevant edep (@ hit_index)
-          MCEdep& edep = __GetEdepArray__(real_track_id).at(hit_index);
-          edep.deps[planeNumber].charge += charge;
-          edep.deps[planeNumber].energy += sed.Energy();
-          log << "\n  plane #" << planeNumber << " => Q=" << edep.deps[planeNumber].charge
-            << " E=" << edep.deps[planeNumber].energy;
+          MCEdep::deposit& dep = trackEDeps.at(hit_index).deps[planeNumber];
+          dep.charge += charge;
+          dep.energy += sed.Energy();
+          log << "\n  plane #" << planeNumber << " => Q=" << dep.charge
+            << " E=" << dep.energy;
         }
-      } // end looping over planes
+      } // end looping over planes in TPC
     }   // end looping over SimEnergyDeposits
 
     if (_debug_mode) {
-      std::cout << Form("  Collected %zu particles' energy depositions...", _mc_edeps.size())
+      std::cout << "  Collected " << _mc_edeps.size() << " particles' energy depositions..."
                 << std::endl;
     }
   }

--- a/larsim/MCSTReco/MCRecoEdep.h
+++ b/larsim/MCSTReco/MCRecoEdep.h
@@ -2,11 +2,11 @@
 #define MCRECOEDEP_H
 
 // LArSoft
+#include "larcorealg/Geometry/GeometryDataContainers.h" // geo::PlaneDataContainer
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 #include "lardataobj/Simulation/SimChannel.h"
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimEnergyDepositLite.h"
-#include "larcorealg/Geometry/GeometryDataContainers.h" // geo::PlaneDataContainer
 
 // Framework includes
 namespace fhicl {
@@ -47,11 +47,11 @@ namespace sim {
     }
   };
 
-  struct UniquePosition: geo::Point_t {
+  struct UniquePosition : geo::Point_t {
 
     using geo::Point_t::Point_t;
-    UniquePosition(geo::Point_t const& p): geo::Point_t{ p } {}
-    
+    UniquePosition(geo::Point_t const& p) : geo::Point_t{p} {}
+
     inline bool operator<(const UniquePosition& rhs) const
     {
       if (X() < rhs.X()) return true;
@@ -76,7 +76,12 @@ namespace sim {
 
     MCEdep() = default;
 
-    MCEdep(sim::UniquePosition p, geo::PlaneID const& pi, size_t num_planes, float e, float c, size_t id)
+    MCEdep(sim::UniquePosition p,
+           geo::PlaneID const& pi,
+           size_t num_planes,
+           float e,
+           float c,
+           size_t id)
       : pos(p), pid(pi), deps(num_planes)
     {
       assert(id < num_planes);

--- a/larsim/MCSTReco/MCRecoEdep.h
+++ b/larsim/MCSTReco/MCRecoEdep.h
@@ -76,6 +76,7 @@ namespace sim {
 
     MCEdep() = default;
 
+    /// @todo Document the protocol for using this object and the (unprotected) `deps` in particular
     MCEdep(sim::UniquePosition p,
            geo::PlaneID const& pi,
            size_t num_planes,
@@ -84,7 +85,7 @@ namespace sim {
            size_t id)
       : pos(p), pid(pi), deps(num_planes)
     {
-      assert(id < num_planes);
+      assert(id < num_planes); // prerequisite
       deps[id].energy = e;
       deps[id].charge = c;
     }

--- a/larsim/MCSTReco/MCRecoEdep.h
+++ b/larsim/MCSTReco/MCRecoEdep.h
@@ -66,8 +66,8 @@ namespace sim {
 
   struct MCEdep {
     struct deposit {
-      float energy;
-      float charge;
+      float energy = 0.0;
+      float charge = 0.0;
     };
 
     sim::UniquePosition pos;

--- a/larsim/MCSTReco/MCRecoPart.cxx
+++ b/larsim/MCSTReco/MCRecoPart.cxx
@@ -17,11 +17,11 @@ namespace sim {
 
   //--------------------------------------------------------------------------------------------
   MCRecoPart::MCRecoPart(fhicl::ParameterSet const& pset)
-    : _x_max{std::numeric_limits<double>::min()}
+    : _x_max{std::numeric_limits<double>::lowest()}
     , _x_min{std::numeric_limits<double>::max()}
-    , _y_max{std::numeric_limits<double>::min()}
+    , _y_max{std::numeric_limits<double>::lowest()}
     , _y_min{std::numeric_limits<double>::max()}
-    , _z_max{std::numeric_limits<double>::min()}
+    , _z_max{std::numeric_limits<double>::lowest()}
     , _z_min{std::numeric_limits<double>::max()}
     , _trackIDOffsets{pset.get<std::vector<unsigned int>>("TrackIDOffsets", {0})}
   {

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -203,15 +203,15 @@ namespace sim {
         double min_dist = sim::kINVALID_DOUBLE;
         for (auto const& edep : daughter_edep) {
 
-          double dist = sqrt(pow(edep.pos._x - daughter_part._start_vtx[0], 2) +
-                             pow(edep.pos._y - daughter_part._start_vtx[1], 2) +
-                             pow(edep.pos._z - daughter_part._start_vtx[2], 2));
+          double dist = sqrt(pow(edep.pos.X() - daughter_part._start_vtx[0], 2) +
+                             pow(edep.pos.Y() - daughter_part._start_vtx[1], 2) +
+                             pow(edep.pos.Z() - daughter_part._start_vtx[2], 2));
 
           if (dist < min_dist) {
             min_dist = dist;
-            mcs_daughter_vtx[0] = edep.pos._x;
-            mcs_daughter_vtx[1] = edep.pos._y;
-            mcs_daughter_vtx[2] = edep.pos._z;
+            mcs_daughter_vtx[0] = edep.pos.X();
+            mcs_daughter_vtx[1] = edep.pos.Y();
+            mcs_daughter_vtx[2] = edep.pos.Z();
             mcs_daughter_vtx[3] = (dist / 100. / 2.998e8) * 1.e9 + daughter_part._start_vtx[3];
           }
         }
@@ -236,9 +236,9 @@ namespace sim {
 
             for (auto const& edep : daughter_edep) {
               std::vector<double> shower_dep_dir(3, 0);
-              shower_dep_dir[0] = edep.pos._x - mcshower[mcs_index].Start().X();
-              shower_dep_dir[1] = edep.pos._y - mcshower[mcs_index].Start().Y();
-              shower_dep_dir[2] = edep.pos._z - mcshower[mcs_index].Start().Z();
+              shower_dep_dir[0] = edep.pos.X() - mcshower[mcs_index].Start().X();
+              shower_dep_dir[1] = edep.pos.Y() - mcshower[mcs_index].Start().Y();
+              shower_dep_dir[2] = edep.pos.Z() - mcshower[mcs_index].Start().Z();
 
               double dist = sqrt(pow(shower_dep_dir[0], 2) + pow(shower_dep_dir[1], 2) +
                                  pow(shower_dep_dir[2], 2));
@@ -253,9 +253,9 @@ namespace sim {
               if (dist < min_dist && angle < 10) {
 
                 min_dist = dist;
-                mcs_daughter_vtx[0] = edep.pos._x;
-                mcs_daughter_vtx[1] = edep.pos._y;
-                mcs_daughter_vtx[2] = edep.pos._z;
+                mcs_daughter_vtx[0] = edep.pos.X();
+                mcs_daughter_vtx[1] = edep.pos.Y();
+                mcs_daughter_vtx[2] = edep.pos.Z();
                 mcs_daughter_vtx[3] =
                   (dist / 100. / 2.998e8) * 1.e9 + mcshower[mcs_index].Start().T();
               }
@@ -286,9 +286,9 @@ namespace sim {
         for (auto const& edep : daughter_edep) {
 
           // Compute unit vector to this energy deposition
-          mom[0] = edep.pos._x - mcs_daughter_vtx[0];
-          mom[1] = edep.pos._y - mcs_daughter_vtx[1];
-          mom[2] = edep.pos._z - mcs_daughter_vtx[2];
+          mom[0] = edep.pos.X() - mcs_daughter_vtx[0];
+          mom[1] = edep.pos.Y() - mcs_daughter_vtx[1];
+          mom[2] = edep.pos.Z() - mcs_daughter_vtx[2];
 
           // Weight by energy (momentum)
           double magnitude = sqrt(pow(mom.at(0), 2) + pow(mom.at(1), 2) + pow(mom.at(2), 2));
@@ -311,9 +311,9 @@ namespace sim {
           //Determine the direction of the shower right at the start point
           double E = 0;
           double N = 0;
-          if (sqrt(pow(edep.pos._x - mcs_daughter_vtx[0], 2) +
-                   pow(edep.pos._y - mcs_daughter_vtx[1], 2) +
-                   pow(edep.pos._z - mcs_daughter_vtx[2], 2)) < 2.4 &&
+          if (sqrt(pow(edep.pos.X() - mcs_daughter_vtx[0], 2) +
+                   pow(edep.pos.Y() - mcs_daughter_vtx[1], 2) +
+                   pow(edep.pos.Z() - mcs_daughter_vtx[2], 2)) < 2.4 &&
               magnitude > 1.e-10) {
 
             mcs_daughter_dir[0] += mom.at(0);
@@ -330,8 +330,7 @@ namespace sim {
 
           // Charge
           auto const pid = edep.pid;
-          auto q_i = pindex.find(pid);
-          if (q_i != pindex.end())
+          if (pindex.hasPlane(pid))
             plane_charge[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
 
         } ///Looping through the MCShower daughter's energy depositions
@@ -378,10 +377,10 @@ namespace sim {
             continue;
           }
           //Radial Distance
-          if ((a * edep.pos._x + b * edep.pos._y + c * edep.pos._z + d) /
+          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
                   sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) <
                 2.4 &&
-              (a * edep.pos._x + b * edep.pos._y + c * edep.pos._z + d) /
+              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
                   sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) >
                 0) {
 
@@ -402,8 +401,7 @@ namespace sim {
 
             // Charge
             auto const pid = edep.pid;
-            auto q_i = pindex.find(pid);
-            if (q_i != pindex.end())
+            if (pindex.hasPlane(pid))
               plane_dqdx[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
           }
         }

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -241,7 +241,9 @@ namespace sim {
               shower_dep_dir[1] = edep.pos.Y() - mcshower[mcs_index].Start().Y();
               shower_dep_dir[2] = edep.pos.Z() - mcshower[mcs_index].Start().Z();
 
-              double dist = std::hypot(shower_dep_dir[0], shower_dep_dir[1], shower_dep_dir[2]);
+              double const dist =
+                std::hypot(shower_dep_dir[0], shower_dep_dir[1], shower_dep_dir[2]);
+              if (dist == 0) continue; // it would yield nonsense anyway
               for (auto& v : shower_dep_dir)
                 v /= dist;
 
@@ -291,7 +293,6 @@ namespace sim {
           mom[2] = edep.pos.Z() - mcs_daughter_vtx[2];
 
           // Weight by energy (momentum)
-          // double magnitude = sqrt(pow(mom.at(0), 2) + pow(mom.at(1), 2) + pow(mom.at(2), 2));
           double magnitude = std::hypot(mom[0], mom[1], mom[2]);
 
           double energy = 0;
@@ -365,8 +366,6 @@ namespace sim {
           // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
           // D = (a*x_1 + b*y_1 + c*z_1 + d )/hypot(a,b,c)
 
-          // double p_mag = sqrt(pow(mcs_daughter_dir[0], 2) + pow(mcs_daughter_dir[1], 2) +
-          //                     pow(mcs_daughter_dir[2], 2));
           double p_mag = std::hypot(mcs_daughter_dir[0], mcs_daughter_dir[1], mcs_daughter_dir[2]);
           double a = 0, b = 0, c = 0, d = 0;
           if (p_mag > 1.e-10) {
@@ -380,10 +379,9 @@ namespace sim {
             continue;
           }
           //Radial Distance
-          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) <
-                2.4 &&
-              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) >
-                0) {
+          double const radialDistance =
+            (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c);
+          if (radialDistance < 2.4 && radialDistance > 0) {
 
             double E = 0;
             double N = 0;

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -379,6 +379,7 @@ namespace sim {
             continue;
           }
           //Radial Distance
+          assert(std::hypot(a, b, c) > 0.0); // guaranteed by p_mag > 0
           double const radialDistance =
             (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c);
           if (radialDistance < 2.4 && radialDistance > 0) {

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -28,6 +28,7 @@
 
 #include <memory>
 #include <vector>
+#include <cmath> // std::hypot()
 
 namespace sim {
 
@@ -203,9 +204,9 @@ namespace sim {
         double min_dist = sim::kINVALID_DOUBLE;
         for (auto const& edep : daughter_edep) {
 
-          double dist = sqrt(pow(edep.pos.X() - daughter_part._start_vtx[0], 2) +
-                             pow(edep.pos.Y() - daughter_part._start_vtx[1], 2) +
-                             pow(edep.pos.Z() - daughter_part._start_vtx[2], 2));
+          double dist = std::hypot(edep.pos.X() - daughter_part._start_vtx[0],
+                                   edep.pos.Y() - daughter_part._start_vtx[1],
+                                   edep.pos.Z() - daughter_part._start_vtx[2]);
 
           if (dist < min_dist) {
             min_dist = dist;
@@ -223,7 +224,7 @@ namespace sim {
           shower_dir[2] = mcshower[mcs_index].Start().Pz();
           double magnitude = 0;
           for (size_t i = 0; i < 3; ++i)
-            magnitude += pow(shower_dir[i], 2);
+            magnitude += shower_dir[i] * shower_dir[i];
 
           magnitude = sqrt(magnitude);
 
@@ -240,8 +241,7 @@ namespace sim {
               shower_dep_dir[1] = edep.pos.Y() - mcshower[mcs_index].Start().Y();
               shower_dep_dir[2] = edep.pos.Z() - mcshower[mcs_index].Start().Z();
 
-              double dist = sqrt(pow(shower_dep_dir[0], 2) + pow(shower_dep_dir[1], 2) +
-                                 pow(shower_dep_dir[2], 2));
+              double dist = std::hypot(shower_dep_dir[0], shower_dep_dir[1], shower_dep_dir[2]);
               for (auto& v : shower_dep_dir)
                 v /= dist;
 
@@ -291,7 +291,8 @@ namespace sim {
           mom[2] = edep.pos.Z() - mcs_daughter_vtx[2];
 
           // Weight by energy (momentum)
-          double magnitude = sqrt(pow(mom.at(0), 2) + pow(mom.at(1), 2) + pow(mom.at(2), 2));
+          // double magnitude = sqrt(pow(mom.at(0), 2) + pow(mom.at(1), 2) + pow(mom.at(2), 2));
+          double magnitude = std::hypot(mom[0], mom[1], mom[2]);
 
           double energy = 0;
           double npid = 0;
@@ -308,12 +309,13 @@ namespace sim {
             mcs_daughter_mom[1] += mom.at(1);
             mcs_daughter_mom[2] += mom.at(2);
           }
+          
           //Determine the direction of the shower right at the start point
           double E = 0;
           double N = 0;
-          if (sqrt(pow(edep.pos.X() - mcs_daughter_vtx[0], 2) +
-                   pow(edep.pos.Y() - mcs_daughter_vtx[1], 2) +
-                   pow(edep.pos.Z() - mcs_daughter_vtx[2], 2)) < 2.4 &&
+          if (std::hypot(edep.pos.X() - mcs_daughter_vtx[0],
+                         edep.pos.Y() - mcs_daughter_vtx[1],
+                         edep.pos.Z() - mcs_daughter_vtx[2]) < 2.4 &&
               magnitude > 1.e-10) {
 
             mcs_daughter_dir[0] += mom.at(0);
@@ -361,10 +363,11 @@ namespace sim {
           // a*x + b*y + c*z + d = 0
           // where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
           // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
-          // D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
+          // D = (a*x_1 + b*y_1 + c*z_1 + d )/hypot(a,b,c)
 
-          double p_mag = sqrt(pow(mcs_daughter_dir[0], 2) + pow(mcs_daughter_dir[1], 2) +
-                              pow(mcs_daughter_dir[2], 2));
+          // double p_mag = sqrt(pow(mcs_daughter_dir[0], 2) + pow(mcs_daughter_dir[1], 2) +
+          //                     pow(mcs_daughter_dir[2], 2));
+          double p_mag = std::hypot(mcs_daughter_dir[0], mcs_daughter_dir[1], mcs_daughter_dir[2]);
           double a = 0, b = 0, c = 0, d = 0;
           if (p_mag > 1.e-10) {
             a = mcs_daughter_dir[0] / p_mag;
@@ -378,10 +381,10 @@ namespace sim {
           }
           //Radial Distance
           if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) <
+                  std::hypot(a, b, c) <
                 2.4 &&
               (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) >
+                  std::hypot(a, b, c) >
                 0) {
 
             double E = 0;
@@ -427,8 +430,7 @@ namespace sim {
       auto& plane_charge = plane_charge_v[mcs_index];
       auto& plane_dqdx = plane_dqdx_v[mcs_index];
 
-      double magnitude =
-        sqrt(pow(daughter_mom[0], 2) + pow(daughter_mom[1], 2) + pow(daughter_mom[2], 2));
+      double magnitude = daughter_mom.P();
 
       if (daughter_mom[3] > 1.e-10) {
         daughter_mom[0] *= daughter_mom[3] / magnitude;

--- a/larsim/MCSTReco/MCShowerRecoAlg.cxx
+++ b/larsim/MCSTReco/MCShowerRecoAlg.cxx
@@ -26,9 +26,9 @@
 #include "larsim/MCSTReco/MCRecoPart.h"
 #include "larsim/MCSTReco/MCShowerRecoPart.h"
 
+#include <cmath> // std::hypot()
 #include <memory>
 #include <vector>
-#include <cmath> // std::hypot()
 
 namespace sim {
 
@@ -309,7 +309,7 @@ namespace sim {
             mcs_daughter_mom[1] += mom.at(1);
             mcs_daughter_mom[2] += mom.at(2);
           }
-          
+
           //Determine the direction of the shower right at the start point
           double E = 0;
           double N = 0;
@@ -380,11 +380,9 @@ namespace sim {
             continue;
           }
           //Radial Distance
-          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  std::hypot(a, b, c) <
+          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) <
                 2.4 &&
-              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  std::hypot(a, b, c) >
+              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) >
                 0) {
 
             double E = 0;

--- a/larsim/MCSTReco/MCTrackRecoAlg.cxx
+++ b/larsim/MCSTReco/MCTrackRecoAlg.cxx
@@ -164,7 +164,7 @@ namespace sim {
         //Iterate through all the energy deposition points
         for (auto const& edep : edeps) {
           // 'x_0' definition
-          TVector3 x_0(edep.pos._x, edep.pos._y, edep.pos._z);
+          TVector3 x_0(edep.pos.X(), edep.pos.Y(), edep.pos.Z());
           // 'A' definition
           TVector3 A(step_trk.Position().X() - x_0.X(),
                      step_trk.Position().Y() - x_0.Y(),
@@ -184,10 +184,10 @@ namespace sim {
           // Add in a voxel before and after to account for MCSteps
           // the line distance allows for 1mm GEANT multiple columb scattering correction,
           // small compared to average MCStep-to-MCStep distance
-          if ((a * edep.pos._x + b * edep.pos._y + c * edep.pos._z + d) /
+          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
                   sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) <=
                 dist + 0.03 &&
-              (a * edep.pos._x + b * edep.pos._y + c * edep.pos._z + d) /
+              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
                   sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) >=
                 0 - 0.03 &&
               LineDist < 0.1) {
@@ -208,8 +208,7 @@ namespace sim {
 
             step_dedx += engy;
             auto const pid = edep.pid;
-            auto q_i = pindex.find(pid);
-            if (q_i != pindex.end())
+            if (pindex.hasPlane(pid))
               step_dqdx[pid.Plane] += (double)(edep.deps[pindex[pid]].charge);
           }
         }

--- a/larsim/MCSTReco/MCTrackRecoAlg.cxx
+++ b/larsim/MCSTReco/MCTrackRecoAlg.cxx
@@ -7,6 +7,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "MCTrackRecoAlg.h"
+#include <cmath>
 #include <iostream>
 
 #include "cetlib_except/exception.h"
@@ -122,8 +123,8 @@ namespace sim {
 
         //Find the distance between two adjacent MCSteps
         double dist =
-          sqrt(pow(step_trk.X() - nxt_step_trk.X(), 2) + pow(step_trk.Y() - nxt_step_trk.Y(), 2) +
-               pow(step_trk.Z() - nxt_step_trk.Z(), 2));
+          std::hypot(step_trk.X() - nxt_step_trk.X(), step_trk.Y() - nxt_step_trk.Y(),
+               step_trk.Z() - nxt_step_trk.Z());
 
         //Make a plane at the step pointed at the next step
 
@@ -132,7 +133,7 @@ namespace sim {
         // a*x + b*y + c*z + d = 0
         // where, a = dir_x, b = dir_y, c = dir_z, d = - (a*x_0+b*y_0+c*z_0)
         // then the *signed* distance of any point (x_1, y_1, z_1) from this plane is:
-        // D = (a*x_1 + b*y_1 + c*z_1 + d )/sqrt( pow(a,2) + pow(b,2) + pow(c,2))
+        // D = (a*x_1 + b*y_1 + c*z_1 + d )/hypot(a,b,c)
 
         double a = 0, b = 0, c = 0, d = 0;
         a = nxt_step_trk.X() - step_trk.X();
@@ -174,7 +175,7 @@ namespace sim {
           double LineDist = 0;
 
           if (B.Mag2() != 0) {
-            LineDist = sqrt(A.Mag2() - 2 * pow(A * B, 2) / B.Mag2() + pow(A * B, 2) / B.Mag2());
+            LineDist = sqrt(A.Mag2() - 2 * (A * B)*(A * B) / B.Mag2() + (A * B)*(A * B) / B.Mag2());
           }
           else {
             LineDist = 0;
@@ -185,10 +186,10 @@ namespace sim {
           // the line distance allows for 1mm GEANT multiple columb scattering correction,
           // small compared to average MCStep-to-MCStep distance
           if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) <=
+                  std::hypot(a, b, c) <=
                 dist + 0.03 &&
               (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  sqrt(pow(a, 2) + pow(b, 2) + pow(c, 2)) >=
+                  std::hypot(a, b, c) >=
                 0 - 0.03 &&
               LineDist < 0.1) {
 

--- a/larsim/MCSTReco/MCTrackRecoAlg.cxx
+++ b/larsim/MCSTReco/MCTrackRecoAlg.cxx
@@ -122,9 +122,9 @@ namespace sim {
         //Defining the track step-by-step dEdx and dQdx
 
         //Find the distance between two adjacent MCSteps
-        double dist =
-          std::hypot(step_trk.X() - nxt_step_trk.X(), step_trk.Y() - nxt_step_trk.Y(),
-               step_trk.Z() - nxt_step_trk.Z());
+        double dist = std::hypot(step_trk.X() - nxt_step_trk.X(),
+                                 step_trk.Y() - nxt_step_trk.Y(),
+                                 step_trk.Z() - nxt_step_trk.Z());
 
         //Make a plane at the step pointed at the next step
 
@@ -175,7 +175,8 @@ namespace sim {
           double LineDist = 0;
 
           if (B.Mag2() != 0) {
-            LineDist = sqrt(A.Mag2() - 2 * (A * B)*(A * B) / B.Mag2() + (A * B)*(A * B) / B.Mag2());
+            LineDist =
+              sqrt(A.Mag2() - 2 * (A * B) * (A * B) / B.Mag2() + (A * B) * (A * B) / B.Mag2());
           }
           else {
             LineDist = 0;
@@ -185,11 +186,9 @@ namespace sim {
           // Add in a voxel before and after to account for MCSteps
           // the line distance allows for 1mm GEANT multiple columb scattering correction,
           // small compared to average MCStep-to-MCStep distance
-          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  std::hypot(a, b, c) <=
+          if ((a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) <=
                 dist + 0.03 &&
-              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) /
-                  std::hypot(a, b, c) >=
+              (a * edep.pos.X() + b * edep.pos.Y() + c * edep.pos.Z() + d) / std::hypot(a, b, c) >=
                 0 - 0.03 &&
               LineDist < 0.1) {
 

--- a/larsim/MCSTReco/MCTrackRecoAlg.h
+++ b/larsim/MCSTReco/MCTrackRecoAlg.h
@@ -20,6 +20,9 @@ namespace sim {
 
 namespace sim {
 
+  /// @todo The implementation of this algorithm has several hard-coded,
+  ///       undocumented values which should be documented and stored
+  ///       into constants.
   class MCTrackRecoAlg {
 
   public:


### PR DESCRIPTION
The algorithm creating `sim::MCTrack` and `sim::MCShower` objects and data products builds upon "MC energy deposition" objects created by `MCRecoEdep` algorithm.
This algorithm was written for MicroBooNE with `sim::SimChannel` objects as input, and later extended to work also with `sim::SimEnergyDeposit` and `sim::SimEnergyDepositLite`. This extension is a separate algorithm, that was shaped after the former and not optimised.
This last implementation is the subject of this pull request.

It suffer from numerous bugs, including:
 * not checking from containment of the points on the planes when asking for the nearest wire to a deposit, which causes a flood of exceptions, typically gigabytes of log files and an according dramatic slow down;
 * because of a faulty check on the existence of a wire nearby¹, adding the same energy deposition (dE/dx) to multiple planes on different TPC;
 * potentially reporting the wrong plane when a deposit is sensed by a channel crossing different TPC;
 * another other minor bug on the determination of the detector volume (minor because the geometry of all experiment detectors using LArSoft do not trigger it).

I have fixed the bugs I have found, optimised the code a bit (nothing dramatic, percent improvement in speed), updated the comments which were outdated.
Now the code runs ×10 fast (because it does not waste its time throwing exceptions and printing messages for a query that is ultimately useless), does not force jobs to require tens of GB of disk space, and gives better results.

Did I write "better"? well, unfortunately there is not much testing on field, since I don't know effectively anybody actually using the dE/dx information I presumably fixed.
I have checked myself and was confirmed by ICARUS users that the changes do not break the algorithm. The number of reconstructed tracks and showers is almost identical, as the objects are as well, except for the dE/dx subject of the fixes.

In addition, I added output to `DumpMCParticles` module (I used it during debugging); **that change is bound to another in LArSoft/lardataalg#51, which has a twin PR**.

Note that despite fixing bugs on a quantity that no experiment seems to be using right now, this fix is still very important for the simulation workflow, because of the reduction of resources required to run the detector physics simulation ("GEANT4 stage").

--- 

**I ask for an exemption on the reformatting of `DumpMCParticle` module**: I have followed the style of the existing code, and since `format-code` reformats only the changes, it results in different styles for equivalent code. For example:
```cpp
    fhicl::Atom<std::string> OutputCategory{
      Name("OutputCategory"),
      Comment("name of the output stream (managed by the message facility)"),
      "DumpMCParticles" /* default value */
    };

    fhicl::Atom<bool> PrintStepPositions{
      Name("PrintStepPositions"),
      Comment("prints the position and time of each trajectory point"),
      true};
    fhicl::Atom<bool> PrintStepMomenta{Name("PrintStepMomenta"),
                                       Comment("prints the momentum at each trajectory point"),
                                       false};
    fhicl::Atom<bool> PrintStepEnergies{Name("PrintStepEnergies"),
                                        Comment("prints the total energy at each trajectory point"),
                                        false};

    fhicl::Atom<unsigned int> PointsPerLine{
      Name("PointsPerLine"),
      Comment("trajectory points printed per line (default: 2; 0 = skip them)"),
      2 /* default value */
    };

```
(`OutputCategory` and `PointsPerLine` show the original style).

--- 

¹ [`geo::PlaneGeo::NearewstWireID()`](https://code-doc.larsoft.org/docs/latest/html/classgeo_1_1PlaneGeo.html#a7d000aa0627101d8ec6a290068fc4406) has "undefined behaviour" (or, buggy behaviour) when used for a point not projecting on the plane.