### PR TITLE
Feature/acastill proton light quenching

### DIFF
--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -147,13 +147,6 @@ namespace larg4 {
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
-    
-    /*
-    if(abs(edep.PdgCode()) == 11 && dEdx>17) {
-      std::cout << "Electron:  Original number of photons " << num_photons << " new number of photons " << energy_deposit * 24000 << std::endl;
-      num_photons = energy_deposit * 24000*fScintPreScale;
-    }
-    */
    
     if( edep.PdgCode() == 2212 ) {
       num_photons = num_photons * fQProton;

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -65,6 +65,7 @@ namespace larg4 {
     fLarqlAlpha = LArG4PropHandle->LarqlAlpha();
     fLarqlBeta = LArG4PropHandle->LarqlBeta();
     fQAlpha = LArG4PropHandle->QAlpha();
+    fQProton = LArG4PropHandle->QProton();
     fGeVToElectrons = LArG4PropHandle->GeVToElectrons();
 
     // ionization work function
@@ -146,6 +147,17 @@ namespace larg4 {
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
+    
+    /*
+    if(abs(edep.PdgCode()) == 11 && dEdx>17) {
+      std::cout << "Electron:  Original number of photons " << num_photons << " new number of photons " << energy_deposit * 24000 << std::endl;
+      num_photons = energy_deposit * 24000*fScintPreScale;
+    }
+    */
+   
+    if( edep.PdgCode() == 2212 ) {
+      num_photons = num_photons * fQProton;
+    }
 
     if (edep.PdgCode() == 1000020040) {
       num_electrons = num_electrons * fQAlpha;

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -148,6 +148,7 @@ namespace larg4 {
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
 
+    // add light quenching factor for protons
     if (edep.PdgCode() == 2212) { num_photons = num_photons * fQProton; }
 
     if (edep.PdgCode() == 1000020040) {

--- a/larsim/IonizationScintillation/ISCalcCorrelated.cxx
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.cxx
@@ -147,10 +147,8 @@ namespace larg4 {
 
     // calculate scintillation photons
     double num_photons = (num_quanta - num_electrons) * fScintPreScale;
-   
-    if( edep.PdgCode() == 2212 ) {
-      num_photons = num_photons * fQProton;
-    }
+
+    if (edep.PdgCode() == 2212) { num_photons = num_photons * fQProton; }
 
     if (edep.PdgCode() == 1000020040) {
       num_electrons = num_electrons * fQAlpha;

--- a/larsim/IonizationScintillation/ISCalcCorrelated.h
+++ b/larsim/IonizationScintillation/ISCalcCorrelated.h
@@ -65,6 +65,7 @@ namespace larg4 {
     double fLarqlAlpha;          ///< from LArG4Parameters service
     double fLarqlBeta;           ///< from LArG4Parameters service
     double fQAlpha;              ///< from LArG4Parameters service
+    double fQProton;             ///< from LArG4Parameters service
     bool fUseModBoxRecomb;       ///< from LArG4Parameters service
     bool fUseEllipsModBoxRecomb; ///< from LArG4Parameters service
     bool fUseModLarqlRecomb;     ///< from LArG4Parameters service

--- a/larsim/Simulation/LArG4Parameters.cc
+++ b/larsim/Simulation/LArG4Parameters.cc
@@ -57,6 +57,7 @@ namespace sim {
     , fLarqlBeta{pset.get<double>("LarqlBeta")}
     , fWph{pset.get<double>("Wph")}
     , fQAlpha{pset.get<double>("QAlpha")}
+    , fQProton{pset.get<double>("QProton")}
     , fUseModBoxRecomb{pset.get<bool>("UseModBoxRecomb")}
     , fUseEllipsModBoxRecomb{pset.get<bool>("UseEllipsModBoxRecomb")}
     , fUseModLarqlRecomb{pset.get<bool>("UseModLarqlRecomb")}

--- a/larsim/Simulation/LArG4Parameters.h
+++ b/larsim/Simulation/LArG4Parameters.h
@@ -133,7 +133,8 @@ namespace sim {
     double const fQAlpha;        ///< Possibly override the QAlpha parameter
     double const fQProton;       ///< Possibly override the QProton parameter
     bool const fUseModBoxRecomb; ///< Use Modified Box model recombination instead of Birks
-    bool const fUseEllipsModBoxRecomb; ///< Use Ellipsoid Modified Box model recombination instead of Birks
+    bool const
+      fUseEllipsModBoxRecomb; ///< Use Ellipsoid Modified Box model recombination instead of Birks
     bool const fUseModLarqlRecomb; ///< Use LArQL model recombination correction (dependence on EF)
     bool const fUseBinomialFlucts; ///< Use binomial fluctuations in correlated method
     std::string const

--- a/larsim/Simulation/LArG4Parameters.h
+++ b/larsim/Simulation/LArG4Parameters.h
@@ -51,6 +51,7 @@ namespace sim {
     double LarqlBeta() const { return fLarqlBeta; }
     double Wph() const { return fWph; }
     double QAlpha() const { return fQAlpha; }
+    double QProton() const { return fQProton; }
     bool UseModBoxRecomb() const { return fUseModBoxRecomb; }
     bool UseEllipsModBoxRecomb() const { return fUseEllipsModBoxRecomb; }
     bool UseModLarqlRecomb() const { return fUseModLarqlRecomb; }
@@ -130,9 +131,9 @@ namespace sim {
     double const fLarqlBeta;     ///< Possibly override the LarqlBeta parameter
     double const fWph;           ///< Possibly override the Wph parameter
     double const fQAlpha;        ///< Possibly override the QAlpha parameter
+    double const fQProton;       ///< Possibly override the QProton parameter
     bool const fUseModBoxRecomb; ///< Use Modified Box model recombination instead of Birks
-    bool const
-      fUseEllipsModBoxRecomb; ///< Use Ellipsoid Modified Box model recombination instead of Birks
+    bool const fUseEllipsModBoxRecomb; ///< Use Ellipsoid Modified Box model recombination instead of Birks
     bool const fUseModLarqlRecomb; ///< Use LArQL model recombination correction (dependence on EF)
     bool const fUseBinomialFlucts; ///< Use binomial fluctuations in correlated method
     std::string const

--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -64,7 +64,7 @@ standard_largeantparameters:
  LarqlBeta: 0.0124
 
 ## Proton Quenching Factor
- QProton: 0.66
+ QProton: 1
 
   #* alpha particle quenching factor
   #* Doke et al. Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538

--- a/larsim/Simulation/simulationservices.fcl
+++ b/larsim/Simulation/simulationservices.fcl
@@ -63,6 +63,9 @@ standard_largeantparameters:
  LarqlAlpha: 0.0372
  LarqlBeta: 0.0124
 
+## Proton Quenching Factor
+ QProton: 0.66
+
   #* alpha particle quenching factor
   #* Doke et al. Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538
  QAlpha: 0.72


### PR DESCRIPTION
This PR introduces the possibility of adding a light quenching factor for protons. This quenching factor is required for the correlated model to reproduce the measured proton light yield from Doke et al., Jpn. J. Appl. Phys. Vol. 41 (2002) pp. 1538–1545. More details can be found in https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=42966&filename=ScintillationYieldSimulation.pdf&version=1. The default value is set to 1 so no quenching factor is applied.
Would you mind having a look at this @ggamezdiego?