### PR TITLE
Updates to semi-analytical light simulation: optical path tool

### DIFF
--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(LibraryMappingTools)
 add_subdirectory(ScintTimeTools)
+add_subdirectory(OpticalPathTools)
 
 cet_make_library(LIBRARY_NAME PhotonLibraryInterface INTERFACE
   SOURCE IPhotonLibrary.h

--- a/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
@@ -1,0 +1,16 @@
+cet_make_library(LIBRARY_NAME OpticalPath INTERFACE
+  SOURCE OpticalPath.h)
+
+cet_write_plugin_builder(phot::OpticalPath art::tool Modules
+  INSTALL_BUILDER)
+
+include (phot::OpticalPath)
+
+cet_build_plugin(StandardOpticalPath phot::OpticalPath
+  LIBRARIES PRIVATE
+  larcoreobj::geo_vectors
+)
+
+install_headers()
+install_fhicl()
+install_source()

--- a/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
@@ -1,0 +1,17 @@
+// Defines whether a photon detector is visible from a given scintillation emission point
+// used for the semi-analytical model fast optical simulation (PDFastSimPAR)
+
+#ifndef OpticalPath_H
+#define OpticalPath_H
+
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+namespace phot {
+    class OpticalPath {
+    public:
+        virtual ~OpticalPath() noexcept = default; 
+        virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) = 0;
+  };
+}
+
+#endif

--- a/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
@@ -7,10 +7,11 @@
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 namespace phot {
-    class OpticalPath {
-    public:
-        virtual ~OpticalPath() noexcept = default; 
-        virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) = 0;
+  class OpticalPath {
+  public:
+    virtual ~OpticalPath() noexcept = default;
+    virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint,
+                                      geo::Point_t const& OpDetPoint) = 0;
   };
 }
 

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
@@ -4,23 +4,24 @@
 #ifndef StandardOpticalPath_H
 #define StandardOpticalPath_H
 
-#include "art/Utilities/ToolMacros.h" 
-#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
+#include "art/Utilities/ToolMacros.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 #include <iostream>
 
 namespace phot {
-    class StandardOpticalPath : public phot::OpticalPath {
-    public:
-        explicit StandardOpticalPath(fhicl::ParameterSet const& ps) {};
-        ~StandardOpticalPath() noexcept override = default;
+  class StandardOpticalPath : public phot::OpticalPath {
+  public:
+    explicit StandardOpticalPath(fhicl::ParameterSet const& ps){};
+    ~StandardOpticalPath() noexcept override = default;
 
-        const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) override { 
-            std::cout << "In StandardOpticalPath::isOpDetVisible" << std::endl;
-            return true; 
-        }
-    };
+    const bool isOpDetVisible(geo::Point_t const& ScintPoint,
+                              geo::Point_t const& OpDetPoint) override
+    {
+      return true;
+    }
+  };
 }
 
 #endif

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
@@ -1,0 +1,26 @@
+// default optical path tool
+// all photon detectors are visible from all scintillation emission points
+
+#ifndef StandardOpticalPath_H
+#define StandardOpticalPath_H
+
+#include "art/Utilities/ToolMacros.h" 
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+#include <iostream>
+
+namespace phot {
+    class StandardOpticalPath : public phot::OpticalPath {
+    public:
+        explicit StandardOpticalPath(fhicl::ParameterSet const& ps) {};
+        ~StandardOpticalPath() noexcept override = default;
+
+        const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) override { 
+            std::cout << "In StandardOpticalPath::isOpDetVisible" << std::endl;
+            return true; 
+        }
+    };
+}
+
+#endif

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
@@ -1,0 +1,5 @@
+
+#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
+#include "art/Utilities/ToolMacros.h"
+
+DEFINE_ART_CLASS_TOOL(phot::StandardOpticalPath)

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
@@ -1,5 +1,5 @@
 
-#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
 #include "art/Utilities/ToolMacros.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
 
 DEFINE_ART_CLASS_TOOL(phot::StandardOpticalPath)

--- a/larsim/PhotonPropagation/OpticalPathTools/opticalpath_tool.fcl
+++ b/larsim/PhotonPropagation/OpticalPathTools/opticalpath_tool.fcl
@@ -1,0 +1,10 @@
+// standard optical path tool
+
+BEGIN_PROLOG
+
+StandardOpticalPath:
+{
+    tool_type: StandardOpticalPath
+}
+
+END_PROLOG

--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -1,5 +1,6 @@
 #include "opticalsimparameterisations.fcl"
 #include "scintillationtime_tool.fcl"
+#include "opticalpath_tool.fcl"
 
 BEGIN_PROLOG
 
@@ -18,6 +19,7 @@ standard_pdfastsim_par_ar:
   OnlyActiveVolume:     true
   OnlyOneCryostat:       false
   ScintTimeTool:         @local::ScintTimeLAr
+  OpticalPathTool:       @local::StandardOpticalPath
   UseXeAbsorption:       false
 
   VUVTiming: @local::common_vuv_timing_parameterization

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -155,7 +155,6 @@ namespace phot {
       double edeposit,
       int num_photons = 1);
 
-    bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
     std::vector<geo::Point_t> opDetCenters() const; 
 
     // semi-analytical model
@@ -458,9 +457,8 @@ namespace phot {
       for (size_t Reflected = 0; Reflected <= DoReflected; ++Reflected) {
         for (size_t channel = 0; channel < fNOpChannels; channel++) {
 
-          if (!fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
-          // fOpaqueCathode && is this needed? obsolete? 
-
+          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
+          
           int ndetected_fast = DetectedNumFast[channel];
           int ndetected_slow = DetectedNumSlow[channel];
           if (Reflected) {
@@ -695,33 +693,6 @@ namespace phot {
   }
 
   //......................................................................
-  // checks whether photo-detector is able to see the emitted light scintillation
-  bool PDFastSimPAR::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
-                                      geo::Point_t const& OpDetPoint) const
-  {
-    // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service
-    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-
-    std::cout << "In PDFastSimPAR::isOpDetInSameTPC" << std::endl;
-
-    // special case for SBND = 2 TPCs
-    // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10.) {
-      return false;
-    }
-
-    // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance
-    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
-      return false;
-    }
-    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
-
-    return true;
-  }
-
   std::vector<geo::Point_t> PDFastSimPAR::opDetCenters() const
   {
     std::vector<geo::Point_t> opDetCenter;

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -38,10 +38,10 @@
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "larsim/IonizationScintillation/ISTPC.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 #include "larsim/PhotonPropagation/PropagationTimeModel.h"
 #include "larsim/PhotonPropagation/ScintTimeTools/ScintTime.h"
 #include "larsim/PhotonPropagation/SemiAnalyticalModel.h"
-#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 #include "nurandom/RandomUtils/NuRandomService.h"
 
@@ -118,7 +118,8 @@ namespace phot {
                        Comment("Tool describing scintillation time structure")};
       DP OpticalPathTool{
         Name("OpticalPathTool"),
-        Comment("Tool to determine visibility of optical detectors from scintillation emission points")};
+        Comment(
+          "Tool to determine visibility of optical detectors from scintillation emission points")};
       fhicl::Atom<bool> UseXeAbsorption{
         Name("UseXeAbsorption"),
         Comment("Use Xe absorption length instead of Ar, default false"),
@@ -155,7 +156,7 @@ namespace phot {
       double edeposit,
       int num_photons = 1);
 
-    std::vector<geo::Point_t> opDetCenters() const; 
+    std::vector<geo::Point_t> opDetCenters() const;
 
     // semi-analytical model
     std::unique_ptr<SemiAnalyticalModel> fVisibilityModel;
@@ -213,7 +214,8 @@ namespace phot {
         config.get_PSet(),
         "SeedScintTime"))
     , fScintTime{art::make_tool<phot::ScintTime>(config().ScintTimeTool.get<fhicl::ParameterSet>())}
-    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(std::move(art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>())))}
+    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(std::move(
+        art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>())))}
     , fGeom(*(lar::providerFrom<geo::Geometry>()))
     , fISTPC{fGeom}
     , fNOpChannels(fGeom.NOpDets())
@@ -283,8 +285,12 @@ namespace phot {
     fScintTime->initRand(fScintTimeEngine);
 
     // photo-detector visibility model (semi-analytical model)
-    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(
-      VUVHitsParams, VISHitsParams, fOpticalPath, fDoReflectedLight, fIncludeAnodeReflections, fUseXeAbsorption);
+    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(VUVHitsParams,
+                                                             VISHitsParams,
+                                                             fOpticalPath,
+                                                             fDoReflectedLight,
+                                                             fIncludeAnodeReflections,
+                                                             fUseXeAbsorption);
 
     // propagation time model
     if (fIncludePropTime)
@@ -457,8 +463,9 @@ namespace phot {
       for (size_t Reflected = 0; Reflected <= DoReflected; ++Reflected) {
         for (size_t channel = 0; channel < fNOpChannels; channel++) {
 
-          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
-          
+          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel]))
+            continue;
+
           int ndetected_fast = DetectedNumFast[channel];
           int ndetected_slow = DetectedNumSlow[channel];
           if (Reflected) {

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -71,6 +71,7 @@ namespace phot {
     const bool fDoFastComponent;
     const bool fDoSlowComponent;
     const bool fIncludePropTime;
+    const bool fGeoPropTimeOnly;
     const bool fUseLitePhotons;
     const bool fStoreReflected;
     const size_t fNOpChannels;
@@ -89,6 +90,7 @@ namespace phot {
     , fDoFastComponent(pset.get<bool>("DoFastComponent", true))
     , fDoSlowComponent(pset.get<bool>("DoSlowComponent", true))
     , fIncludePropTime(pset.get<bool>("IncludePropTime", false))
+    , fGeoPropTimeOnly(pset.get<bool>("GeoPropTimeOnly", false))
     , fUseLitePhotons(art::ServiceHandle<sim::LArG4Parameters const>()->UseLitePhotons())
     , fStoreReflected(fPVS->StoreReflected())
     , fNOpChannels(fPVS->NOpChannels())
@@ -130,7 +132,7 @@ namespace phot {
     // propagation time model
     if (fIncludePropTime)
       fPropTimeModel = std::make_unique<PropagationTimeModel>(
-        VUVTimingParams, VISTimingParams, fScintTimeEngine, fStoreReflected);
+        VUVTimingParams, VISTimingParams, fScintTimeEngine, fStoreReflected, fGeoPropTimeOnly);
 
     if (fUseLitePhotons) {
       mf::LogInfo("PDFastSimPVS") << "Use Lite Photon." << std::endl;

--- a/larsim/PhotonPropagation/PropagationTimeModel.cxx
+++ b/larsim/PhotonPropagation/PropagationTimeModel.cxx
@@ -158,7 +158,11 @@ namespace phot {
     }
     else {
       // determine nearest parameterisation in discretisation
-      int index = std::round((distance - fmin_d) / fstep_size);
+      size_t index = std::round((distance - fmin_d) / fstep_size);
+      // check index is within range, otherwise use furthest parameterisation
+      if (index >= number_of_vuv_timing_params) {
+        index = number_of_vuv_timing_params - 1;
+      }
       // randomly sample parameterisation for each photon
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
         arrivalTimes[i] = fVUVTimingGen[angle_bin][index].fire() *
@@ -198,6 +202,7 @@ namespace phot {
     fVUVTimingGen = std::vector(num_angles, std::vector(num_params, CLHEP::RandGeneral(dummy, 1)));
     fVUV_max = std::vector(num_angles, std::vector(num_params, 0.0));
     fVUV_min = std::vector(num_angles, std::vector(num_params, 0.0));
+    number_of_vuv_timing_params = num_params;
 
     std::vector<std::vector<double>> parameters[7];
     parameters[0] = std::vector(1, VUVTimingParams.get<std::vector<double>>("Distances_landau"));
@@ -355,7 +360,9 @@ namespace phot {
     if (VUVdist < fmin_d) { vuv_time = VUVdist / fvuv_vgroup_max; }
     else {
       // find index of required parameterisation
-      const size_t index = std::round((VUVdist - fmin_d) / fstep_size);
+      size_t index = std::round((VUVdist - fmin_d) / fstep_size);
+      // check index is within range, otherwise use furthest parameterisation
+      if (index >= number_of_vuv_timing_params) index = number_of_vuv_timing_params - 1;
       // find shortest time
       vuv_time = fVUV_min[angle_bin_vuv][index];
     }

--- a/larsim/PhotonPropagation/PropagationTimeModel.cxx
+++ b/larsim/PhotonPropagation/PropagationTimeModel.cxx
@@ -160,9 +160,7 @@ namespace phot {
       // determine nearest parameterisation in discretisation
       size_t index = std::round((distance - fmin_d) / fstep_size);
       // check index is within range, otherwise use furthest parameterisation
-      if (index >= number_of_vuv_timing_params) {
-        index = number_of_vuv_timing_params - 1;
-      }
+      if (index >= number_of_vuv_timing_params) { index = number_of_vuv_timing_params - 1; }
       // randomly sample parameterisation for each photon
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
         arrivalTimes[i] = fVUVTimingGen[angle_bin][index].fire() *

--- a/larsim/PhotonPropagation/PropagationTimeModel.h
+++ b/larsim/PhotonPropagation/PropagationTimeModel.h
@@ -90,6 +90,7 @@ namespace phot {
     double fstep_size, fvuv_vgroup_mean, fvuv_vgroup_max, fmin_d, finflexion_point_distance,
       fangle_bin_timing_vuv;
     // vector containing generated VUV timing parameterisations
+    unsigned int number_of_vuv_timing_params;
     std::vector<std::vector<CLHEP::RandGeneral>> fVUVTimingGen;
     // vector containing min and max range VUV timing parameterisations are
     // sampled to

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -30,7 +30,7 @@ namespace phot {
   // constructor
   SemiAnalyticalModel::SemiAnalyticalModel(const fhicl::ParameterSet& VUVHitsParams,
                                            const fhicl::ParameterSet& VISHitsParams,
-                                           const std::shared_ptr<OpticalPath> &OpticalPath,
+                                           const std::shared_ptr<OpticalPath>& OpticalPath,
                                            const bool doReflectedLight,
                                            const bool includeAnodeReflections,
                                            const bool useXeAbsorption)
@@ -264,9 +264,7 @@ namespace phot {
     // radial distance from centre of detector (Y-Z standard / X-Z laterals)
     // special case: VerticalBorderCorrectionMode use Y direction only
     double r = 0;
-    if (fVerticalBorderCorrectionMode) {
-      r = std::abs(ScintPoint.Y() - fcathode_centre[1]);
-    }    
+    if (fVerticalBorderCorrectionMode) { r = std::abs(ScintPoint.Y() - fcathode_centre[1]); }
     else {
       if (opDet.orientation == 2)
         r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -764,34 +764,6 @@ namespace phot {
   }
 
   //......................................................................
-  // checks photo-detector is in same TPC/argon volume as scintillation
-  bool SemiAnalyticalModel::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
-                                             geo::Point_t const& OpDetPoint) const
-  {
-    // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service
-    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-
-    std::cout << "In SemiAnalyticalModel::isOpDetInSameTPC" << std::endl;
-    
-    // special case for SBND = 2 TPCs
-    // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10.) {
-      return false;
-    }
-
-    // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance
-    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
-      return false;
-    }
-
-    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
-
-    return true;
-  }
-
   std::vector<SemiAnalyticalModel::OpticalDetector> SemiAnalyticalModel::opticalDetectors() const
   {
     std::vector<SemiAnalyticalModel::OpticalDetector> opticalDetector;

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -68,6 +68,7 @@ namespace phot {
     fMaxPDDistance = VUVHitsParams.get<double>(
       "MaxPDDistance",
       1000); // max distance between scintillation and PD to evaluate light, default 10m
+    fVerticalBorderCorrectionMode = VUVHitsParams.get<bool>("VerticalBorderCorrectionMode", false);
 
     if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
       throw cet::exception("SemiAnalyticalModel")
@@ -261,13 +262,19 @@ namespace phot {
 
     // determine GH parameters, accounting for border effects
     // radial distance from centre of detector (Y-Z standard / X-Z laterals)
+    // special case: VerticalBorderCorrectionMode use Y direction only
     double r = 0;
-    if (opDet.orientation == 2)
-      r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);
-    else if (opDet.orientation == 1)
-      r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Z() - fcathode_centre[2]);
-    else
-      r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    if (fVerticalBorderCorrectionMode) {
+      r = std::abs(ScintPoint.Y() - fcathode_centre[1]);
+    }    
+    else {
+      if (opDet.orientation == 2)
+        r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);
+      else if (opDet.orientation == 1)
+        r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Z() - fcathode_centre[2]);
+      else
+        r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    }
 
     double pars_ini[4] = {0, 0, 0, 0};
     double s1 = 0;

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -163,6 +163,9 @@ namespace phot {
     // maximum distance
     double fMaxPDDistance;
 
+    // flag to apply border corrections for vertical direction only
+    bool fVerticalBorderCorrectionMode;
+
     // Tool to to determine visibility of optical detectors from scintillation emission points
     std::shared_ptr<OpticalPath> fOpticalPath;
   };

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -25,8 +25,8 @@
 #include "boost/math/policies/policy.hpp"
 
 #include <map>
-#include <vector>
 #include <memory>
+#include <vector>
 
 // Define a new policy *not* internally promoting RealType to double:
 typedef boost::math::policies::policy<boost::math::policies::promote_double<false>>
@@ -39,7 +39,7 @@ namespace phot {
     // constructor
     SemiAnalyticalModel(const fhicl::ParameterSet& VUVHits,
                         const fhicl::ParameterSet& VISHits,
-                        const std::shared_ptr<OpticalPath> &OpticalPath,
+                        const std::shared_ptr<OpticalPath>& OpticalPath,
                         const bool doReflectedLight = false,
                         const bool includeAnodeReflections = false,
                         const bool useXeAbsorption = false);

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -94,7 +94,6 @@ namespace phot {
     // dome aperture calculation
     double Omega_Dome_Model(const double distance, const double theta) const;
 
-    bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
     std::vector<OpticalDetector> opticalDetectors() const;
 
     // geometry properties

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -15,6 +15,7 @@
 #include "larcorealg/Geometry/fwd.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 #include "larsim/IonizationScintillation/ISTPC.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 // fhicl
 #include "fhiclcpp/fwd.h"
@@ -25,6 +26,7 @@
 
 #include <map>
 #include <vector>
+#include <memory>
 
 // Define a new policy *not* internally promoting RealType to double:
 typedef boost::math::policies::policy<boost::math::policies::promote_double<false>>
@@ -37,6 +39,7 @@ namespace phot {
     // constructor
     SemiAnalyticalModel(const fhicl::ParameterSet& VUVHits,
                         const fhicl::ParameterSet& VISHits,
+                        const std::shared_ptr<OpticalPath> &OpticalPath,
                         const bool doReflectedLight = false,
                         const bool includeAnodeReflections = false,
                         const bool useXeAbsorption = false);
@@ -159,6 +162,9 @@ namespace phot {
 
     // maximum distance
     double fMaxPDDistance;
+
+    // Tool to to determine visibility of optical detectors from scintillation emission points
+    std::shared_ptr<OpticalPath> fOpticalPath;
   };
 
 } // namespace phot


### PR DESCRIPTION
This PR adds a tool "OpticalPath" for identifying which photon detectors are visible depending on where the light emission occurs for detectors where there are multiple optically isolated volumes. This replaces the placeholder solution discussed in relation to https://github.com/LArSoft/larsim/pull/145 in January. 

The default behaviour of the tool is that all optical detectors are visible for any emission point. This case works in DUNE-HD 1x2x6, DUNE VD, protoDUNE VD and MicroBooNE.

Custom cases are implemented for: 
- SBND: https://github.com/SBNSoftware/sbndcode/pull/756
(Note: SBND is currently several releases behind LArSoft, so the CI checks will fail; but this has been tested locally using cherry-picked build) 
- DUNE-HD 10kt, protoDUNE-HD: https://github.com/DUNE/dunesw/pull/186 and https://github.com/DUNE/duneopdet/pull/104

Also requires: https://github.com/LArSoft/larwirecell/pull/58 

The PR also implements two minor/maintenance changes to the models:
- adds a safeguard for vuv timing parameterisations going out of range, to avoid potential segfault
- adds a special case to apply border corrections in vertical direction only for use in DUNE-HD 10kt