### PR TITLE
Remove use of art's `art::Event::getView`

### DIFF
--- a/larsim/DetSim/SimWire_module.cc
+++ b/larsim/DetSim/SimWire_module.cc
@@ -240,12 +240,11 @@ namespace detsim {
     //     of entries as the number of channels in the detector
     //     and set the entries for the channels that have signal on them
     //     using the chanHandle
-    std::vector<const sim::SimChannel*> chanHandle;
-    evt.getView(fDriftEModuleLabel, chanHandle);
+    auto const& avail_channels = evt.getProduct<std::vector<sim::SimChannel>>(fDriftEModuleLabel);
 
     std::vector<const sim::SimChannel*> channels(nchannels);
-    for (size_t c = 0; c < chanHandle.size(); ++c) {
-      channels[chanHandle[c]->Channel()] = chanHandle[c];
+    for (auto const& ch : avail_channels) {
+      channels[ch.Channel()] = &ch;
     }
 
     // ... make an unique_ptr of sim::SimDigits that allows ownership of the produced

--- a/larsim/LegacyLArG4/LArG4Ana_module.cc
+++ b/larsim/LegacyLArG4/LArG4Ana_module.cc
@@ -191,8 +191,7 @@ namespace larg4 {
 
     // loop over all sim::SimChannels in the event and make sure there are no
     // sim::IDEs with trackID values that are not in the sim::ParticleList
-    std::vector<const sim::SimChannel*> sccol;
-    evt.getView(fG4ModuleLabel, sccol);
+    auto const& sccol = evt.getProduct<std::vector<sim::SimChannel>>(fG4ModuleLabel);
 
     double totalCharge = 0.0;
     double totalEnergy = 0.0;
@@ -201,7 +200,7 @@ namespace larg4 {
       double numIDEs = 0.0;
       double scCharge = 0.0;
       double scEnergy = 0.0;
-      const auto& tdcidemap = sccol[sc]->TDCIDEMap();
+      const auto& tdcidemap = sccol[sc].TDCIDEMap();
       for (auto mapitr = tdcidemap.begin(); mapitr != tdcidemap.end(); mapitr++) {
         const std::vector<sim::IDE> idevec = (*mapitr).second;
         numIDEs += idevec.size();

--- a/larsim/Simulation/SimListUtils.cxx
+++ b/larsim/Simulation/SimListUtils.cxx
@@ -27,16 +27,15 @@ namespace sim {
     auto const clocks = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(evt);
 
     // get the sim::SimChannels
-    std::vector<const sim::SimChannel*> sccol;
-    evt.getView(moduleLabel, sccol);
+    auto const& sccol = evt.getProduct<std::vector<sim::SimChannel>>(moduleLabel);
 
     sim::LArVoxelList voxList;
 
     // loop over the voxels and put them into the list
-    for (auto itr = sccol.begin(); itr != sccol.end(); ++itr) {
+    for (auto const& sc : sccol) {
 
       // get all sim::IDE associated with this channel
-      const auto& idemap = (*itr)->TDCIDEMap();
+      const auto& idemap = sc.TDCIDEMap();
 
       // loop over all the sim::IDE values
       for (auto mitr = idemap.begin(); mitr != idemap.end(); mitr++) {


### PR DESCRIPTION
Only containers of type `std::vector<sim::SimChannel>` are written to disk. Using an art view is therefore unnecessary and, in anticipation of the Phlex framework (which will not support views), this PR changes to using the more conventional `evt.getProduct<std::vector<sim::SimChannel>>(...)`.