### PR TITLE
Reimplementation of sim::BackTracker::HitToSimIDEs_Ps()

### DIFF
--- a/larsim/MCCheater/BackTracker.cc
+++ b/larsim/MCCheater/BackTracker.cc
@@ -320,7 +320,10 @@ namespace cheat {
     if (start_tdc < 0) start_tdc = 0;
     if (end_tdc < 0) end_tdc = 0;
 
-    if (start_tdc > end_tdc) { throw; }
+    if (start_tdc > end_tdc) {
+      throw cet::exception("BackTracker") << "HitToSimIDEs_Ps(): Requested empty tick interval "
+                                          << start_tdc << " - " << end_tdc << "\n";
+    }
 
     // The following does not return a std::map. It returns a vector... with no guarantee
     // that it is sorted...


### PR DESCRIPTION
This is an optional reimplementation of `sim::BackTracker::HitToSimIDEs_Ps()` taking advantage of the new `sim::SimChannel` interface from LArSoft/lardataobj#56.

It also changes the behaviour on invalid parameters from an implicit `std::terminate()` (`throw;`) to an actual exception, just for good practice.

On the reimplementation: much of the excised code stemmed from not assuming the elements of `sim::SimChannel` to be ordered in time, but this is an actual invariant of that class.
The rest of the overhead was working around lookup on the sorted data because of lack of an appropriate comparison, which is what LArSoft/lardataobj#56 provides.