### PR TITLE
Update QAlpha from 0.72 to 0.33 for alpha simulation

### DIFF
--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -65,7 +65,7 @@ standard_largeantparameters:
 
   #* alpha particle quenching factor
   #* Doke et al. Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538
- QAlpha: 0.72
+ QAlpha: 0.33
 
   #* ion+excitation work function in eV
   #* https://doi.org/10.1016/0168-9002(90)90011-T


### PR DESCRIPTION
## Context

This pull request updates the `Qalpha` parameter from 0.72 to 0.33 in alignment with the observed light yield in alpha particle simulations for ProtoDUNE-VD.

## Justification

We observed the following results when simulating a 5.36 MeV alpha particle:

- With Qalpha = 0.72:
  - Photons produced = 195,144
  - Photons/MeV = 36,407

- With Qalpha = 0.33:
  - Photons produced = 89,422
  - Photons/MeV = 16,683

## Acknowledgments

This change was discussed with the ProtoDUNE DRA Photon Detection System team, led by:

- Jose Alfonso Soto Oton (j.soto@cern.ch)
- Laura Paulucci (laura.paulucci@ufabc.edu.br)

Laura Paulucci has confirmed approval for this change and suggested that it be submitted via pull request to LArSoft for review.

## Author

- Angelo Ralaikoto (ralaikotoangelo@gmail.com)
- Project: "Alpha particle simulation studies - ProtoDUNE-VD"
