### PR TITLE
PDFastSimPAR can now be configured to restrict the TPCs in which edeps can produce photons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules 3.24.00 REQUIRED)
-project(larsim VERSION 10.06.03 LANGUAGES CXX)
+project(larsim VERSION 10.07.00 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 find_package(cetmodules 3.24.00 REQUIRED)
-project(larsim VERSION 10.06.02 LANGUAGES CXX)
+project(larsim VERSION 10.06.03 LANGUAGES CXX)
 
 include(CetCMakeEnv)
 cet_cmake_env()

--- a/larsim/PhotonPropagation/CMakeLists.txt
+++ b/larsim/PhotonPropagation/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(LibraryMappingTools)
 add_subdirectory(ScintTimeTools)
+add_subdirectory(OpticalPathTools)
 
 cet_make_library(LIBRARY_NAME PhotonLibraryInterface INTERFACE
   SOURCE IPhotonLibrary.h

--- a/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
@@ -1,0 +1,16 @@
+cet_make_library(LIBRARY_NAME OpticalPath INTERFACE
+  SOURCE OpticalPath.h)
+
+cet_write_plugin_builder(phot::OpticalPath art::tool Modules
+  INSTALL_BUILDER)
+
+include (phot::OpticalPath)
+
+cet_build_plugin(StandardOpticalPath phot::OpticalPath
+  LIBRARIES PRIVATE
+  larcoreobj::geo_vectors
+)
+
+install_headers()
+install_fhicl()
+install_source()

--- a/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
+++ b/larsim/PhotonPropagation/OpticalPathTools/CMakeLists.txt
@@ -8,6 +8,7 @@ include (phot::OpticalPath)
 
 cet_build_plugin(StandardOpticalPath phot::OpticalPath
   LIBRARIES PRIVATE
+  larsim::OpticalPath
   larcoreobj::geo_vectors
 )
 

--- a/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
@@ -1,0 +1,17 @@
+// Defines whether a photon detector is visible from a given scintillation emission point
+// used for the semi-analytical model fast optical simulation (PDFastSimPAR)
+
+#ifndef OpticalPath_H
+#define OpticalPath_H
+
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+namespace phot {
+    class OpticalPath {
+    public:
+        virtual ~OpticalPath() noexcept = default; 
+        virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) = 0;
+  };
+}
+
+#endif

--- a/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h
@@ -7,10 +7,11 @@
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 namespace phot {
-    class OpticalPath {
-    public:
-        virtual ~OpticalPath() noexcept = default; 
-        virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) = 0;
+  class OpticalPath {
+  public:
+    virtual ~OpticalPath() noexcept = default;
+    virtual const bool isOpDetVisible(geo::Point_t const& ScintPoint,
+                                      geo::Point_t const& OpDetPoint) = 0;
   };
 }
 

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
@@ -4,23 +4,24 @@
 #ifndef StandardOpticalPath_H
 #define StandardOpticalPath_H
 
-#include "art/Utilities/ToolMacros.h" 
-#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
+#include "art/Utilities/ToolMacros.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 #include <iostream>
 
 namespace phot {
-    class StandardOpticalPath : public phot::OpticalPath {
-    public:
-        explicit StandardOpticalPath(fhicl::ParameterSet const& ps) {};
-        ~StandardOpticalPath() noexcept override = default;
+  class StandardOpticalPath : public phot::OpticalPath {
+  public:
+    explicit StandardOpticalPath(fhicl::ParameterSet const& ps){};
+    ~StandardOpticalPath() noexcept override = default;
 
-        const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) override { 
-            std::cout << "In StandardOpticalPath::isOpDetVisible" << std::endl;
-            return true; 
-        }
-    };
+    const bool isOpDetVisible(geo::Point_t const& ScintPoint,
+                              geo::Point_t const& OpDetPoint) override
+    {
+      return true;
+    }
+  };
 }
 
 #endif

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h
@@ -1,0 +1,26 @@
+// default optical path tool
+// all photon detectors are visible from all scintillation emission points
+
+#ifndef StandardOpticalPath_H
+#define StandardOpticalPath_H
+
+#include "art/Utilities/ToolMacros.h" 
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+#include <iostream>
+
+namespace phot {
+    class StandardOpticalPath : public phot::OpticalPath {
+    public:
+        explicit StandardOpticalPath(fhicl::ParameterSet const& ps) {};
+        ~StandardOpticalPath() noexcept override = default;
+
+        const bool isOpDetVisible(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) override { 
+            std::cout << "In StandardOpticalPath::isOpDetVisible" << std::endl;
+            return true; 
+        }
+    };
+}
+
+#endif

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
@@ -1,0 +1,5 @@
+
+#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
+#include "art/Utilities/ToolMacros.h"
+
+DEFINE_ART_CLASS_TOOL(phot::StandardOpticalPath)

--- a/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
+++ b/larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath_tool.cc
@@ -1,5 +1,5 @@
 
-#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
 #include "art/Utilities/ToolMacros.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/StandardOpticalPath.h"
 
 DEFINE_ART_CLASS_TOOL(phot::StandardOpticalPath)

--- a/larsim/PhotonPropagation/OpticalPathTools/opticalpath_tool.fcl
+++ b/larsim/PhotonPropagation/OpticalPathTools/opticalpath_tool.fcl
@@ -1,0 +1,10 @@
+// standard optical path tool
+
+BEGIN_PROLOG
+
+StandardOpticalPath:
+{
+    tool_type: StandardOpticalPath
+}
+
+END_PROLOG

--- a/larsim/PhotonPropagation/PDFastSimPAR.fcl
+++ b/larsim/PhotonPropagation/PDFastSimPAR.fcl
@@ -1,5 +1,6 @@
 #include "opticalsimparameterisations.fcl"
 #include "scintillationtime_tool.fcl"
+#include "opticalpath_tool.fcl"
 
 BEGIN_PROLOG
 
@@ -18,6 +19,7 @@ standard_pdfastsim_par_ar:
   OnlyActiveVolume:     true
   OnlyOneCryostat:       false
   ScintTimeTool:         @local::ScintTimeLAr
+  OpticalPathTool:       @local::StandardOpticalPath
   UseXeAbsorption:       false
 
   VUVTiming: @local::common_vuv_timing_parameterization

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -57,11 +57,11 @@
 #include "cetlib_except/exception.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Comment.h"
 #include "fhiclcpp/types/DelegatedParameter.h"
 #include "fhiclcpp/types/Name.h"
 #include "fhiclcpp/types/OptionalDelegatedParameter.h"
+#include "fhiclcpp/types/Sequence.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // Random numbers
@@ -113,10 +113,10 @@ namespace phot {
         Name("OnlyActiveVolume"),
         Comment("PAR fast sim usually only for active volume, default true"),
         true};
-      fhicl::Sequence<int> RestrictedTPCs{
-        Name("RestrictedTPCs"),
-        Comment("Simulate for EDeps only in these TPCs.\nDefault is empty which means simulate in all TPCs"),
-        default_TPCs};
+      fhicl::Sequence<int> RestrictedTPCs{Name("RestrictedTPCs"),
+                                          Comment("Simulate for EDeps only in these TPCs.\nDefault "
+                                                  "is empty which means simulate in all TPCs"),
+                                          default_TPCs};
       fhicl::Atom<bool> OnlyOneCryostat{Name("OnlyOneCryostat"),
                                         Comment("Set to true if light is only supported in C:1")};
       DP ScintTimeTool{Name("ScintTimeTool"),
@@ -289,7 +289,7 @@ namespace phot {
     }
 
     mf::LogDebug("PDFastSimPAR") << "Only generating edeps in the following TPCs:";
-    for (const auto & tpc : fRestrictedTPCs)
+    for (const auto& tpc : fRestrictedTPCs)
       mf::LogDebug("PDFastSimPAR") << tpc;
 
     // Initialise the Scintillation Time
@@ -310,9 +310,10 @@ namespace phot {
 
     {
       mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
-                                   << fActiveVolumes.size() << " volumes:";
+                                  << fActiveVolumes.size() << " volumes:";
       for (auto const& [iCryo, box] : ::ranges::views::enumerate(fActiveVolumes)) {
-        mf::LogInfo("PDFastSimPAR") << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
+        mf::LogInfo("PDFastSimPAR")
+          << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
       }
     }
 
@@ -438,15 +439,13 @@ namespace phot {
       //If we're in the active volume (and we want to simulate within it),
       //check which TPC we're in and whether we want to simulate within that TPC
       int scint_point_TPC = fGeom.PositionToTPCID(ScintPoint).TPC;
-      auto in_valid_TPC = (
-        (fRestrictedTPCs.size() == 0) || //If no TPCs specified, simulate in all
-        std::find(fRestrictedTPCs.begin(),
-                  fRestrictedTPCs.end(),
-                  scint_point_TPC) != fRestrictedTPCs.end()
-      );
+      auto in_valid_TPC =
+        ((fRestrictedTPCs.size() == 0) || //If no TPCs specified, simulate in all
+         std::find(fRestrictedTPCs.begin(), fRestrictedTPCs.end(), scint_point_TPC) !=
+           fRestrictedTPCs.end());
       if (fOnlyActiveVolume && !(in_valid_TPC)) {
         skipped_edeps[scint_point_TPC]++;
-        
+
         continue;
       }
 
@@ -648,7 +647,7 @@ namespace phot {
         << "OpDet: " << iopbtr.OpDetNum() << " " << iopbtr.timePDclockSDPsMap().size();
     }
 
-    for (const auto & [tpc, nskipped] : skipped_edeps) {
+    for (const auto& [tpc, nskipped] : skipped_edeps) {
       mf::LogDebug("PDFastSimPAR") << "Skipped " << nskipped << " edeps in TPC " << tpc;
     }
 

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -563,8 +563,7 @@ namespace phot {
                 // calculates the time at which the photon was produced
                 double dtime = edepi.StartT() + fScintTime->fastScintTime();
                 if (fIncludePropTime) dtime += transport_time[i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else
@@ -577,8 +576,7 @@ namespace phot {
               for (int i = 0; i < n; ++i) {
                 double dtime = edepi.StartT() + fScintTime->slowScintTime();
                 if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -214,8 +214,8 @@ namespace phot {
         config.get_PSet(),
         "SeedScintTime"))
     , fScintTime{art::make_tool<phot::ScintTime>(config().ScintTimeTool.get<fhicl::ParameterSet>())}
-    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(std::move(
-        art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>())))}
+    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(
+        art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>()))}
     , fGeom(*(lar::providerFrom<geo::Geometry>()))
     , fISTPC{fGeom}
     , fNOpChannels(fGeom.NOpDets())

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -155,7 +155,6 @@ namespace phot {
       double edeposit,
       int num_photons = 1);
 
-    bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
     std::vector<geo::Point_t> opDetCenters() const; 
 
     // semi-analytical model
@@ -458,9 +457,8 @@ namespace phot {
       for (size_t Reflected = 0; Reflected <= DoReflected; ++Reflected) {
         for (size_t channel = 0; channel < fNOpChannels; channel++) {
 
-          if (!fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
-          // fOpaqueCathode && is this needed? obsolete? 
-
+          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
+          
           int ndetected_fast = DetectedNumFast[channel];
           int ndetected_slow = DetectedNumSlow[channel];
           if (Reflected) {
@@ -695,33 +693,6 @@ namespace phot {
   }
 
   //......................................................................
-  // checks whether photo-detector is able to see the emitted light scintillation
-  bool PDFastSimPAR::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
-                                      geo::Point_t const& OpDetPoint) const
-  {
-    // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service
-    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-
-    std::cout << "In PDFastSimPAR::isOpDetInSameTPC" << std::endl;
-
-    // special case for SBND = 2 TPCs
-    // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10.) {
-      return false;
-    }
-
-    // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance
-    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
-      return false;
-    }
-    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
-
-    return true;
-  }
-
   std::vector<geo::Point_t> PDFastSimPAR::opDetCenters() const
   {
     std::vector<geo::Point_t> opDetCenter;

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -57,6 +57,7 @@
 #include "cetlib_except/exception.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Comment.h"
 #include "fhiclcpp/types/DelegatedParameter.h"
 #include "fhiclcpp/types/Name.h"
@@ -83,7 +84,7 @@ namespace phot {
       using Comment = fhicl::Comment;
       using DP = fhicl::DelegatedParameter;
       using ODP = fhicl::OptionalDelegatedParameter;
-
+      const std::vector<int> default_TPCs{};
       fhicl::Atom<art::InputTag> SimulationLabel{Name("SimulationLabel"),
                                                  Comment("SimEnergyDeposit label.")};
       fhicl::Atom<bool> DoFastComponent{Name("DoFastComponent"),
@@ -112,6 +113,10 @@ namespace phot {
         Name("OnlyActiveVolume"),
         Comment("PAR fast sim usually only for active volume, default true"),
         true};
+      fhicl::Sequence<int> RestrictedTPCs{
+        Name("RestrictedTPCs"),
+        Comment("Simulate for EDeps only in these TPCs.\nDefault is empty which means simulate in all TPCs"),
+        default_TPCs};
       fhicl::Atom<bool> OnlyOneCryostat{Name("OnlyOneCryostat"),
                                         Comment("Set to true if light is only supported in C:1")};
       DP ScintTimeTool{Name("ScintTimeTool"),
@@ -179,6 +184,7 @@ namespace phot {
     const size_t fNOpChannels;
     const std::vector<geo::BoxBoundedGeo> fActiveVolumes;
     const int fNTPC;
+    const std::vector<int> fRestrictedTPCs;
     double fDriftDistance;
     const std::vector<geo::Point_t> fOpDetCenter;
 
@@ -221,6 +227,7 @@ namespace phot {
     , fNOpChannels(fGeom.NOpDets())
     , fActiveVolumes(fISTPC.extractActiveLArVolume(fGeom))
     , fNTPC(fGeom.NTPC())
+    , fRestrictedTPCs(config().RestrictedTPCs())
     , fOpDetCenter(opDetCenters())
     , fSimTag(config().SimulationLabel())
     , fDoFastComponent(config().DoFastComponent())
@@ -281,6 +288,10 @@ namespace phot {
       }
     }
 
+    mf::LogDebug("PDFastSimPAR") << "Only generating edeps in the following TPCs:";
+    for (const auto & tpc : fRestrictedTPCs)
+      mf::LogDebug("PDFastSimPAR") << tpc;
+
     // Initialise the Scintillation Time
     fScintTime->initRand(fScintTimeEngine);
 
@@ -298,10 +309,10 @@ namespace phot {
         VUVTimingParams, VISTimingParams, fScintTimeEngine, fDoReflectedLight, fGeoPropTimeOnly);
 
     {
-      auto log = mf::LogTrace("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
-                                              << fActiveVolumes.size() << " volumes:";
+      mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
+                                   << fActiveVolumes.size() << " volumes:";
       for (auto const& [iCryo, box] : ::ranges::views::enumerate(fActiveVolumes)) {
-        log << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
+        mf::LogInfo("PDFastSimPAR") << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
       }
     }
 
@@ -394,6 +405,8 @@ namespace phot {
     mf::LogTrace("PDFastSimPAR") << "Creating SimPhotonsLite/SimPhotons from " << (*edeps).size()
                                  << " energy deposits\n";
 
+    std::map<int, size_t> skipped_edeps;
+
     for (auto const& edepi : *edeps) {
 
       if (!(num_points % 1000)) {
@@ -419,7 +432,23 @@ namespace phot {
       double pos[3] = {edepi.MidPointX(), edepi.MidPointY(), edepi.MidPointZ()};
       geo::Point_t const ScintPoint = {pos[0], pos[1], pos[2]};
 
+      //Check if we're within the active volume and sim or skip accordingly
       if (fOnlyActiveVolume && !fISTPC.isScintInActiveVolume(ScintPoint)) continue;
+
+      //If we're in the active volume (and we want to simulate within it),
+      //check which TPC we're in and whether we want to simulate within that TPC
+      int scint_point_TPC = fGeom.PositionToTPCID(ScintPoint).TPC;
+      auto in_valid_TPC = (
+        (fRestrictedTPCs.size() == 0) || //If no TPCs specified, simulate in all
+        std::find(fRestrictedTPCs.begin(),
+                  fRestrictedTPCs.end(),
+                  scint_point_TPC) != fRestrictedTPCs.end()
+      );
+      if (fOnlyActiveVolume && !(in_valid_TPC)) {
+        skipped_edeps[scint_point_TPC]++;
+        
+        continue;
+      }
 
       // direct light
       std::vector<int> DetectedNumFast(fNOpChannels);
@@ -617,6 +646,10 @@ namespace phot {
     for (auto& iopbtr : *opbtr_ref) {
       mf::LogDebug("PDFastSimPAR")
         << "OpDet: " << iopbtr.OpDetNum() << " " << iopbtr.timePDclockSDPsMap().size();
+    }
+
+    for (const auto & [tpc, nskipped] : skipped_edeps) {
+      mf::LogDebug("PDFastSimPAR") << "Skipped " << nskipped << " edeps in TPC " << tpc;
     }
 
     if (fUseLitePhotons) {

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -56,11 +56,11 @@
 #include "cetlib_except/exception.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Comment.h"
 #include "fhiclcpp/types/DelegatedParameter.h"
 #include "fhiclcpp/types/Name.h"
 #include "fhiclcpp/types/OptionalDelegatedParameter.h"
+#include "fhiclcpp/types/Sequence.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 // Random numbers
@@ -112,10 +112,10 @@ namespace phot {
         Name("OnlyActiveVolume"),
         Comment("PAR fast sim usually only for active volume, default true"),
         true};
-      fhicl::Sequence<int> RestrictedTPCs{
-        Name("RestrictedTPCs"),
-        Comment("Simulate for EDeps only in these TPCs.\nDefault is empty which means simulate in all TPCs"),
-        default_TPCs};
+      fhicl::Sequence<int> RestrictedTPCs{Name("RestrictedTPCs"),
+                                          Comment("Simulate for EDeps only in these TPCs.\nDefault "
+                                                  "is empty which means simulate in all TPCs"),
+                                          default_TPCs};
       fhicl::Atom<bool> OnlyOneCryostat{Name("OnlyOneCryostat"),
                                         Comment("Set to true if light is only supported in C:1")};
       DP ScintTimeTool{Name("ScintTimeTool"),
@@ -280,7 +280,7 @@ namespace phot {
     }
 
     mf::LogDebug("PDFastSimPAR") << "Only generating edeps in the following TPCs:";
-    for (const auto & tpc : fRestrictedTPCs)
+    for (const auto& tpc : fRestrictedTPCs)
       mf::LogDebug("PDFastSimPAR") << tpc;
 
     // Initialise the Scintillation Time
@@ -297,9 +297,10 @@ namespace phot {
 
     {
       mf::LogInfo("PDFastSimPAR") << "PDFastSimPAR: active volume boundaries from "
-                                   << fActiveVolumes.size() << " volumes:";
+                                  << fActiveVolumes.size() << " volumes:";
       for (auto const& [iCryo, box] : ::ranges::views::enumerate(fActiveVolumes)) {
-        mf::LogInfo("PDFastSimPAR") << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
+        mf::LogInfo("PDFastSimPAR")
+          << "\n - C:" << iCryo << ": " << box.Min() << " -- " << box.Max() << " cm";
       }
     }
 
@@ -425,15 +426,13 @@ namespace phot {
       //If we're in the active volume (and we want to simulate within it),
       //check which TPC we're in and whether we want to simulate within that TPC
       int scint_point_TPC = fGeom.PositionToTPCID(ScintPoint).TPC;
-      auto in_valid_TPC = (
-        (fRestrictedTPCs.size() == 0) || //If no TPCs specified, simulate in all
-        std::find(fRestrictedTPCs.begin(),
-                  fRestrictedTPCs.end(),
-                  scint_point_TPC) != fRestrictedTPCs.end()
-      );
+      auto in_valid_TPC =
+        ((fRestrictedTPCs.size() == 0) || //If no TPCs specified, simulate in all
+         std::find(fRestrictedTPCs.begin(), fRestrictedTPCs.end(), scint_point_TPC) !=
+           fRestrictedTPCs.end());
       if (fOnlyActiveVolume && !(in_valid_TPC)) {
         skipped_edeps[scint_point_TPC]++;
-        
+
         continue;
       }
 
@@ -636,7 +635,7 @@ namespace phot {
         << "OpDet: " << iopbtr.OpDetNum() << " " << iopbtr.timePDclockSDPsMap().size();
     }
 
-    for (const auto & [tpc, nskipped] : skipped_edeps) {
+    for (const auto& [tpc, nskipped] : skipped_edeps) {
       mf::LogDebug("PDFastSimPAR") << "Skipped " << nskipped << " edeps in TPC " << tpc;
     }
 

--- a/larsim/PhotonPropagation/PDFastSimPAR_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPAR_module.cc
@@ -38,10 +38,10 @@
 #include "lardataobj/Simulation/SimEnergyDeposit.h"
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "larsim/IonizationScintillation/ISTPC.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 #include "larsim/PhotonPropagation/PropagationTimeModel.h"
 #include "larsim/PhotonPropagation/ScintTimeTools/ScintTime.h"
 #include "larsim/PhotonPropagation/SemiAnalyticalModel.h"
-#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 #include "nurandom/RandomUtils/NuRandomService.h"
 
@@ -118,7 +118,8 @@ namespace phot {
                        Comment("Tool describing scintillation time structure")};
       DP OpticalPathTool{
         Name("OpticalPathTool"),
-        Comment("Tool to determine visibility of optical detectors from scintillation emission points")};
+        Comment(
+          "Tool to determine visibility of optical detectors from scintillation emission points")};
       fhicl::Atom<bool> UseXeAbsorption{
         Name("UseXeAbsorption"),
         Comment("Use Xe absorption length instead of Ar, default false"),
@@ -155,7 +156,7 @@ namespace phot {
       double edeposit,
       int num_photons = 1);
 
-    std::vector<geo::Point_t> opDetCenters() const; 
+    std::vector<geo::Point_t> opDetCenters() const;
 
     // semi-analytical model
     std::unique_ptr<SemiAnalyticalModel> fVisibilityModel;
@@ -213,7 +214,8 @@ namespace phot {
         config.get_PSet(),
         "SeedScintTime"))
     , fScintTime{art::make_tool<phot::ScintTime>(config().ScintTimeTool.get<fhicl::ParameterSet>())}
-    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(std::move(art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>())))}
+    , fOpticalPath{std::shared_ptr<phot::OpticalPath>(std::move(
+        art::make_tool<phot::OpticalPath>(config().OpticalPathTool.get<fhicl::ParameterSet>())))}
     , fGeom(*(lar::providerFrom<geo::Geometry>()))
     , fISTPC{fGeom}
     , fNOpChannels(fGeom.NOpDets())
@@ -283,8 +285,12 @@ namespace phot {
     fScintTime->initRand(fScintTimeEngine);
 
     // photo-detector visibility model (semi-analytical model)
-    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(
-      VUVHitsParams, VISHitsParams, fOpticalPath, fDoReflectedLight, fIncludeAnodeReflections, fUseXeAbsorption);
+    fVisibilityModel = std::make_unique<SemiAnalyticalModel>(VUVHitsParams,
+                                                             VISHitsParams,
+                                                             fOpticalPath,
+                                                             fDoReflectedLight,
+                                                             fIncludeAnodeReflections,
+                                                             fUseXeAbsorption);
 
     // propagation time model
     if (fIncludePropTime)
@@ -457,8 +463,9 @@ namespace phot {
       for (size_t Reflected = 0; Reflected <= DoReflected; ++Reflected) {
         for (size_t channel = 0; channel < fNOpChannels; channel++) {
 
-          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel])) continue;
-          
+          if (fOpaqueCathode && !fOpticalPath->isOpDetVisible(ScintPoint, fOpDetCenter[channel]))
+            continue;
+
           int ndetected_fast = DetectedNumFast[channel];
           int ndetected_slow = DetectedNumSlow[channel];
           if (Reflected) {

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -71,6 +71,7 @@ namespace phot {
     const bool fDoFastComponent;
     const bool fDoSlowComponent;
     const bool fIncludePropTime;
+    const bool fGeoPropTimeOnly;
     const bool fUseLitePhotons;
     const bool fStoreReflected;
     const size_t fNOpChannels;
@@ -89,6 +90,7 @@ namespace phot {
     , fDoFastComponent(pset.get<bool>("DoFastComponent", true))
     , fDoSlowComponent(pset.get<bool>("DoSlowComponent", true))
     , fIncludePropTime(pset.get<bool>("IncludePropTime", false))
+    , fGeoPropTimeOnly(pset.get<bool>("GeoPropTimeOnly", false))
     , fUseLitePhotons(art::ServiceHandle<sim::LArG4Parameters const>()->UseLitePhotons())
     , fStoreReflected(fPVS->StoreReflected())
     , fNOpChannels(fPVS->NOpChannels())
@@ -130,7 +132,7 @@ namespace phot {
     // propagation time model
     if (fIncludePropTime)
       fPropTimeModel = std::make_unique<PropagationTimeModel>(
-        VUVTimingParams, VISTimingParams, fScintTimeEngine, fStoreReflected);
+        VUVTimingParams, VISTimingParams, fScintTimeEngine, fStoreReflected, fGeoPropTimeOnly);
 
     if (fUseLitePhotons) {
       mf::LogInfo("PDFastSimPVS") << "Use Lite Photon." << std::endl;

--- a/larsim/PhotonPropagation/PDFastSimPVS_module.cc
+++ b/larsim/PhotonPropagation/PDFastSimPVS_module.cc
@@ -308,8 +308,7 @@ namespace phot {
                 // calculates the time at which the photon was produced
                 double dtime = edepi.StartT() + fScintTime->fastScintTime();
                 if (fIncludePropTime) dtime += transport_time[i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else
@@ -320,8 +319,7 @@ namespace phot {
               for (int i = 0; i < ndetected_slow; ++i) {
                 double dtime = edepi.StartT() + fScintTime->slowScintTime();
                 if (fIncludePropTime) dtime += transport_time[ndetected_fast + i];
-                int time = static_cast<int>(std::round(dtime));
-                photon.Time = time;
+                photon.Time = dtime;
                 if (Reflected)
                   ref_photcol[channel].insert(ref_photcol[channel].end(), 1, photon);
                 else

--- a/larsim/PhotonPropagation/PropagationTimeModel.cxx
+++ b/larsim/PhotonPropagation/PropagationTimeModel.cxx
@@ -158,7 +158,11 @@ namespace phot {
     }
     else {
       // determine nearest parameterisation in discretisation
-      int index = std::round((distance - fmin_d) / fstep_size);
+      size_t index = std::round((distance - fmin_d) / fstep_size);
+      // check index is within range, otherwise use furthest parameterisation
+      if (index >= number_of_vuv_timing_params) {
+        index = number_of_vuv_timing_params - 1;
+      }
       // randomly sample parameterisation for each photon
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
         arrivalTimes[i] = fVUVTimingGen[angle_bin][index].fire() *
@@ -198,6 +202,7 @@ namespace phot {
     fVUVTimingGen = std::vector(num_angles, std::vector(num_params, CLHEP::RandGeneral(dummy, 1)));
     fVUV_max = std::vector(num_angles, std::vector(num_params, 0.0));
     fVUV_min = std::vector(num_angles, std::vector(num_params, 0.0));
+    number_of_vuv_timing_params = num_params;
 
     std::vector<std::vector<double>> parameters[7];
     parameters[0] = std::vector(1, VUVTimingParams.get<std::vector<double>>("Distances_landau"));
@@ -355,7 +360,9 @@ namespace phot {
     if (VUVdist < fmin_d) { vuv_time = VUVdist / fvuv_vgroup_max; }
     else {
       // find index of required parameterisation
-      const size_t index = std::round((VUVdist - fmin_d) / fstep_size);
+      size_t index = std::round((VUVdist - fmin_d) / fstep_size);
+      // check index is within range, otherwise use furthest parameterisation
+      if (index >= number_of_vuv_timing_params) index = number_of_vuv_timing_params - 1;
       // find shortest time
       vuv_time = fVUV_min[angle_bin_vuv][index];
     }

--- a/larsim/PhotonPropagation/PropagationTimeModel.cxx
+++ b/larsim/PhotonPropagation/PropagationTimeModel.cxx
@@ -160,9 +160,7 @@ namespace phot {
       // determine nearest parameterisation in discretisation
       size_t index = std::round((distance - fmin_d) / fstep_size);
       // check index is within range, otherwise use furthest parameterisation
-      if (index >= number_of_vuv_timing_params) {
-        index = number_of_vuv_timing_params - 1;
-      }
+      if (index >= number_of_vuv_timing_params) { index = number_of_vuv_timing_params - 1; }
       // randomly sample parameterisation for each photon
       for (size_t i = 0; i < arrivalTimes.size(); ++i) {
         arrivalTimes[i] = fVUVTimingGen[angle_bin][index].fire() *

--- a/larsim/PhotonPropagation/PropagationTimeModel.h
+++ b/larsim/PhotonPropagation/PropagationTimeModel.h
@@ -90,6 +90,7 @@ namespace phot {
     double fstep_size, fvuv_vgroup_mean, fvuv_vgroup_max, fmin_d, finflexion_point_distance,
       fangle_bin_timing_vuv;
     // vector containing generated VUV timing parameterisations
+    unsigned int number_of_vuv_timing_params;
     std::vector<std::vector<CLHEP::RandGeneral>> fVUVTimingGen;
     // vector containing min and max range VUV timing parameterisations are
     // sampled to

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -30,7 +30,7 @@ namespace phot {
   // constructor
   SemiAnalyticalModel::SemiAnalyticalModel(const fhicl::ParameterSet& VUVHitsParams,
                                            const fhicl::ParameterSet& VISHitsParams,
-                                           const std::shared_ptr<OpticalPath> &OpticalPath,
+                                           const std::shared_ptr<OpticalPath>& OpticalPath,
                                            const bool doReflectedLight,
                                            const bool includeAnodeReflections,
                                            const bool useXeAbsorption)
@@ -264,9 +264,7 @@ namespace phot {
     // radial distance from centre of detector (Y-Z standard / X-Z laterals)
     // special case: VerticalBorderCorrectionMode use Y direction only
     double r = 0;
-    if (fVerticalBorderCorrectionMode) {
-      r = std::abs(ScintPoint.Y() - fcathode_centre[1]);
-    }    
+    if (fVerticalBorderCorrectionMode) { r = std::abs(ScintPoint.Y() - fcathode_centre[1]); }
     else {
       if (opDet.orientation == 2)
         r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -764,34 +764,6 @@ namespace phot {
   }
 
   //......................................................................
-  // checks photo-detector is in same TPC/argon volume as scintillation
-  bool SemiAnalyticalModel::isOpDetInSameTPC(geo::Point_t const& ScintPoint,
-                                             geo::Point_t const& OpDetPoint) const
-  {
-    // check optical channel is in same TPC as scintillation light, if not doesn't see light
-    // temporary method, needs to be replaced with geometry service
-    // working for SBND, uBooNE, DUNE HD 1x2x6, DUNE HD 10kt and DUNE VD subset
-
-    std::cout << "In SemiAnalyticalModel::isOpDetInSameTPC" << std::endl;
-    
-    // special case for SBND = 2 TPCs
-    // check x coordinate has same sign or is close to zero
-    if (fNTPC == 2 && ((ScintPoint.X() < 0.) != (OpDetPoint.X() < 0.)) &&
-        std::abs(OpDetPoint.X()) > 10.) {
-      return false;
-    }
-
-    // special case for DUNE-HD 10kt = 300 TPCs
-    // check whether distance in drift direction > 1 drift distance
-    if (fNTPC == 300 && std::abs(ScintPoint.X() - OpDetPoint.X()) > fDriftDistance) {
-      return false;
-    }
-
-    // not needed for DUNE HD 1x2x6, DUNE VD subset, uBooNE
-
-    return true;
-  }
-
   std::vector<SemiAnalyticalModel::OpticalDetector> SemiAnalyticalModel::opticalDetectors() const
   {
     std::vector<SemiAnalyticalModel::OpticalDetector> opticalDetector;

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.cxx
@@ -68,6 +68,7 @@ namespace phot {
     fMaxPDDistance = VUVHitsParams.get<double>(
       "MaxPDDistance",
       1000); // max distance between scintillation and PD to evaluate light, default 10m
+    fVerticalBorderCorrectionMode = VUVHitsParams.get<bool>("VerticalBorderCorrectionMode", false);
 
     if (!fIsFlatPDCorr && !fIsDomePDCorr && !fIsFlatPDCorrLat) {
       throw cet::exception("SemiAnalyticalModel")
@@ -261,13 +262,19 @@ namespace phot {
 
     // determine GH parameters, accounting for border effects
     // radial distance from centre of detector (Y-Z standard / X-Z laterals)
+    // special case: VerticalBorderCorrectionMode use Y direction only
     double r = 0;
-    if (opDet.orientation == 2)
-      r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);
-    else if (opDet.orientation == 1)
-      r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Z() - fcathode_centre[2]);
-    else
-      r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    if (fVerticalBorderCorrectionMode) {
+      r = std::abs(ScintPoint.Y() - fcathode_centre[1]);
+    }    
+    else {
+      if (opDet.orientation == 2)
+        r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Y() - fcathode_centre[1]);
+      else if (opDet.orientation == 1)
+        r = std::hypot(ScintPoint.X() - fcathode_centre[0], ScintPoint.Z() - fcathode_centre[2]);
+      else
+        r = std::hypot(ScintPoint.Y() - fcathode_centre[1], ScintPoint.Z() - fcathode_centre[2]);
+    }
 
     double pars_ini[4] = {0, 0, 0, 0};
     double s1 = 0;

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -163,6 +163,9 @@ namespace phot {
     // maximum distance
     double fMaxPDDistance;
 
+    // flag to apply border corrections for vertical direction only
+    bool fVerticalBorderCorrectionMode;
+
     // Tool to to determine visibility of optical detectors from scintillation emission points
     std::shared_ptr<OpticalPath> fOpticalPath;
   };

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -25,8 +25,8 @@
 #include "boost/math/policies/policy.hpp"
 
 #include <map>
-#include <vector>
 #include <memory>
+#include <vector>
 
 // Define a new policy *not* internally promoting RealType to double:
 typedef boost::math::policies::policy<boost::math::policies::promote_double<false>>
@@ -39,7 +39,7 @@ namespace phot {
     // constructor
     SemiAnalyticalModel(const fhicl::ParameterSet& VUVHits,
                         const fhicl::ParameterSet& VISHits,
-                        const std::shared_ptr<OpticalPath> &OpticalPath,
+                        const std::shared_ptr<OpticalPath>& OpticalPath,
                         const bool doReflectedLight = false,
                         const bool includeAnodeReflections = false,
                         const bool useXeAbsorption = false);

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -94,7 +94,6 @@ namespace phot {
     // dome aperture calculation
     double Omega_Dome_Model(const double distance, const double theta) const;
 
-    bool isOpDetInSameTPC(geo::Point_t const& ScintPoint, geo::Point_t const& OpDetPoint) const;
     std::vector<OpticalDetector> opticalDetectors() const;
 
     // geometry properties

--- a/larsim/PhotonPropagation/SemiAnalyticalModel.h
+++ b/larsim/PhotonPropagation/SemiAnalyticalModel.h
@@ -15,6 +15,7 @@
 #include "larcorealg/Geometry/fwd.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 #include "larsim/IonizationScintillation/ISTPC.h"
+#include "larsim/PhotonPropagation/OpticalPathTools/OpticalPath.h"
 
 // fhicl
 #include "fhiclcpp/fwd.h"
@@ -25,6 +26,7 @@
 
 #include <map>
 #include <vector>
+#include <memory>
 
 // Define a new policy *not* internally promoting RealType to double:
 typedef boost::math::policies::policy<boost::math::policies::promote_double<false>>
@@ -37,6 +39,7 @@ namespace phot {
     // constructor
     SemiAnalyticalModel(const fhicl::ParameterSet& VUVHits,
                         const fhicl::ParameterSet& VISHits,
+                        const std::shared_ptr<OpticalPath> &OpticalPath,
                         const bool doReflectedLight = false,
                         const bool includeAnodeReflections = false,
                         const bool useXeAbsorption = false);
@@ -159,6 +162,9 @@ namespace phot {
 
     // maximum distance
     double fMaxPDDistance;
+
+    // Tool to to determine visibility of optical detectors from scintillation emission points
+    std::shared_ptr<OpticalPath> fOpticalPath;
   };
 
 } // namespace phot

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,7 +249,7 @@ gdmldir	product_dir	gdml
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-larg4		v10_00_11	-
+larg4		v10_00_12	-
 larsoft_data    v1_02_02
 marley		v1_2_1d		-
 nugen		v1_21_07	-


### PR DESCRIPTION
Mainly this is to help PDHD's memory utilization.

Configured using a sequence of integers representing TPC numbers. In the case of an empty sequence, the module produces photons from all edeps/TPCs. Default configuration is an empty sequence.