### PR TITLE
Fix SimPhoton time rounding

### DIFF
--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -563,8 +563,7 @@ namespace phot {
                 // calculates the time at which the photon was produced
                 double dtime = edepi.StartT() + fScintTime->fastScintTime();
                 if (fIncludePropTime) dtime += transport_time[i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else
@@ -577,8 +576,7 @@ namespace phot {
               for (int i = 0; i < n; ++i) {
                 double dtime = edepi.StartT() + fScintTime->slowScintTime();
                 if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -308,8 +308,7 @@ namespace phot {
                 // calculates the time at which the photon was produced
                 double dtime = edepi.StartT() + fScintTime->fastScintTime();
                 if (fIncludePropTime) dtime += transport_time[i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else
@@ -320,8 +319,7 @@ namespace phot {
               for (int i = 0; i < ndetected_slow; ++i) {
                 double dtime = edepi.StartT() + fScintTime->slowScintTime();
                 if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else


### PR DESCRIPTION
This PR fixes the incorrect rounding of photon times when producing `SimPhotons` collections.

Both `PDFastSimPAR` and `PDFastSimPVS` modules currently round the photon times to the closest integer when preparing their `SimPhotons` collections. While the rounding is needed for the `SimPhotonsLite` approach -- time is used as index for the vector -- this should not be done when saving each individual `sim::OnePhoton` time.


 