### PR TITLE
replace the infinite while loop in multipart rain module

### DIFF
--- a/larsim/EventGenerator/MultiPart/MultiPartRain_module.cc
+++ b/larsim/EventGenerator/MultiPart/MultiPartRain_module.cc
@@ -412,7 +412,9 @@ std::array<double, 3U> MultiPartRain::extractDirection() const
   return result;
 }
 
-std::array<double, 3U> MultiPartRain::extractDirection(double sign_x, double sign_y, double sign_z) const
+std::array<double, 3U> MultiPartRain::extractDirection(double sign_x,
+                                                       double sign_y,
+                                                       double sign_z) const
 {
   double px, py, pz;
 
@@ -452,7 +454,6 @@ std::array<double, 3U> MultiPartRain::extractDirection(double sign_x, double sig
 
   return {px, py, pz};
 }
-
 
 TVector3 MultiPartRain::GenMomentum(const PartGenParam& param,
                                     const double& mass,
@@ -505,7 +506,6 @@ TVector3 MultiPartRain::GenMomentum(const PartGenParam& param,
     px = p[0];
     py = p[1];
     pz = p[2];
-
   }
 
   if (_debug) {


### PR DESCRIPTION
While running the ProtoDUNE-VD MPVMP generator, the infinite loop in `MultiPartRain_module.cc` was leading to segmentation faults. Constraining the generated direction to a single octant instead of the full sphere resolved the issue.