### PR TITLE
Update mpv to include the pdune beams

### DIFF
--- a/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
+++ b/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
@@ -5,6 +5,17 @@
 //
 // Generated at Tue Dec 13 15:48:59 2016 by Kazuhiro Terao using artmod
 // from cetpkgsupport v1_11_00.
+//
+// Modified to support beam-mode hemisphere start position:
+//   particles are generated on the surface of a hemisphere of configurable
+//   radius, centered on a beam entrance point, with the flat face of the
+//   hemisphere flush with the detector entrance.  The momentum direction
+//   is always aimed from the surface point back through the entrance and
+//   into the detector.
+//
+// Further modified: allow random target point around beam entrance
+//   (BeamTargetRadius) so that particles are aimed at a random point
+//   within a disk of that radius, simulating a finite beam spot.
 ////////////////////////////////////////////////////////////////////////
 
 #include "art/Framework/Core/EDProducer.h"
@@ -70,9 +81,17 @@ public:
   TVector3 GenPosition();
   TVector3 GenBoost();
 
-  std::array<double, 3U> extractDirection() const;
+  // Beam-mode generators
+  TVector3 GenBeamEntrancePosition();
+  TVector3 GenBeamTarget() const;
+  std::array<double, 3U> GenBeamDirection(const TVector3& start_pos,
+                                          const TVector3& target) const;
+
+  std::array<double, 3U> extractDirection() const; 
   TVector3 GenMomentum(const PartGenParam& param, const double& mass);
   TVector3 GenMomentum(const PartGenParam& param, const double& mass, bool& same_range);
+  TVector3 GenMomentum(const PartGenParam& param, const double& mass,
+                       bool& same_range, const std::array<double, 3>& dir);
 
   double GenMomentumSF(const double& sf, const double& mass, const double& p);
   std::vector<size_t> GenParticles() const;
@@ -112,6 +131,25 @@ private:
 
   bool _use_boost;
   bool _revert;
+
+  // ---------------------------------------------------------------
+  // Beam-mode members
+  // ---------------------------------------------------------------
+  bool _beam_mode;
+
+  // Centre of the hemisphere = the nominal beam entrance point on the
+  // detector face, in LArSoft cm coordinates.
+  std::array<double, 3> _beam_entrance;
+
+  // Radius of the hemisphere [cm].  Particles are placed on this surface.
+  double _beam_radius;
+
+  // Unit vector pointing *into* the detector from the entrance face.
+  std::array<double, 3> _beam_inward_dir;
+
+  // Radius (in cm) of the disk in which the random target point is generated
+  // around _beam_entrance.  If zero, target = _beam_entrance exactly.
+  double _beam_target_radius;
 };
 
 void MultiPartVertex::abort(const std::string msg) const
@@ -148,13 +186,55 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   _multi_min = p.get<size_t>("MultiMin");
   _multi_max = p.get<size_t>("MultiMax");
 
+  // ---------------------------------------------------------------
+  // Beam-mode configuration
+  // ---------------------------------------------------------------
+  _beam_mode   = p.get<bool>("BeamMode", false);
+  _beam_radius = p.get<double>("BeamRadius", 10.0); // cm
+  _beam_target_radius = p.get<double>("BeamTargetRadius", 0.0);
+  if (_beam_target_radius < 0.0)
+    this->abort("BeamTargetRadius must be >= 0");
+
+  auto beam_entrance_v = p.get<std::vector<double>>("BeamEntrance", {94.8, 142.6, 0.7});
+  if (beam_entrance_v.size() != 3)
+    this->abort("BeamEntrance must have exactly 3 elements [x, y, z]");
+  _beam_entrance = {beam_entrance_v[0], beam_entrance_v[1], beam_entrance_v[2]};
+
+  auto beam_inward_v = p.get<std::vector<double>>("BeamInwardDirection", {0.0, 0.0, 1.0});
+  if (beam_inward_v.size() != 3)
+    this->abort("BeamInwardDirection must have exactly 3 elements");
+  double norm = std::sqrt(beam_inward_v[0]*beam_inward_v[0] +
+                          beam_inward_v[1]*beam_inward_v[1] +
+                          beam_inward_v[2]*beam_inward_v[2]);
+  if (norm < 1e-9) this->abort("BeamInwardDirection has zero magnitude!");
+  _beam_inward_dir = {beam_inward_v[0]/norm, beam_inward_v[1]/norm, beam_inward_v[2]/norm};
+
+  if (_beam_radius <= 0.)
+    this->abort("BeamRadius must be positive!");
+
+  if (_beam_mode && _debug > 0) {
+    std::cout << "[MultiPartVertex] BeamMode ENABLED\n"
+              << "  Entrance  : (" << _beam_entrance[0] << ", "
+                                   << _beam_entrance[1] << ", "
+                                   << _beam_entrance[2] << ") cm\n"
+              << "  Radius    : " << _beam_radius << " cm\n"
+              << "  Inward dir: (" << _beam_inward_dir[0] << ", "
+                                   << _beam_inward_dir[1] << ", "
+                                   << _beam_inward_dir[2] << ")\n"
+              << "  Target radius : " << _beam_target_radius << " cm\n";
+  }
+
+  // ---------------------------------------------------------------
+  // Original TPC-based geometry (still required by the constructor
+  // even in beam mode, for the particle parameter sanity checks)
+  // ---------------------------------------------------------------
   _tpc_v = p.get<std::vector<std::vector<unsigned short>>>("TPCRange");
   auto const xrange = p.get<std::vector<double>>("XRange");
   auto const yrange = p.get<std::vector<double>>("YRange");
   auto const zrange = p.get<std::vector<double>>("ZRange");
 
   auto const part_cfg = p.get<fhicl::ParameterSet>("ParticleParameter");
-  _gamma_beta_range =
+  _gamma_beta_range = 
     p.get<std::array<double, 2>>("GammaBetaRange", {0.0, 0.0}); // _gamma_beta denotes gamma * beta
 
   auto const pdg_v = part_cfg.get<std::vector<std::vector<int>>>("PDGCode");
@@ -174,7 +254,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
     kerange_v = momrange_v;
     use_mom = true;
   }
-  // sanity check
+// sanity check
   if (pdg_v.size() != kerange_v.size() || pdg_v.size() != minmult_v.size() ||
       pdg_v.size() != maxmult_v.size() || pdg_v.size() != weight_v.size())
     this->abort("configuration parameters have incompatible lengths!");
@@ -184,7 +264,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
     if (r.empty()) this->abort("PDG code not given!");
   }
   for (auto const& r : kerange_v) {
-    if (r.size() != 2) this->abort("Incompatible legnth @ KE vector!");
+    if (r.size() != 2) this->abort("Incompatible length @ KE vector!");
   }
   if (_gamma_beta_range[0] > _gamma_beta_range[1]) this->abort("Incompatible boost range!");
 
@@ -197,9 +277,9 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   _multi_min = std::max(_multi_min, multi_min);
   if (_multi_max < _multi_min) this->abort("Overall MultiMax <= overall MultiMin!");
 
-  if (!xrange.empty() && xrange.size() > 2) this->abort("Incompatible legnth @ X vector!");
-  if (!yrange.empty() && yrange.size() > 2) this->abort("Incompatible legnth @ Y vector!");
-  if (!zrange.empty() && zrange.size() > 2) this->abort("Incompatible legnth @ Z vector!");
+  if (!xrange.empty() && xrange.size() > 2) this->abort("Incompatible length @ X vector!");
+  if (!yrange.empty() && yrange.size() > 2) this->abort("Incompatible length @ Y vector!");
+  if (!zrange.empty() && zrange.size() > 2) this->abort("Incompatible length @ Z vector!");
 
   // slight modification from mpv: define the overall volume across specified TPC IDs + range options
   double xmin, xmax, ymin, ymax, zmin, zmax;
@@ -235,9 +315,9 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   if (yrange.size() == 1) { _yrange[0] = _yrange[1] = yrange[0]; }
   if (zrange.size() == 1) { _zrange[0] = _zrange[1] = zrange[0]; }
   if (xrange.size() == 2) {
-    _xrange[0] = xrange[0];
-    _xrange[1] = xrange[1];
-  }
+     _xrange[0] = xrange[0];
+     _xrange[1] = xrange[1];
+    }
   if (yrange.size() == 2) {
     _yrange[0] = yrange[0];
     _yrange[1] = yrange[1];
@@ -307,7 +387,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
 void MultiPartVertex::beginRun(art::Run& run)
 {
   // grab the geometry object to see what geometry we are using
-  art::ServiceHandle<geo::Geometry> geo;
+    art::ServiceHandle<geo::Geometry> geo;
 
   std::unique_ptr<sumdata::RunData> runData(new sumdata::RunData(geo->DetectorName()));
 
@@ -365,6 +445,7 @@ std::vector<size_t> MultiPartVertex::GenParticles() const
   return result;
 }
 
+// used when _beam_mode == false
 TVector3 MultiPartVertex::GenPosition()
 {
 
@@ -380,6 +461,96 @@ TVector3 MultiPartVertex::GenPosition()
   return TVector3(x, y, z);
 }
 
+// ---------------------------------------------------------------------------
+// Beam-mode: uniform sample on the upstream hemisphere of radius _beam_radius
+// centred on _beam_entrance.
+TVector3 MultiPartVertex::GenBeamEntrancePosition()
+{
+  double ct  = fFlatRandom->fire(0.0, 1.0);
+  double st  = TMath::Sqrt(1.0 - ct * ct);
+  double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
+
+  TVector3 n_up(-_beam_inward_dir[0], -_beam_inward_dir[1], -_beam_inward_dir[2]);
+
+  TVector3 arb(1., 0., 0.);
+  if (std::fabs(n_up.Dot(arb)) > 0.9) arb = TVector3(0., 1., 0.);
+
+  TVector3 e1 = (arb - n_up * n_up.Dot(arb)).Unit();
+  TVector3 e2 = n_up.Cross(e1).Unit();
+
+  TVector3 offset = _beam_radius * (st * TMath::Cos(phi) * e1 +
+                                    st * TMath::Sin(phi) * e2 +
+                                    ct               * n_up);
+
+  TVector3 pos(_beam_entrance[0] + offset.X(),
+               _beam_entrance[1] + offset.Y(),
+               _beam_entrance[2] + offset.Z());
+
+  if (_debug > 0)
+    std::cout << "[BeamMode] Start position: ("
+              << pos.X() << ", " << pos.Y() << ", " << pos.Z() << ") cm\n"
+              << "           Offset from entrance: ("
+              << offset.X() << ", " << offset.Y() << ", " << offset.Z() << ") cm" << std::endl;
+
+  return pos;
+}
+
+// ---------------------------------------------------------------------------
+// Generate a random target point within a disk of radius _beam_target_radius
+// centred on _beam_entrance, in the plane perpendicular to _beam_inward_dir.
+TVector3 MultiPartVertex::GenBeamTarget() const
+{
+  if (_beam_target_radius <= 0.0)
+    return TVector3(_beam_entrance[0], _beam_entrance[1], _beam_entrance[2]);
+
+  TVector3 n_in(_beam_inward_dir[0], _beam_inward_dir[1], _beam_inward_dir[2]);
+  TVector3 arb(1.,0.,0.);
+  if (std::fabs(n_in.Dot(arb)) > 0.9) arb = TVector3(0.,1.,0.);
+  TVector3 u = (arb - n_in * n_in.Dot(arb)).Unit();
+  TVector3 v = n_in.Cross(u).Unit();
+
+  double r   = std::sqrt(fFlatRandom->fire()) * _beam_target_radius;
+  double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
+  TVector3 offset = r * (std::cos(phi) * u + std::sin(phi) * v);
+
+  TVector3 target(_beam_entrance[0] + offset.X(),
+                  _beam_entrance[1] + offset.Y(),
+                  _beam_entrance[2] + offset.Z());
+
+  if (_debug > 0)
+    std::cout << "[BeamMode] Target point: ("
+              << target.X() << ", " << target.Y() << ", " << target.Z() << ") cm\n"
+              << "           Offset from entrance: ("
+              << offset.X() << ", " << offset.Y() << ", " << offset.Z() << ") cm" << std::endl;
+
+  return target;
+}
+
+// ---------------------------------------------------------------------------
+// Returns the unit vector from start_pos toward target.
+std::array<double, 3U>
+MultiPartVertex::GenBeamDirection(const TVector3& start_pos, const TVector3& target) const
+{
+  TVector3 dir = (target - start_pos).Unit();
+
+  if (_debug > 0)
+    std::cout << "[BeamMode] Direction: ("
+              << dir.X() << ", " << dir.Y() << ", " << dir.Z() << ")" << std::endl;
+
+  return {dir.X(), dir.Y(), dir.Z()};
+}
+
+// ---------------------------------------------------------------------------
+// Isotropic direction sampler (original, used when _beam_mode == false).
+std::array<double, 3U> MultiPartVertex::extractDirection() const
+{
+  double ct  = fFlatRandom->fire(-1.0, 1.0);
+  double st  = TMath::Sqrt(1.0 - ct * ct);
+  double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
+  return {st * TMath::Cos(phi), st * TMath::Sin(phi), ct};
+}
+
+// ---------------------------------------------------------------------------
 TVector3 MultiPartVertex::GenBoost()
 {
 
@@ -409,25 +580,14 @@ TVector3 MultiPartVertex::GenBoost()
   return TVector3(bx, by, bz);
 }
 
-std::array<double, 3U> MultiPartVertex::extractDirection() const
-{
-  double ct = fFlatRandom->fire(-1.0, 1.0);
-  double st = TMath::Sqrt(1.0 - ct * ct);
-  double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
-  double px = st * TMath::Cos(phi);
-  double py = st * TMath::Sin(phi);
-  double pz = ct;
-  std::array<double, 3U> result = {px, py, pz};
-  return result;
-}
 
 TVector3 MultiPartVertex::GenMomentum(const PartGenParam& param, const double& mass)
 {
 
   double tot_energy = 0;
   if (param.use_mom)
-    tot_energy =
-      std::hypot(fFlatRandom->fire(param.kerange[0], param.kerange[1]), mass); // KE + mass
+    tot_energy = 
+    std::hypot(fFlatRandom->fire(param.kerange[0], param.kerange[1]), mass); // KE + mass
   else
     tot_energy = fFlatRandom->fire(param.kerange[0], param.kerange[1]) + mass;
 
@@ -490,6 +650,33 @@ TVector3 MultiPartVertex::GenMomentum(const PartGenParam& param,
   return TVector3(px, py, pz);
 }
 
+// ---------------------------------------------------------------------------
+// Beam-mode overload: direction is supplied explicitly instead of sampled isotropically.
+TVector3 MultiPartVertex::GenMomentum(const PartGenParam& param,
+                                      const double& mass,
+                                      bool& same_range,
+                                      const std::array<double, 3>& dir)
+{
+  if (!same_range)
+    return GenMomentum(param, mass);
+
+  double tot_energy = 0;
+  if (param.use_mom)
+    tot_energy = std::hypot(fFlatRandom->fire(param.kerange[0], param.kerange[1]), mass);
+  else
+    tot_energy = fFlatRandom->fire(param.kerange[0], 1) + mass;
+
+  double mom_mag = sqrt(cet::square(tot_energy) - cet::square(mass));
+
+  if (_debug > 1)
+    std::cout << "    Direction : (" << dir[0] << "," << dir[1] << "," << dir[2] << ")\n"
+              << "    Momentum  : " << mom_mag << " [MeV/c]\n"
+              << "    Energy    : " << tot_energy << " [MeV/c^2]" << std::endl;
+
+  return TVector3(dir[0] * mom_mag, dir[1] * mom_mag, dir[2] * mom_mag);
+}
+
+// ---------------------------------------------------------------------------
 double MultiPartVertex::GenMomentumSF(const double& sf, const double& m, const double& p)
 {
   double p_sf =
@@ -508,7 +695,21 @@ void MultiPartVertex::produce(art::Event& e)
 
   double g4_time = fFlatRandom->fire(_t0 - _t0_sigma / 2., _t0 + _t0_sigma / 2.);
 
-  TVector3 position = GenPosition();
+  // ------------------------------------------------------------------
+  // Determine start position and beam direction for this event
+  // ------------------------------------------------------------------
+  TVector3 position;
+  std::array<double, 3> beam_dir{};  // only used in beam mode
+
+  if (_beam_mode) {
+    position = GenBeamEntrancePosition();
+    TVector3 target = GenBeamTarget();
+    beam_dir = GenBeamDirection(position, target);
+  }
+  else {
+    position = GenPosition();
+  }
+
   double x = position.X();
   double y = position.Y();
   double z = position.Z();
@@ -535,7 +736,7 @@ void MultiPartVertex::produce(art::Event& e)
   auto const param_idx_v = GenParticles();
   if (_debug)
     std::cout << "Event Vertex @ (" << x << "," << y << "," << z << ") ... " << param_idx_v.size()
-              << " particles..." << std::endl;
+    << " particles..." << std::endl;
 
   for (size_t idx = 0; idx < param_idx_v.size(); ++idx) {
     auto const& param = _param_v[param_idx_v[idx]];
@@ -549,6 +750,9 @@ void MultiPartVertex::produce(art::Event& e)
     // empty  TVector3 momentum
     TVector3 momentum;
     if (_revert) { momentum = GenMomentum(param, mass); }
+    else if (_beam_mode) {
+      momentum = GenMomentum(param, mass, same_range, beam_dir);
+    }
     else {
       momentum = GenMomentum(param, mass, same_range);
     }
@@ -592,7 +796,7 @@ void MultiPartVertex::produce(art::Event& e)
           double mom_sf = 1;
           double temp_p =
             sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
-          if (_debug)
+            if (_debug)
             std::cout << "KE range: " << param.kerange[1] << " , pdg :  " << pdg_vec[idx]
                       << std::endl;
           mom_sf = GenMomentumSF(param.kerange[1], mass_vec[idx], temp_p);
@@ -631,7 +835,7 @@ void MultiPartVertex::produce(art::Event& e)
         auto const& param = _param_v[param_idx_v[idx]];
         double mom_sf = 1;
         double temp_p =
-          sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
+        sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
         if (_debug)
           std::cout << "KE range: " << param.kerange[1] << " , pdg :  " << pdg_vec[idx]
                     << std::endl;

--- a/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
+++ b/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
@@ -378,6 +378,30 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
 
     _param_v.push_back(param);
   }
+  
+  // ---------------------------------------------------------------
+  // Advisory: this generator samples phase space with intentionally
+  // broad, approximately uniform distributions (flat in KE/momentum,
+  // isotropic in angle, uniform in vertex position).  These choices
+  // maximise coverage of the detector response space and are well
+  // suited for training and validating AI/ML reconstruction models,
+  // but they do NOT reflect any physically motivated interaction
+  // cross-section or flux weighting.  Generated samples should NOT
+  // be used for physics analyses that require a realistic prior on
+  // particle kinematics or interaction rates.
+  // ---------------------------------------------------------------
+  mf::LogWarning("MultiPartVertex")
+    << "\n"
+    << "************************************************************\n"
+    << "  MultiPartVertex: INTENDED FOR AI/ML TRAINING USE ONLY\n"
+    << "  This generator samples phase space with broad, approximately\n"
+    << "  uniform distributions (flat in KE/momentum, isotropic in\n"
+    << "  angle, uniform in vertex position) to maximise detector-\n"
+    << "  response coverage for training and validating reconstruction\n"
+    << "  models.  It does NOT apply physical cross-section or flux\n"
+    << "  weighting and is NOT suitable for physics analyses requiring\n"
+    << "  a realistic kinematic or rate prior.\n"
+    << "************************************************************\n";
 }
 
 void MultiPartVertex::beginRun(art::Run& run)

--- a/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
+++ b/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
@@ -378,7 +378,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
 
     _param_v.push_back(param);
   }
-  
+
   // ---------------------------------------------------------------
   // Advisory: this generator samples phase space with intentionally
   // broad, approximately uniform distributions (flat in KE/momentum,

--- a/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
+++ b/larsim/EventGenerator/MultiPart/MultiPartVertex_module.cc
@@ -84,14 +84,15 @@ public:
   // Beam-mode generators
   TVector3 GenBeamEntrancePosition();
   TVector3 GenBeamTarget() const;
-  std::array<double, 3U> GenBeamDirection(const TVector3& start_pos,
-                                          const TVector3& target) const;
+  std::array<double, 3U> GenBeamDirection(const TVector3& start_pos, const TVector3& target) const;
 
-  std::array<double, 3U> extractDirection() const; 
+  std::array<double, 3U> extractDirection() const;
   TVector3 GenMomentum(const PartGenParam& param, const double& mass);
   TVector3 GenMomentum(const PartGenParam& param, const double& mass, bool& same_range);
-  TVector3 GenMomentum(const PartGenParam& param, const double& mass,
-                       bool& same_range, const std::array<double, 3>& dir);
+  TVector3 GenMomentum(const PartGenParam& param,
+                       const double& mass,
+                       bool& same_range,
+                       const std::array<double, 3>& dir);
 
   double GenMomentumSF(const double& sf, const double& mass, const double& p);
   std::vector<size_t> GenParticles() const;
@@ -189,11 +190,10 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   // ---------------------------------------------------------------
   // Beam-mode configuration
   // ---------------------------------------------------------------
-  _beam_mode   = p.get<bool>("BeamMode", false);
+  _beam_mode = p.get<bool>("BeamMode", false);
   _beam_radius = p.get<double>("BeamRadius", 10.0); // cm
   _beam_target_radius = p.get<double>("BeamTargetRadius", 0.0);
-  if (_beam_target_radius < 0.0)
-    this->abort("BeamTargetRadius must be >= 0");
+  if (_beam_target_radius < 0.0) this->abort("BeamTargetRadius must be >= 0");
 
   auto beam_entrance_v = p.get<std::vector<double>>("BeamEntrance", {94.8, 142.6, 0.7});
   if (beam_entrance_v.size() != 3)
@@ -201,26 +201,22 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   _beam_entrance = {beam_entrance_v[0], beam_entrance_v[1], beam_entrance_v[2]};
 
   auto beam_inward_v = p.get<std::vector<double>>("BeamInwardDirection", {0.0, 0.0, 1.0});
-  if (beam_inward_v.size() != 3)
-    this->abort("BeamInwardDirection must have exactly 3 elements");
-  double norm = std::sqrt(beam_inward_v[0]*beam_inward_v[0] +
-                          beam_inward_v[1]*beam_inward_v[1] +
-                          beam_inward_v[2]*beam_inward_v[2]);
+  if (beam_inward_v.size() != 3) this->abort("BeamInwardDirection must have exactly 3 elements");
+  double norm =
+    std::sqrt(beam_inward_v[0] * beam_inward_v[0] + beam_inward_v[1] * beam_inward_v[1] +
+              beam_inward_v[2] * beam_inward_v[2]);
   if (norm < 1e-9) this->abort("BeamInwardDirection has zero magnitude!");
-  _beam_inward_dir = {beam_inward_v[0]/norm, beam_inward_v[1]/norm, beam_inward_v[2]/norm};
+  _beam_inward_dir = {beam_inward_v[0] / norm, beam_inward_v[1] / norm, beam_inward_v[2] / norm};
 
-  if (_beam_radius <= 0.)
-    this->abort("BeamRadius must be positive!");
+  if (_beam_radius <= 0.) this->abort("BeamRadius must be positive!");
 
   if (_beam_mode && _debug > 0) {
     std::cout << "[MultiPartVertex] BeamMode ENABLED\n"
-              << "  Entrance  : (" << _beam_entrance[0] << ", "
-                                   << _beam_entrance[1] << ", "
-                                   << _beam_entrance[2] << ") cm\n"
+              << "  Entrance  : (" << _beam_entrance[0] << ", " << _beam_entrance[1] << ", "
+              << _beam_entrance[2] << ") cm\n"
               << "  Radius    : " << _beam_radius << " cm\n"
-              << "  Inward dir: (" << _beam_inward_dir[0] << ", "
-                                   << _beam_inward_dir[1] << ", "
-                                   << _beam_inward_dir[2] << ")\n"
+              << "  Inward dir: (" << _beam_inward_dir[0] << ", " << _beam_inward_dir[1] << ", "
+              << _beam_inward_dir[2] << ")\n"
               << "  Target radius : " << _beam_target_radius << " cm\n";
   }
 
@@ -234,7 +230,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   auto const zrange = p.get<std::vector<double>>("ZRange");
 
   auto const part_cfg = p.get<fhicl::ParameterSet>("ParticleParameter");
-  _gamma_beta_range = 
+  _gamma_beta_range =
     p.get<std::array<double, 2>>("GammaBetaRange", {0.0, 0.0}); // _gamma_beta denotes gamma * beta
 
   auto const pdg_v = part_cfg.get<std::vector<std::vector<int>>>("PDGCode");
@@ -254,7 +250,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
     kerange_v = momrange_v;
     use_mom = true;
   }
-// sanity check
+  // sanity check
   if (pdg_v.size() != kerange_v.size() || pdg_v.size() != minmult_v.size() ||
       pdg_v.size() != maxmult_v.size() || pdg_v.size() != weight_v.size())
     this->abort("configuration parameters have incompatible lengths!");
@@ -315,9 +311,9 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
   if (yrange.size() == 1) { _yrange[0] = _yrange[1] = yrange[0]; }
   if (zrange.size() == 1) { _zrange[0] = _zrange[1] = zrange[0]; }
   if (xrange.size() == 2) {
-     _xrange[0] = xrange[0];
-     _xrange[1] = xrange[1];
-    }
+    _xrange[0] = xrange[0];
+    _xrange[1] = xrange[1];
+  }
   if (yrange.size() == 2) {
     _yrange[0] = yrange[0];
     _yrange[1] = yrange[1];
@@ -387,7 +383,7 @@ MultiPartVertex::MultiPartVertex(fhicl::ParameterSet const& p)
 void MultiPartVertex::beginRun(art::Run& run)
 {
   // grab the geometry object to see what geometry we are using
-    art::ServiceHandle<geo::Geometry> geo;
+  art::ServiceHandle<geo::Geometry> geo;
 
   std::unique_ptr<sumdata::RunData> runData(new sumdata::RunData(geo->DetectorName()));
 
@@ -466,8 +462,8 @@ TVector3 MultiPartVertex::GenPosition()
 // centred on _beam_entrance.
 TVector3 MultiPartVertex::GenBeamEntrancePosition()
 {
-  double ct  = fFlatRandom->fire(0.0, 1.0);
-  double st  = TMath::Sqrt(1.0 - ct * ct);
+  double ct = fFlatRandom->fire(0.0, 1.0);
+  double st = TMath::Sqrt(1.0 - ct * ct);
   double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
 
   TVector3 n_up(-_beam_inward_dir[0], -_beam_inward_dir[1], -_beam_inward_dir[2]);
@@ -478,19 +474,17 @@ TVector3 MultiPartVertex::GenBeamEntrancePosition()
   TVector3 e1 = (arb - n_up * n_up.Dot(arb)).Unit();
   TVector3 e2 = n_up.Cross(e1).Unit();
 
-  TVector3 offset = _beam_radius * (st * TMath::Cos(phi) * e1 +
-                                    st * TMath::Sin(phi) * e2 +
-                                    ct               * n_up);
+  TVector3 offset =
+    _beam_radius * (st * TMath::Cos(phi) * e1 + st * TMath::Sin(phi) * e2 + ct * n_up);
 
-  TVector3 pos(_beam_entrance[0] + offset.X(),
-               _beam_entrance[1] + offset.Y(),
-               _beam_entrance[2] + offset.Z());
+  TVector3 pos(
+    _beam_entrance[0] + offset.X(), _beam_entrance[1] + offset.Y(), _beam_entrance[2] + offset.Z());
 
   if (_debug > 0)
-    std::cout << "[BeamMode] Start position: ("
-              << pos.X() << ", " << pos.Y() << ", " << pos.Z() << ") cm\n"
-              << "           Offset from entrance: ("
-              << offset.X() << ", " << offset.Y() << ", " << offset.Z() << ") cm" << std::endl;
+    std::cout << "[BeamMode] Start position: (" << pos.X() << ", " << pos.Y() << ", " << pos.Z()
+              << ") cm\n"
+              << "           Offset from entrance: (" << offset.X() << ", " << offset.Y() << ", "
+              << offset.Z() << ") cm" << std::endl;
 
   return pos;
 }
@@ -504,38 +498,37 @@ TVector3 MultiPartVertex::GenBeamTarget() const
     return TVector3(_beam_entrance[0], _beam_entrance[1], _beam_entrance[2]);
 
   TVector3 n_in(_beam_inward_dir[0], _beam_inward_dir[1], _beam_inward_dir[2]);
-  TVector3 arb(1.,0.,0.);
-  if (std::fabs(n_in.Dot(arb)) > 0.9) arb = TVector3(0.,1.,0.);
+  TVector3 arb(1., 0., 0.);
+  if (std::fabs(n_in.Dot(arb)) > 0.9) arb = TVector3(0., 1., 0.);
   TVector3 u = (arb - n_in * n_in.Dot(arb)).Unit();
   TVector3 v = n_in.Cross(u).Unit();
 
-  double r   = std::sqrt(fFlatRandom->fire()) * _beam_target_radius;
+  double r = std::sqrt(fFlatRandom->fire()) * _beam_target_radius;
   double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
   TVector3 offset = r * (std::cos(phi) * u + std::sin(phi) * v);
 
-  TVector3 target(_beam_entrance[0] + offset.X(),
-                  _beam_entrance[1] + offset.Y(),
-                  _beam_entrance[2] + offset.Z());
+  TVector3 target(
+    _beam_entrance[0] + offset.X(), _beam_entrance[1] + offset.Y(), _beam_entrance[2] + offset.Z());
 
   if (_debug > 0)
-    std::cout << "[BeamMode] Target point: ("
-              << target.X() << ", " << target.Y() << ", " << target.Z() << ") cm\n"
-              << "           Offset from entrance: ("
-              << offset.X() << ", " << offset.Y() << ", " << offset.Z() << ") cm" << std::endl;
+    std::cout << "[BeamMode] Target point: (" << target.X() << ", " << target.Y() << ", "
+              << target.Z() << ") cm\n"
+              << "           Offset from entrance: (" << offset.X() << ", " << offset.Y() << ", "
+              << offset.Z() << ") cm" << std::endl;
 
   return target;
 }
 
 // ---------------------------------------------------------------------------
 // Returns the unit vector from start_pos toward target.
-std::array<double, 3U>
-MultiPartVertex::GenBeamDirection(const TVector3& start_pos, const TVector3& target) const
+std::array<double, 3U> MultiPartVertex::GenBeamDirection(const TVector3& start_pos,
+                                                         const TVector3& target) const
 {
   TVector3 dir = (target - start_pos).Unit();
 
   if (_debug > 0)
-    std::cout << "[BeamMode] Direction: ("
-              << dir.X() << ", " << dir.Y() << ", " << dir.Z() << ")" << std::endl;
+    std::cout << "[BeamMode] Direction: (" << dir.X() << ", " << dir.Y() << ", " << dir.Z() << ")"
+              << std::endl;
 
   return {dir.X(), dir.Y(), dir.Z()};
 }
@@ -544,8 +537,8 @@ MultiPartVertex::GenBeamDirection(const TVector3& start_pos, const TVector3& tar
 // Isotropic direction sampler (original, used when _beam_mode == false).
 std::array<double, 3U> MultiPartVertex::extractDirection() const
 {
-  double ct  = fFlatRandom->fire(-1.0, 1.0);
-  double st  = TMath::Sqrt(1.0 - ct * ct);
+  double ct = fFlatRandom->fire(-1.0, 1.0);
+  double st = TMath::Sqrt(1.0 - ct * ct);
   double phi = fFlatRandom->fire(0.0, 2.0 * M_PI);
   return {st * TMath::Cos(phi), st * TMath::Sin(phi), ct};
 }
@@ -580,14 +573,13 @@ TVector3 MultiPartVertex::GenBoost()
   return TVector3(bx, by, bz);
 }
 
-
 TVector3 MultiPartVertex::GenMomentum(const PartGenParam& param, const double& mass)
 {
 
   double tot_energy = 0;
   if (param.use_mom)
-    tot_energy = 
-    std::hypot(fFlatRandom->fire(param.kerange[0], param.kerange[1]), mass); // KE + mass
+    tot_energy =
+      std::hypot(fFlatRandom->fire(param.kerange[0], param.kerange[1]), mass); // KE + mass
   else
     tot_energy = fFlatRandom->fire(param.kerange[0], param.kerange[1]) + mass;
 
@@ -657,8 +649,7 @@ TVector3 MultiPartVertex::GenMomentum(const PartGenParam& param,
                                       bool& same_range,
                                       const std::array<double, 3>& dir)
 {
-  if (!same_range)
-    return GenMomentum(param, mass);
+  if (!same_range) return GenMomentum(param, mass);
 
   double tot_energy = 0;
   if (param.use_mom)
@@ -699,7 +690,7 @@ void MultiPartVertex::produce(art::Event& e)
   // Determine start position and beam direction for this event
   // ------------------------------------------------------------------
   TVector3 position;
-  std::array<double, 3> beam_dir{};  // only used in beam mode
+  std::array<double, 3> beam_dir{}; // only used in beam mode
 
   if (_beam_mode) {
     position = GenBeamEntrancePosition();
@@ -736,7 +727,7 @@ void MultiPartVertex::produce(art::Event& e)
   auto const param_idx_v = GenParticles();
   if (_debug)
     std::cout << "Event Vertex @ (" << x << "," << y << "," << z << ") ... " << param_idx_v.size()
-    << " particles..." << std::endl;
+              << " particles..." << std::endl;
 
   for (size_t idx = 0; idx < param_idx_v.size(); ++idx) {
     auto const& param = _param_v[param_idx_v[idx]];
@@ -796,7 +787,7 @@ void MultiPartVertex::produce(art::Event& e)
           double mom_sf = 1;
           double temp_p =
             sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
-            if (_debug)
+          if (_debug)
             std::cout << "KE range: " << param.kerange[1] << " , pdg :  " << pdg_vec[idx]
                       << std::endl;
           mom_sf = GenMomentumSF(param.kerange[1], mass_vec[idx], temp_p);
@@ -835,7 +826,7 @@ void MultiPartVertex::produce(art::Event& e)
         auto const& param = _param_v[param_idx_v[idx]];
         double mom_sf = 1;
         double temp_p =
-        sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
+          sqrt(cet::square(px_vec[idx]) + cet::square(py_vec[idx]) + cet::square(pz_vec[idx]));
         if (_debug)
           std::cout << "KE range: " << param.kerange[1] << " , pdg :  " << pdg_vec[idx]
                     << std::endl;


### PR DESCRIPTION
Adds a configurable beam mode to the MultiPartVertex generator where particles are placed on the surface of an upstream hemisphere rather than uniformly within the TPC volume specifically designed for PDVD, PDSP, and PDHD.
**What changed**
BeamMode: when true, start positions are sampled uniformly on a hemisphere of radius BeamRadius centred on BeamEntrance, with the flat face flush with the detector entrance plane
BeamInwardDirection: unit vector pointing into the detector, defines hemisphere orientation (default [0,0,1] for PDVD)
BeamTargetRadius: particles are aimed at a random point within a disk of this radius around BeamEntrance, simulating a finite beam spot. Set to 0 to aim at the exact entrance point

New fcl parameters
```
BeamMode:            true
BeamEntrance:        [94.8, 142.6, 0.7]  
BeamRadius:          15.0                
BeamTargetRadius:    0.0                
BeamInwardDirection: [0.0, 0.0, 1.0]  
```

Adding beam mode generator display (BeamMode: true) and standard isotropic display (BeamMode: false) for comparison --> 20 events
<img width="1775" height="956" alt="image" src="https://github.com/user-attachments/assets/89bda263-19f9-490c-8950-9662ffe426ab" />
